### PR TITLE
Create dedicated usage reporting access scope

### DIFF
--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -386,7 +386,12 @@ export function initSeed() {
                   return result.updateOperationInDocumentCollection;
                 },
                 async createToken({
-                  targetScopes = [TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite],
+                  targetScopes = [
+                    TargetAccessScope.RegistryRead,
+                    TargetAccessScope.RegistryWrite,
+                    TargetAccessScope.UsageRead,
+                    TargetAccessScope.UsageWrite,
+                  ],
                   projectScopes = [],
                   organizationScopes = [],
                   targetId = target.cleanId,

--- a/integration-tests/tests/api/organization/get-started.spec.ts
+++ b/integration-tests/tests/api/organization/get-started.spec.ts
@@ -47,6 +47,8 @@ test.concurrent('completing each step should result in updated Get Started progr
       TargetAccessScope.Read,
       TargetAccessScope.RegistryRead,
       TargetAccessScope.RegistryWrite,
+      TargetAccessScope.UsageRead,
+      TargetAccessScope.UsageWrite,
       TargetAccessScope.Settings,
     ],
     projectScopes: [ProjectAccessScope.Read],

--- a/integration-tests/tests/api/organization/members.spec.ts
+++ b/integration-tests/tests/api/organization/members.spec.ts
@@ -36,8 +36,9 @@ test.concurrent('invited member should have basic scopes (Viewer role)', async (
   // Should have only target:read and target:registry:read access
   expect(member.targetAccessScopes).toContainEqual(TargetAccessScope.Read);
   expect(member.targetAccessScopes).toContainEqual(TargetAccessScope.RegistryRead);
+  expect(member.targetAccessScopes).toContainEqual(TargetAccessScope.UsageRead);
   // Nothing more
-  expect(member.targetAccessScopes).toHaveLength(2);
+  expect(member.targetAccessScopes).toHaveLength(3);
 });
 
 test.concurrent(

--- a/integration-tests/tests/api/rate-limit/emails.spec.ts
+++ b/integration-tests/tests/api/rate-limit/emails.spec.ts
@@ -35,8 +35,8 @@ test('rate limit approaching and reached for organization', async () => {
   const { collectLegacyOperations: collectOperations } = await createToken({
     targetScopes: [
       TargetAccessScope.Read,
-      TargetAccessScope.RegistryRead,
-      TargetAccessScope.RegistryWrite,
+      TargetAccessScope.UsageRead,
+      TargetAccessScope.UsageWrite,
     ],
     projectScopes: [ProjectAccessScope.Read],
     organizationScopes: [OrganizationAccessScope.Read],

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -43,7 +43,7 @@ test.concurrent(
       organizationScopes: [OrganizationAccessScope.Read],
     });
 
-    const writeToken = await createToken({
+    const registryWriteToken = await createToken({
       targetScopes: [
         TargetAccessScope.Read,
         TargetAccessScope.RegistryRead,
@@ -53,13 +53,29 @@ test.concurrent(
       organizationScopes: [OrganizationAccessScope.Read],
     });
 
-    const readToken = await createToken({
+    const usageWriteToken = await createToken({
+      targetScopes: [
+        TargetAccessScope.Read,
+        TargetAccessScope.UsageRead,
+        TargetAccessScope.UsageWrite,
+      ],
+      projectScopes: [ProjectAccessScope.Read],
+      organizationScopes: [OrganizationAccessScope.Read],
+    });
+
+    const registryReadToken = await createToken({
       targetScopes: [TargetAccessScope.Read, TargetAccessScope.RegistryRead],
       projectScopes: [ProjectAccessScope.Read],
       organizationScopes: [OrganizationAccessScope.Read],
     });
 
-    const schemaPublishResult = await writeToken
+    const usageReadToken = await createToken({
+      targetScopes: [TargetAccessScope.Read, TargetAccessScope.UsageRead],
+      projectScopes: [ProjectAccessScope.Read],
+      organizationScopes: [OrganizationAccessScope.Read],
+    });
+
+    const schemaPublishResult = await registryWriteToken
       .publishSchema({
         author: 'Kamil',
         commit: 'abc123',
@@ -75,12 +91,12 @@ test.concurrent(
     expect(targetValidationResult.setTargetValidation.validationSettings.period).toEqual(30);
 
     // should not be breaking because the field is unused
-    const unusedCheckResult = await readToken
+    const unusedCheckResult = await registryReadToken
       .checkSchema(`type Query { me: String }`)
       .then(r => r.expectNoGraphQLErrors());
     expect(unusedCheckResult.schemaCheck.__typename).toEqual('SchemaCheckSuccess');
 
-    const collectResult = await writeToken.collectLegacyOperations([
+    const collectResult = await usageWriteToken.collectLegacyOperations([
       {
         operation: 'query ping { ping }',
         operationName: 'ping',
@@ -96,7 +112,7 @@ test.concurrent(
     await waitFor(5000);
 
     // should be breaking because the field is used now
-    const usedCheckResult = await readToken
+    const usedCheckResult = await registryReadToken
       .checkSchema(`type Query { me: String }`)
       .then(r => r.expectNoGraphQLErrors());
 
@@ -108,13 +124,13 @@ test.concurrent(
 
     const from = formatISO(subHours(Date.now(), 6));
     const to = formatISO(Date.now());
-    const operationsStats = await readToken.readOperationsStats(from, to);
+    const operationsStats = await usageReadToken.readOperationsStats(from, to);
     expect(operationsStats.operations.nodes).toHaveLength(1);
 
     const op = operationsStats.operations.nodes[0];
 
     expect(op.count).toEqual(1);
-    await expect(writeToken.readOperationBody(op.operationHash!)).resolves.toEqual(
+    await expect(usageReadToken.readOperationBody(op.operationHash!)).resolves.toEqual(
       'query ping{ping}',
     );
     expect(op.operationHash).toBeDefined();
@@ -137,6 +153,8 @@ test.concurrent('normalize and collect operation without breaking its syntax', a
       TargetAccessScope.Read,
       TargetAccessScope.RegistryRead,
       TargetAccessScope.RegistryWrite,
+      TargetAccessScope.UsageRead,
+      TargetAccessScope.UsageWrite,
     ],
     projectScopes: [ProjectAccessScope.Read],
     organizationScopes: [OrganizationAccessScope.Read],
@@ -261,6 +279,8 @@ test.concurrent(
         TargetAccessScope.Read,
         TargetAccessScope.RegistryRead,
         TargetAccessScope.RegistryWrite,
+        TargetAccessScope.UsageRead,
+        TargetAccessScope.UsageWrite,
       ],
       projectScopes: [ProjectAccessScope.Read],
       organizationScopes: [OrganizationAccessScope.Read],
@@ -331,6 +351,8 @@ test.concurrent('check usage from two selected targets', async () => {
       TargetAccessScope.Read,
       TargetAccessScope.RegistryRead,
       TargetAccessScope.RegistryWrite,
+      TargetAccessScope.UsageRead,
+      TargetAccessScope.UsageWrite,
       TargetAccessScope.Settings,
     ],
     projectScopes: [ProjectAccessScope.Read],
@@ -342,6 +364,8 @@ test.concurrent('check usage from two selected targets', async () => {
       TargetAccessScope.Read,
       TargetAccessScope.RegistryRead,
       TargetAccessScope.RegistryWrite,
+      TargetAccessScope.UsageRead,
+      TargetAccessScope.UsageWrite,
     ],
     projectScopes: [ProjectAccessScope.Read],
     organizationScopes: [OrganizationAccessScope.Read],
@@ -460,6 +484,8 @@ test.concurrent('check usage not from excluded client names', async () => {
       TargetAccessScope.Read,
       TargetAccessScope.RegistryRead,
       TargetAccessScope.RegistryWrite,
+      TargetAccessScope.UsageRead,
+      TargetAccessScope.UsageWrite,
       TargetAccessScope.Settings,
     ],
     projectScopes: [ProjectAccessScope.Read],
@@ -658,6 +684,8 @@ describe('changes with usage data', () => {
           TargetAccessScope.Read,
           TargetAccessScope.RegistryRead,
           TargetAccessScope.RegistryWrite,
+          TargetAccessScope.UsageRead,
+          TargetAccessScope.UsageWrite,
           TargetAccessScope.Settings,
         ],
         projectScopes: [ProjectAccessScope.Read],
@@ -929,6 +957,8 @@ test.concurrent('number of produced and collected operations should match', asyn
       TargetAccessScope.Read,
       TargetAccessScope.RegistryRead,
       TargetAccessScope.RegistryWrite,
+      TargetAccessScope.UsageRead,
+      TargetAccessScope.UsageWrite,
     ],
     projectScopes: [ProjectAccessScope.Read],
     organizationScopes: [OrganizationAccessScope.Read],
@@ -1020,6 +1050,8 @@ test.concurrent(
         TargetAccessScope.Read,
         TargetAccessScope.RegistryRead,
         TargetAccessScope.RegistryWrite,
+        TargetAccessScope.UsageRead,
+        TargetAccessScope.UsageWrite,
       ],
       projectScopes: [ProjectAccessScope.Read],
       organizationScopes: [OrganizationAccessScope.Read],
@@ -1083,6 +1115,8 @@ test.concurrent(
         TargetAccessScope.Read,
         TargetAccessScope.RegistryRead,
         TargetAccessScope.RegistryWrite,
+        TargetAccessScope.UsageRead,
+        TargetAccessScope.UsageWrite,
       ],
       projectScopes: [ProjectAccessScope.Read],
       organizationScopes: [OrganizationAccessScope.Read],
@@ -1150,6 +1184,8 @@ test.concurrent(
         TargetAccessScope.Read,
         TargetAccessScope.RegistryRead,
         TargetAccessScope.RegistryWrite,
+        TargetAccessScope.UsageRead,
+        TargetAccessScope.UsageWrite,
       ],
       projectScopes: [ProjectAccessScope.Read],
       organizationScopes: [OrganizationAccessScope.Read],
@@ -1211,6 +1247,8 @@ test.concurrent('ignore operations with syntax errors', async () => {
       TargetAccessScope.Read,
       TargetAccessScope.RegistryRead,
       TargetAccessScope.RegistryWrite,
+      TargetAccessScope.UsageRead,
+      TargetAccessScope.UsageWrite,
     ],
     projectScopes: [ProjectAccessScope.Read],
     organizationScopes: [OrganizationAccessScope.Read],
@@ -1279,6 +1317,8 @@ test.concurrent('ensure correct data', async () => {
       TargetAccessScope.Read,
       TargetAccessScope.RegistryRead,
       TargetAccessScope.RegistryWrite,
+      TargetAccessScope.UsageRead,
+      TargetAccessScope.UsageWrite,
     ],
     projectScopes: [ProjectAccessScope.Read],
     organizationScopes: [OrganizationAccessScope.Read],

--- a/packages/migrations/src/actions/2024.04.11T10-00-00.usage-token.ts
+++ b/packages/migrations/src/actions/2024.04.11T10-00-00.usage-token.ts
@@ -5,25 +5,36 @@ export default {
   noTransaction: true,
   run: ({ sql }) => [
     {
-      name: 'Update scopes in organization_member_roles',
+      name: 'Update scopes in "organization_member_roles"',
       query: sql`
         UPDATE organization_member_roles
-        SET scopes = array_append(scopes, 'target:usage:write')
-        WHERE scopes @> ARRAY['target:registry:write'];
+          SET scopes = array_append(scopes, 'target:usage:write')
+          WHERE scopes @> ARRAY['target:registry:write'];
         UPDATE organization_member_roles
-        SET scopes = array_append(scopes, 'target:usage:read')
-        WHERE scopes @> ARRAY['target:registry:read'];
+          SET scopes = array_append(scopes, 'target:usage:read')
+          WHERE scopes @> ARRAY['target:registry:read'];
       `,
     },
     {
-      name: 'Update scopes in organization_member',
+      name: 'Update scopes in "organization_member"',
       query: sql`
         UPDATE organization_member
-        SET scopes = array_append(scopes, 'target:usage:write')
-        WHERE scopes @> ARRAY['target:registry:write'];
+          SET scopes = array_append(scopes, 'target:usage:write')
+          WHERE scopes @> ARRAY['target:registry:write'];
         UPDATE organization_member
-        SET scopes = array_append(scopes, 'target:usage:read')
-        WHERE scopes @> ARRAY['target:registry:read'];
+          SET scopes = array_append(scopes, 'target:usage:read')
+          WHERE scopes @> ARRAY['target:registry:read'];
+      `,
+    },
+    {
+      name: 'Update scopes in "tokens"',
+      query: sql`
+        UPDATE tokens
+          SET scopes = array_append(scopes, 'target:usage:write')
+          WHERE scopes @> ARRAY['target:registry:write'];
+        UPDATE tokens
+          SET scopes = array_append(scopes, 'target:usage:read')
+          WHERE scopes @> ARRAY['target:registry:read'];
       `,
     },
   ],

--- a/packages/migrations/src/actions/2024.04.11T10-00-00.usage-token.ts
+++ b/packages/migrations/src/actions/2024.04.11T10-00-00.usage-token.ts
@@ -1,0 +1,30 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+export default {
+  name: '2024.04.11T10-00-00.usage-token.ts',
+  noTransaction: true,
+  run: ({ sql }) => [
+    {
+      name: 'Update scopes in organization_member_roles',
+      query: sql`
+        UPDATE organization_member_roles
+        SET scopes = array_append(scopes, 'target:usage:write')
+        WHERE scopes @> ARRAY['target:registry:write'];
+        UPDATE organization_member_roles
+        SET scopes = array_append(scopes, 'target:usage:read')
+        WHERE scopes @> ARRAY['target:registry:read'];
+      `,
+    },
+    {
+      name: 'Update scopes in organization_member',
+      query: sql`
+        UPDATE organization_member
+        SET scopes = array_append(scopes, 'target:usage:write')
+        WHERE scopes @> ARRAY['target:registry:write'];
+        UPDATE organization_member
+        SET scopes = array_append(scopes, 'target:usage:read')
+        WHERE scopes @> ARRAY['target:registry:read'];
+      `,
+    },
+  ],
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -63,6 +63,7 @@ import migration_2024_01_12_01T00_00_00_contracts from './actions/2024.01.26T00.
 import migration_2024_01_12_01T00_00_00_schema_check_pagination_index_update from './actions/2024.01.26T00.00.01.schema-check-pagination-index-update';
 import migration_2024_02_19_01T00_00_00_schema_check_store_breaking_change_metadata from './actions/2024.02.19T00.00.01.schema-check-store-breaking-change-metadata';
 import migration_2024_04_09T10_10_00_check_approval_comment from './actions/2024.04.09T10-10-00.check-approval-comment';
+import migration_2024_04_11T10_00_00_usage_token from './actions/2024.04.11T10-00-00.usage-token';
 import { runMigrations } from './pg-migrator';
 
 export const runPGMigrations = (args: { slonik: DatabasePool; runTo?: string }) =>
@@ -134,5 +135,6 @@ export const runPGMigrations = (args: { slonik: DatabasePool; runTo?: string }) 
       migration_2024_01_12_01T00_00_00_schema_check_pagination_index_update,
       migration_2024_02_19_01T00_00_00_schema_check_store_breaking_change_metadata,
       migration_2024_04_09T10_10_00_check_approval_comment,
+      migration_2024_04_11T10_00_00_usage_token,
     ],
   });

--- a/packages/migrations/test/2023.11.20T10-00-00.organization-member-roles.test.ts
+++ b/packages/migrations/test/2023.11.20T10-00-00.organization-member-roles.test.ts
@@ -6,8 +6,7 @@ import { initMigrationTestingEnvironment } from './utils/testkit';
 
 await describe('migration: organization-member-roles', async () => {
   await test('should incrementally adopt roles without corrupting existing and new data', async () => {
-    const { db, runTo, complete, done, seed, connectionString } =
-      await initMigrationTestingEnvironment();
+    const { db, runTo, done, seed, connectionString } = await initMigrationTestingEnvironment();
     const storage = await createStorage(connectionString, 1);
     try {
       // Run migrations all the way to the point before the one we are testing
@@ -133,7 +132,7 @@ await describe('migration: organization-member-roles', async () => {
       );
 
       // Run the remaining migrations
-      await complete();
+      await runTo('2023.11.20T10-00-00.organization-member-roles.ts');
 
       // assert scopes are still in place and identical
       assert.deepStrictEqual(

--- a/packages/migrations/test/2024.04.05T10-00-00.usage-token.test.ts
+++ b/packages/migrations/test/2024.04.05T10-00-00.usage-token.test.ts
@@ -1,0 +1,149 @@
+import assert from 'node:assert';
+import { describe, test } from 'node:test';
+import { sql } from 'slonik';
+import { createStorage } from '../../services/storage/src/index';
+import { initMigrationTestingEnvironment } from './utils/testkit';
+
+await describe('migration: usage-token', async () => {
+  await test('should replace target:registry:{read,write} with target:usage:{read,write}', async () => {
+    const { db, runTo, complete, done, seed, connectionString } =
+      await initMigrationTestingEnvironment();
+    const storage = await createStorage(connectionString, 1);
+    try {
+      await runTo('2023.11.09T00.00.00.schema-check-approval.ts');
+
+      // Seed the database with some data (schema_sdl, supergraph_sdl, composite_schema_sdl)
+      const admin = await seed.user({
+        user: {
+          name: 'test1',
+          email: 'test1@test.com',
+        },
+      });
+      const developer = await seed.user({
+        user: {
+          name: 'test2',
+          email: 'test2@test.com',
+        },
+      });
+      const noRoleUser = await seed.user({
+        user: {
+          name: 'test3',
+          email: 'test3@test.com',
+        },
+      });
+      const organization = await seed.organization({
+        organization: {
+          name: 'org-1',
+        },
+        user: admin,
+      });
+
+      const developerScopes = [
+        'organization:read',
+        'project:read',
+        'project:settings',
+        'project:alerts',
+        'project:operations-store:read',
+        'project:operations-store:write',
+        'target:read',
+        'target:settings',
+        'target:registry:read',
+        'target:registry:write',
+        'target:tokens:read',
+        'target:tokens:write',
+      ];
+      const noRoleUserScopes = [
+        'organization:read',
+        'project:read',
+        'target:read',
+        'project:alerts',
+        'target:registry:read',
+      ];
+
+      await runTo('2023.11.20T10-00-00.organization-member-roles.ts');
+
+      const adminRoleId = await db.oneFirst<string>(sql`
+        SELECT id FROM organization_member_roles WHERE name = 'Admin' AND organization_id = ${organization.id}
+      `);
+
+      const developerRoleId = await db.oneFirst<string>(sql`
+        INSERT INTO organization_member_roles
+          (
+            organization_id,
+            name,
+            description,
+            scopes,
+            locked
+          )
+        VALUES
+          (${organization.id}, 'Developer', 'Developer', ${sql.array(
+            developerScopes,
+            'text',
+          )}, ${false})
+        RETURNING id
+      `);
+
+      await db.query(sql`
+        INSERT INTO organization_member (organization_id, user_id, scopes, role_id)
+        VALUES
+          (${organization.id}, ${admin.id}, ARRAY[]::text[], ${adminRoleId}),
+          (${organization.id}, ${developer.id}, ${sql.array(
+            developerScopes,
+            'text',
+          )}, ${developerRoleId}),
+          (${organization.id}, ${noRoleUser.id}, ${sql.array(noRoleUserScopes, 'text')}, ${null})
+      `);
+
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${developer.id}
+        `),
+        developerScopes,
+      );
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${noRoleUser.id}
+        `),
+        noRoleUserScopes,
+      );
+
+      // Run the remaining migrations
+      await complete();
+
+      // assert scopes
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${developer.id}
+        `),
+        developerScopes.concat(['target:usage:write', 'target:usage:read']),
+      );
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${noRoleUser.id}
+        `),
+        noRoleUserScopes.concat(['target:usage:read']),
+      );
+
+      // assert assigned roles
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT omr.scopes
+        FROM organization_member as om
+        LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
+        WHERE om.user_id = ${developer.id} AND omr.organization_id = ${organization.id}
+        `),
+        developerScopes.concat(['target:usage:write', 'target:usage:read']),
+      );
+      // assert no role user has no role
+      assert.strictEqual(
+        await db.oneFirst(sql`
+        SELECT role_id FROM organization_member WHERE user_id = ${noRoleUser.id}
+        `),
+        null,
+      );
+    } finally {
+      await done();
+      await storage.destroy();
+    }
+  });
+});

--- a/packages/migrations/test/root.ts
+++ b/packages/migrations/test/root.ts
@@ -2,3 +2,4 @@ import './2023.02.22T09.27.02.delete-personal-org.test';
 import './2023.09.25T15.23.00.github-check-with-project-name.test';
 import './2023.11.20T10-00-00.organization-member-roles.test';
 import './2024.01.26T00.00.01.schema-check-purging.test';
+import './2024.04.05T10-00-00.usage-token.test';

--- a/packages/services/api/src/modules/auth/module.graphql.ts
+++ b/packages/services/api/src/modules/auth/module.graphql.ts
@@ -107,6 +107,8 @@ export default gql`
     SETTINGS
     REGISTRY_READ
     REGISTRY_WRITE
+    USAGE_READ
+    USAGE_WRITE
     TOKENS_READ
     TOKENS_WRITE
   }

--- a/packages/services/api/src/modules/auth/providers/scopes.ts
+++ b/packages/services/api/src/modules/auth/providers/scopes.ts
@@ -70,6 +70,14 @@ export enum TargetAccessScope {
    */
   REGISTRY_WRITE = 'target:registry:write',
   /**
+   * Who can read reported operations
+   */
+  USAGE_READ = 'target:usage:read',
+  /**
+   * Who can write reported operations
+   */
+  USAGE_WRITE = 'target:usage:write',
+  /**
    * Who can read tokens
    */
   TOKENS_READ = 'target:tokens:read',

--- a/packages/services/api/src/modules/auth/resolvers.ts
+++ b/packages/services/api/src/modules/auth/resolvers.ts
@@ -72,6 +72,8 @@ export const resolvers: AuthModule.Resolvers & {
     READ: TargetAccessScope.READ,
     REGISTRY_READ: TargetAccessScope.REGISTRY_READ,
     REGISTRY_WRITE: TargetAccessScope.REGISTRY_WRITE,
+    USAGE_READ: TargetAccessScope.USAGE_READ,
+    USAGE_WRITE: TargetAccessScope.USAGE_WRITE,
     DELETE: TargetAccessScope.DELETE,
     SETTINGS: TargetAccessScope.SETTINGS,
     TOKENS_READ: TargetAccessScope.TOKENS_READ,

--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -108,7 +108,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return await this.reader.readOperation({
@@ -145,7 +145,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return await this.reader.countUniqueDocuments({
@@ -162,7 +162,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return hasCollectedOperationsCached(target, () =>
@@ -178,7 +178,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.getHasCollectedSubscriptionOperations({
@@ -206,7 +206,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader
@@ -235,7 +235,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader
@@ -261,7 +261,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.countOperationsWithoutDetails({
@@ -307,7 +307,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.countFailures({
@@ -329,7 +329,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     const [totalField, total] = await Promise.all([
@@ -380,7 +380,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.readFieldListStats({
@@ -410,7 +410,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     // Maybe it needs less data
@@ -453,7 +453,7 @@ export class OperationsManager {
           organization,
           project,
           target,
-          scope: TargetAccessScope.REGISTRY_READ,
+          scope: TargetAccessScope.USAGE_READ,
         }),
       ),
     );
@@ -514,7 +514,7 @@ export class OperationsManager {
           organization,
           project,
           target,
-          scope: TargetAccessScope.REGISTRY_READ,
+          scope: TargetAccessScope.USAGE_READ,
         }),
       ),
     );
@@ -552,7 +552,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.requestsOverTime({
@@ -589,7 +589,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.failuresOverTime({
@@ -625,7 +625,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.durationOverTime({
@@ -654,7 +654,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.generalDurationPercentiles({
@@ -690,7 +690,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.durationPercentiles({
@@ -721,7 +721,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.countUniqueClients({
@@ -745,7 +745,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.readUniqueClientNames({
@@ -772,7 +772,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.readClientVersions({
@@ -803,7 +803,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.countClientVersions({
@@ -857,7 +857,7 @@ export class OperationsManager {
       organization: args.organization,
       project: args.project,
       target: args.target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     const loader = this.getClientNamesPerCoordinateOfTypeLoader({
@@ -936,7 +936,7 @@ export class OperationsManager {
       organization: args.organizationId,
       project: args.projectId,
       target: args.targetId,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     const loader = this.getTopOperationForTypeLoader({
@@ -958,7 +958,7 @@ export class OperationsManager {
       organization: args.organizationId,
       project: args.projectId,
       target: args.targetId,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     return this.reader.getReportedSchemaCoordinates({
@@ -1014,7 +1014,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     const rows = await this.reader.countCoordinatesOfType({
@@ -1060,7 +1060,7 @@ export class OperationsManager {
       organization,
       project,
       target,
-      scope: TargetAccessScope.REGISTRY_READ,
+      scope: TargetAccessScope.USAGE_READ,
     });
 
     const rows = await this.reader.countCoordinatesOfTarget({

--- a/packages/services/api/src/modules/organization/providers/organization-config.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-config.ts
@@ -62,4 +62,5 @@ export const organizationViewerScopes = [
   ProjectAccessScope.OPERATIONS_STORE_READ,
   TargetAccessScope.READ,
   TargetAccessScope.REGISTRY_READ,
+  TargetAccessScope.USAGE_READ,
 ];

--- a/packages/services/server/src/api.ts
+++ b/packages/services/server/src/api.ts
@@ -25,6 +25,7 @@ const oidcDefaultScopes = [
   ProjectAccessScope.READ,
   TargetAccessScope.READ,
   TargetAccessScope.REGISTRY_READ,
+  TargetAccessScope.USAGE_READ,
 ];
 
 const t = initTRPC.context<Context>().create();

--- a/packages/services/tokens/src/cache.ts
+++ b/packages/services/tokens/src/cache.ts
@@ -9,7 +9,7 @@ import { cacheHits, cacheInvalidations, cacheMisses } from './metrics';
 import type { Storage, StorageItem } from './storage';
 
 function generateKey(hashedToken: string) {
-  return `tokens:cache:${hashedToken}`;
+  return `tokens:v2:cache:${hashedToken}`;
 }
 
 interface CacheStorage extends Omit<Storage, 'touchTokens'> {

--- a/packages/services/usage/src/tokens.ts
+++ b/packages/services/usage/src/tokens.ts
@@ -39,7 +39,7 @@ export function createTokens(config: { endpoint: string; logger: ServiceLogger }
       });
 
       if (info) {
-        const result = info.scopes.includes('target:registry:write')
+        const result = info.scopes.includes('target:usage:write')
           ? {
               target: info.target,
               project: info.project,

--- a/packages/web/app/package.json
+++ b/packages/web/app/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-radio-group": "1.1.3",
     "@radix-ui/react-scroll-area": "1.0.5",
     "@radix-ui/react-select": "2.0.0",
+    "@radix-ui/react-separator": "1.0.3",
     "@radix-ui/react-slider": "1.1.2",
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-switch": "1.0.3",

--- a/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/settings.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/settings.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useCallback, useState } from 'react';
 import NextLink from 'next/link';
-import clsx from 'clsx';
 import { formatISO } from 'date-fns';
 import { useFormik } from 'formik';
 import { useMutation, useQuery } from 'urql';
@@ -42,6 +41,7 @@ import { ProjectType } from '@/gql/graphql';
 import { canAccessTarget, TargetAccessScope } from '@/lib/access/target';
 import { subDays } from '@/lib/date-time';
 import { useRouteSelector, useToggle } from '@/lib/hooks';
+import { cn } from '@/lib/utils';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const TargetSettings_TargetValidationSettingsFragment = graphql(`
@@ -528,7 +528,7 @@ const ConditionalBreakingChanges = (): ReactElement => {
           </CardDescription>
         </CardHeader>
         <CardContent
-          className={clsx('text-gray-300', !isEnabled && 'pointer-events-none opacity-25')}
+          className={cn('text-gray-300', !isEnabled && 'pointer-events-none opacity-25')}
         >
           <div>
             A schema change is considered as breaking only if it affects more than

--- a/packages/web/app/src/components/organization/members/common.tsx
+++ b/packages/web/app/src/components/organization/members/common.tsx
@@ -64,6 +64,7 @@ export function RoleSelector<T>(props: {
             <CommandGroup>
               {props.onNoRole ? (
                 <CommandItem
+                  value="none"
                   className={cn('flex cursor-pointer flex-col items-start space-y-1 px-4 py-2')}
                   onSelect={() => {
                     if (props.onNoRole) {
@@ -90,6 +91,7 @@ export function RoleSelector<T>(props: {
                     <Tooltip delayDuration={200} {...(isActive ? { open: false } : {})}>
                       <TooltipTrigger className="w-full text-left">
                         <CommandItem
+                          value={role.id}
                           onSelect={() => {
                             setPhase('busy');
                             setOpen(false);

--- a/packages/web/app/src/components/target/laboratory/connect-lab-modal.tsx
+++ b/packages/web/app/src/components/target/laboratory/connect-lab-modal.tsx
@@ -17,7 +17,7 @@ export const ConnectLabModal = (props: {
   endpoint: string;
   isCDNEnabled: FragmentType<typeof Laboratory_IsCDNEnabledFragment> | null;
 }): ReactElement => {
-  const docsUrl = getDocsUrl('/management/targets#registry-access-tokens');
+  const docsUrl = getDocsUrl('/management/targets#api-access-tokens');
   const isCDNEnabled = useFragment(Laboratory_IsCDNEnabledFragment, props.isCDNEnabled);
 
   return (

--- a/packages/web/app/src/components/ui/separator.tsx
+++ b/packages/web/app/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      'bg-border shrink-0',
+      orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+      className,
+    )}
+    {...props}
+  />
+));
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/packages/web/app/src/components/v2/modals/create-access-token.tsx
+++ b/packages/web/app/src/components/v2/modals/create-access-token.tsx
@@ -177,19 +177,25 @@ function Presets(props: {
         if (value === 'usage-reporting') {
           props.onSelected({
             value,
-            usageScope: TargetAccessScope.UsageRead,
-            registryScope: TargetAccessScope.RegistryRead,
+            usageScope: TargetAccessScope.UsageWrite,
+            registryScope: 'no-access',
           });
         } else if (value === 'schema-push') {
           props.onSelected({
             value,
-            usageScope: TargetAccessScope.UsageRead,
+            usageScope: 'no-access',
             registryScope: TargetAccessScope.RegistryWrite,
           });
         } else if (value === 'schema-check') {
           props.onSelected({
             value,
-            usageScope: TargetAccessScope.UsageRead,
+            usageScope: 'no-access',
+            registryScope: TargetAccessScope.RegistryRead,
+          });
+        } else if (value === 'registry-readonly') {
+          props.onSelected({
+            value,
+            usageScope: 'no-access',
             registryScope: TargetAccessScope.RegistryRead,
           });
         } else {
@@ -217,7 +223,7 @@ function Presets(props: {
           description="Use Hive CLI (schema:check) to detect changes and validate your schema"
         />
         <PresetOption
-          value="schema-check"
+          value="registry-readonly"
           name="Reading from Schema Registry"
           description="Consume schema and its metadata from the registry"
         />

--- a/packages/web/app/src/components/v2/modals/create-access-token.tsx
+++ b/packages/web/app/src/components/v2/modals/create-access-token.tsx
@@ -305,7 +305,7 @@ function ModalContent(props: {
     selectedRegistryScope === 'no-access' && selectedUsageScope === 'no-access';
 
   return (
-    <DialogContent className="max-h-5/6 w-[650px]">
+    <DialogContent className="w-[650px]">
       {mutation.data?.createToken.ok ? (
         <>
           <DialogHeader>

--- a/packages/web/app/src/components/v2/modals/create-access-token.tsx
+++ b/packages/web/app/src/components/v2/modals/create-access-token.tsx
@@ -1,12 +1,29 @@
-import { ReactElement, useState } from 'react';
+import { ReactElement, useCallback, useRef, useState } from 'react';
 import { useFormik } from 'formik';
 import { useMutation, useQuery } from 'urql';
 import * as Yup from 'yup';
 import { PermissionScopeItem, usePermissionsManager } from '@/components/organization/Permissions';
-import { Accordion, Button, CopyValue, Heading, Input, Modal, Tag } from '@/components/v2';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
+import { CopyValue, Input, Tag } from '@/components/v2';
 import { FragmentType, graphql, useFragment } from '@/gql';
 import { TargetAccessScope } from '@/gql/graphql';
-import { RegistryAccessScope } from '@/lib/access/common';
+import { RegistryAccessScope, UsageAccessScope } from '@/lib/access/common';
 import { useRouteSelector } from '@/lib/hooks';
 
 export const CreateAccessToken_CreateTokenMutation = graphql(`
@@ -62,11 +79,7 @@ export function CreateAccessTokenModal({
   const organization = organizationQuery.data?.organization?.organization;
 
   return (
-    <Modal
-      open={isOpen}
-      onOpenChange={toggleModalOpen}
-      className="flex h-5/6 w-[650px] overflow-hidden"
-    >
+    <Dialog open={isOpen} onOpenChange={toggleModalOpen}>
       {organization ? (
         <ModalContent
           organization={organization}
@@ -76,7 +89,7 @@ export function CreateAccessTokenModal({
           toggleModalOpen={toggleModalOpen}
         />
       ) : null}
-    </Modal>
+    </Dialog>
   );
 }
 
@@ -91,16 +104,126 @@ const CreateAccessTokenModalContent_OrganizationFragment = graphql(`
 `);
 
 function getFinalTargetAccessScopes(
-  selectedScope: 'no-access' | TargetAccessScope,
-): Array<TargetAccessScope> {
-  if (selectedScope === 'no-access') {
-    return [];
+  selectedRegistryScope: 'no-access' | TargetAccessScope,
+  selectedUsageScope: 'no-access' | TargetAccessScope,
+): TargetAccessScope[] {
+  const scopes: TargetAccessScope[] = [];
+
+  if (selectedRegistryScope !== 'no-access') {
+    // When :write got selected, we also need to provide :read
+    if (selectedRegistryScope === TargetAccessScope.RegistryWrite) {
+      scopes.push(TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite);
+    } else {
+      scopes.push(TargetAccessScope.RegistryRead);
+    }
   }
-  /** When RegistryWrite got selected, we also need to provide RegistryRead.  */
-  if (selectedScope === TargetAccessScope.RegistryWrite) {
-    return [TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite];
+
+  if (selectedUsageScope !== 'no-access') {
+    // When :write got selected, we also need to provide :read
+    if (selectedUsageScope === TargetAccessScope.UsageWrite) {
+      scopes.push(TargetAccessScope.UsageRead, TargetAccessScope.UsageWrite);
+    } else {
+      scopes.push(TargetAccessScope.UsageRead);
+    }
   }
-  return [TargetAccessScope.RegistryRead];
+
+  return scopes;
+}
+
+function PresetOption(props: { value: string; name: string; description: string }) {
+  return (
+    <SelectItem value={props.value}>
+      <div className="flex items-start gap-3">
+        <div className="grid gap-0.5">
+          <p>{props.name}</p>
+          <p className="text-muted-foreground text-xs" data-description>
+            {props.description}
+          </p>
+        </div>
+      </div>
+    </SelectItem>
+  );
+}
+
+function Presets(props: {
+  selected: string | undefined;
+  onSelected: (
+    event: {
+      value: string;
+      usageScope: TargetAccessScope | 'no-access';
+      registryScope: TargetAccessScope | 'no-access';
+    } | null,
+  ) => void;
+}) {
+  const key = useRef(0);
+  const previousSelected = useRef<string | undefined>();
+
+  if (previousSelected.current === undefined) {
+    previousSelected.current = props.selected;
+  }
+
+  // Every time the selected value changes, we increment the key
+  // We do it to reset the select component and make it show the placeholder
+  if (key.current >= 0 && previousSelected.current !== props.selected) {
+    key.current += 1;
+    previousSelected.current = props.selected;
+  }
+
+  return (
+    <Select
+      key={key.current}
+      value={props.selected}
+      onValueChange={value => {
+        if (value === 'usage-reporting') {
+          props.onSelected({
+            value,
+            usageScope: TargetAccessScope.UsageRead,
+            registryScope: TargetAccessScope.RegistryRead,
+          });
+        } else if (value === 'schema-push') {
+          props.onSelected({
+            value,
+            usageScope: TargetAccessScope.UsageRead,
+            registryScope: TargetAccessScope.RegistryWrite,
+          });
+        } else if (value === 'schema-check') {
+          props.onSelected({
+            value,
+            usageScope: TargetAccessScope.UsageRead,
+            registryScope: TargetAccessScope.RegistryRead,
+          });
+        } else {
+          props.onSelected(null);
+        }
+      }}
+    >
+      <SelectTrigger className="items-start [&_[data-description]]:hidden">
+        <SelectValue placeholder="Select an option" />
+      </SelectTrigger>
+      <SelectContent>
+        <PresetOption
+          value="usage-reporting"
+          name="Usage Reporting and Monitoring"
+          description="Collect usage data and monitor performance of your GraphQL API"
+        />
+        <PresetOption
+          value="schema-push"
+          name="Updating Schema Registry"
+          description="Use Hive CLI (schema:publish, schema:delete) to push your schema to the registry"
+        />
+        <PresetOption
+          value="schema-check"
+          name="Checking Schema"
+          description="Use Hive CLI (schema:check) to detect changes and validate your schema"
+        />
+        <PresetOption
+          value="schema-check"
+          name="Reading from Schema Registry"
+          description="Consume schema and its metadata from the registry"
+        />
+      </SelectContent>
+    </Select>
+  );
 }
 
 function ModalContent(props: {
@@ -114,7 +237,10 @@ function ModalContent(props: {
     CreateAccessTokenModalContent_OrganizationFragment,
     props.organization,
   );
-  const [selectedScope, setSelectedScope] = useState(
+  const [selectedRegistryScope, setSelectedRegistryScope] = useState(
+    'no-access' as TargetAccessScope | 'no-access',
+  );
+  const [selectedUsageScope, setSelectedUsageScope] = useState(
     'no-access' as TargetAccessScope | 'no-access',
   );
 
@@ -125,12 +251,40 @@ function ModalContent(props: {
     passMemberScopes: false,
   });
 
+  const [selectedPreset, setSelectedPreset] = useState<
+    | {
+        value: string;
+        usageScope: TargetAccessScope | 'no-access' | null;
+        registryScope: TargetAccessScope | 'no-access' | null;
+      }
+    | undefined
+  >();
+  const onSelectedPreset = useCallback(
+    (
+      event: {
+        value: string;
+        usageScope: TargetAccessScope | 'no-access';
+        registryScope: TargetAccessScope | 'no-access';
+      } | null,
+    ) => {
+      if (event === null) {
+        setSelectedPreset(undefined);
+        return;
+      }
+
+      setSelectedPreset(event);
+      setSelectedUsageScope(event.usageScope);
+      setSelectedRegistryScope(event.registryScope);
+    },
+    [setSelectedPreset, setSelectedUsageScope, setSelectedRegistryScope],
+  );
+
   const [mutation, mutate] = useMutation(CreateAccessToken_CreateTokenMutation);
   const { handleSubmit, values, handleChange, handleBlur, isSubmitting, errors, touched } =
     useFormik({
       initialValues: { name: '' },
       validationSchema: Yup.object().shape({
-        name: Yup.string().required('Must enter description'),
+        name: Yup.string().required('Description is required. It helps you identify the token.'),
       }),
       async onSubmit(values) {
         await mutate({
@@ -141,110 +295,140 @@ function ModalContent(props: {
             name: values.name,
             organizationScopes: [],
             projectScopes: [],
-            targetScopes: getFinalTargetAccessScopes(selectedScope),
+            targetScopes: getFinalTargetAccessScopes(selectedRegistryScope, selectedUsageScope),
           },
         });
       },
     });
 
-  const noPermissionsSelected = selectedScope === 'no-access';
+  const noPermissionsSelected =
+    selectedRegistryScope === 'no-access' && selectedUsageScope === 'no-access';
 
   return (
-    <>
+    <DialogContent className="max-h-5/6 w-[650px]">
       {mutation.data?.createToken.ok ? (
-        <div className="flex grow flex-col gap-5">
-          <Heading className="text-center">Token successfully created!</Heading>
-          <CopyValue value={mutation.data.createToken.ok.secret} />
-          <Tag color="green">
-            This is your unique API key and it is non-recoverable. If you lose this key, you will
-            need to create a new one.
-          </Tag>
-          <div className="grow" />
-          <Button
-            variant="primary"
-            size="large"
-            className="ml-auto"
-            onClick={props.toggleModalOpen}
-          >
-            Ok, got it!
-          </Button>
-        </div>
+        <>
+          <DialogHeader>
+            <DialogTitle>Token successfully created!</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-5">
+            <CopyValue value={mutation.data.createToken.ok.secret} />
+            <Tag color="green">
+              This is your unique API key and it is non-recoverable. If you lose this key, you will
+              need to create a new one.
+            </Tag>
+          </div>
+          <DialogFooter className="text-right">
+            <Button onClick={props.toggleModalOpen}>Ok, got it!</Button>
+          </DialogFooter>
+        </>
       ) : (
-        <form className="flex grow flex-col gap-5" onSubmit={handleSubmit}>
-          <div className="shrink-0">
-            <div className="flex-none">
-              <Heading className="mb-2 text-center">Create an access token</Heading>
-              <p className="mb-2 text-sm text-gray-500">
-                To access GraphQL Hive, your application or tool needs an active API key.
-              </p>
+        <>
+          <DialogHeader>
+            <DialogTitle>Create an access token</DialogTitle>
+            <DialogDescription>
+              To access GraphQL Hive, your application or tool needs an active API key.
+            </DialogDescription>
+          </DialogHeader>
+          <form className="space-y-5" onSubmit={handleSubmit}>
+            <div>
+              <div>
+                <Input
+                  placeholder="Token description"
+                  name="name"
+                  value={values.name}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  disabled={isSubmitting}
+                  isInvalid={touched.name && !!errors.name}
+                  className="w-full"
+                />
+              </div>
+              {touched.name && errors.name && (
+                <div className="mt-2 text-sm text-red-500">{errors.name}</div>
+              )}
+              {mutation.data?.createToken.error && (
+                <div className="mt-2 text-sm text-red-500">
+                  {mutation.data?.createToken.error.message}
+                </div>
+              )}
+            </div>
+            <div className="flex flex-1 flex-col overflow-hidden">
+              <PermissionScopeItem
+                scope={RegistryAccessScope}
+                canManageScope={
+                  manager.canAccessTarget(RegistryAccessScope.mapping['read-only']) ||
+                  manager.canAccessTarget(RegistryAccessScope.mapping['read-write'])
+                }
+                checkAccess={manager.canAccessTarget}
+                onChange={value => {
+                  if (value !== selectedPreset?.registryScope) {
+                    setSelectedPreset(undefined);
+                  }
 
-              <Input
-                placeholder="Token description"
-                name="name"
-                value={values.name}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                disabled={isSubmitting}
-                isInvalid={touched.name && !!errors.name}
-                className="w-full"
+                  if (value === 'no-access') {
+                    setSelectedRegistryScope('no-access');
+                    return;
+                  }
+                  setSelectedRegistryScope(value);
+                }}
+                possibleScope={Object.values(RegistryAccessScope.mapping)}
+                initialScope={selectedRegistryScope}
+                selectedScope={selectedRegistryScope}
+              />
+              <PermissionScopeItem
+                scope={UsageAccessScope}
+                canManageScope={
+                  manager.canAccessTarget(UsageAccessScope.mapping['read-only']) ||
+                  manager.canAccessTarget(UsageAccessScope.mapping['read-write'])
+                }
+                checkAccess={manager.canAccessTarget}
+                onChange={value => {
+                  if (value !== selectedPreset?.registryScope) {
+                    setSelectedPreset(undefined);
+                  }
+
+                  if (value === 'no-access') {
+                    setSelectedUsageScope('no-access');
+                    return;
+                  }
+                  setSelectedUsageScope(value);
+                }}
+                possibleScope={Object.values(UsageAccessScope.mapping)}
+                initialScope={selectedUsageScope}
+                selectedScope={selectedUsageScope}
               />
             </div>
-            {touched.name && errors.name && (
-              <div className="mt-2 text-sm text-red-500">{errors.name}</div>
-            )}
-            {mutation.data?.createToken.error && (
-              <div className="mt-2 text-sm text-red-500">
-                {mutation.data?.createToken.error.message}
-              </div>
-            )}
-          </div>
-          <div className="flex flex-1 flex-col overflow-hidden">
-            <Accordion defaultValue="Permissions">
-              <Accordion.Item value="Permissions">
-                <Accordion.Header>Registry & Usage</Accordion.Header>
-                <Accordion.Content>
-                  <PermissionScopeItem
-                    scope={RegistryAccessScope}
-                    canManageScope={
-                      manager.canAccessTarget(RegistryAccessScope.mapping['read-only']) ||
-                      manager.canAccessTarget(RegistryAccessScope.mapping['read-write'])
-                    }
-                    checkAccess={manager.canAccessTarget}
-                    onChange={value => {
-                      if (value === 'no-access') {
-                        setSelectedScope('no-access');
-                        return;
-                      }
-                      setSelectedScope(value);
-                    }}
-                    possibleScope={Object.values(RegistryAccessScope.mapping)}
-                    initialScope={selectedScope}
-                    selectedScope={selectedScope}
-                  />
-                </Accordion.Content>
-              </Accordion.Item>
-            </Accordion>
-          </div>
-          <div className="shrink-0">
-            {mutation.error && <div className="text-sm text-red-500">{mutation.error.message}</div>}
-
-            <div className="flex w-full gap-2">
-              <Button type="button" size="large" block onClick={props.toggleModalOpen}>
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                size="large"
-                block
-                variant="primary"
-                disabled={isSubmitting || noPermissionsSelected}
-              >
-                Generate Token
-              </Button>
+            <div className="my-4 flex flex-row items-center justify-between">
+              <Separator className="shrink" />
+              <div className="text-muted-foreground shrink-0 px-4">or</div>
+              <Separator className="shrink" />
             </div>
-          </div>
-        </form>
+            <div>
+              <Presets selected={selectedPreset?.value} onSelected={onSelectedPreset} />
+            </div>
+            <DialogFooter>
+              {mutation.error && (
+                <div className="text-sm text-red-500">{mutation.error.message}</div>
+              )}
+
+              <div className="space-x-2 text-right">
+                <Button
+                  variant="secondary"
+                  disabled={isSubmitting}
+                  type="button"
+                  onClick={props.toggleModalOpen}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isSubmitting || noPermissionsSelected}>
+                  Generate Token
+                </Button>
+              </div>
+            </DialogFooter>
+          </form>
+        </>
       )}
-    </>
+    </DialogContent>
   );
 }

--- a/packages/web/app/src/lib/access/common.ts
+++ b/packages/web/app/src/lib/access/common.ts
@@ -15,10 +15,19 @@ export const NoAccess = 'no-access';
 
 export const RegistryAccessScope = {
   name: 'Registry',
-  description: 'Manage registry (publish schemas, run checks, report usage)',
+  description: 'Manage registry (publish and check schemas)',
   mapping: {
     'read-only': TargetAccessScope.RegistryRead,
     'read-write': TargetAccessScope.RegistryWrite,
+  },
+};
+
+export const UsageAccessScope = {
+  name: 'Usage reporting',
+  description: 'Read and report GraphQL requests',
+  mapping: {
+    'read-only': TargetAccessScope.UsageRead,
+    'read-write': TargetAccessScope.UsageWrite,
   },
 };
 
@@ -97,6 +106,7 @@ export const scopes: {
       },
     },
     RegistryAccessScope,
+    UsageAccessScope,
     {
       name: 'Settings',
       description: 'Manage target settings (change its name, etc.)',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1598,6 +1598,9 @@ importers:
       '@radix-ui/react-select':
         specifier: 2.0.0
         version: 2.0.0(@types/react-dom@18.2.24)(@types/react@18.2.75)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-separator':
+        specifier: 1.0.3
+        version: 1.0.3(@types/react-dom@18.2.24)(@types/react@18.2.75)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-slider':
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@18.2.24)(@types/react@18.2.75)(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
Closes #124

> [!NOTE]  
> Backwards-compatible change.
> Every registry access token or organization member with `target:registry:{read,write}` will get `target:usage:{read,write}`.

> [!WARNING]  
> PG migration takes around 11s (3-5s for each of 3 transactions)

| scope               | schema:check | schema:publish | report usage |
| ------------------- | ------------ | -------------- | ------------ |
| usage:read-write    | ❌           | ❌             | ✅           |
| usage:read-only     | ❌           | ❌             | ❌           |
| registry:read-write | ✅           | ✅             | ❌           |
| registry:read-only  | ✅           | ❌             | ❌           |

## Screenshots

![Screenshot 2024-04-11 at 16 59 46](https://github.com/kamilkisiela/graphql-hive/assets/8167190/6c155b73-f98c-4bed-98b3-7fb191cbe382)

![Screenshot 2024-04-11 at 17 00 02](https://github.com/kamilkisiela/graphql-hive/assets/8167190/cdc8a15a-91a0-43e5-90c6-a770e64fc573)

![Screenshot 2024-04-11 at 17 00 13](https://github.com/kamilkisiela/graphql-hive/assets/8167190/5d5dbd80-519b-4837-a3ae-9d9ca5be6e6f)

![Screenshot 2024-04-11 at 17 00 19](https://github.com/kamilkisiela/graphql-hive/assets/8167190/0bd1e021-ca2c-4c43-99d7-5e375a977b53)