### PR TITLE
trcp call timeout

### DIFF
--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -19,6 +19,7 @@
     "@hive/cdn-script": "workspace:*",
     "@hive/emails": "workspace:*",
     "@hive/schema": "workspace:*",
+    "@hive/service-common": "workspace:*",
     "@hive/storage": "workspace:*",
     "@hive/tokens": "workspace:*",
     "@hive/webhooks": "workspace:*",

--- a/packages/services/api/src/modules/alerts/providers/adapters/webhook.ts
+++ b/packages/services/api/src/modules/alerts/providers/adapters/webhook.ts
@@ -1,6 +1,7 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
+import { createTimeoutHTTPLink } from '@hive/service-common';
 import type { WebhooksApi } from '@hive/webhooks';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTRPCProxyClient } from '@trpc/client';
 import { HttpClient } from '../../../shared/providers/http-client';
 import { Logger } from '../../../shared/providers/logger';
 import type { WebhooksConfig } from '../tokens';
@@ -23,7 +24,7 @@ export class WebhookCommunicationAdapter implements CommunicationAdapter {
     this.logger = logger.child({ service: 'WebhookCommunicationAdapter' });
     this.webhooksService = createTRPCProxyClient<WebhooksApi>({
       links: [
-        httpLink({
+        createTimeoutHTTPLink({
           url: `${config.endpoint}/trpc`,
           fetch,
           headers: {

--- a/packages/services/api/src/modules/billing/providers/billing.provider.ts
+++ b/packages/services/api/src/modules/billing/providers/billing.provider.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
+import { createTimeoutHTTPLink } from '@hive/service-common';
 import type { StripeBillingApi, StripeBillingApiInput } from '@hive/stripe-billing';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTRPCProxyClient } from '@trpc/client';
 import { OrganizationSelector } from '../../../__generated__/types';
 import { OrganizationBilling } from '../../../shared/entities';
 import { Logger } from '../../shared/providers/logger';
@@ -26,7 +27,7 @@ export class BillingProvider {
     this.logger = logger.child({ source: 'BillingProvider' });
     this.billingService = billingConfig.endpoint
       ? createTRPCProxyClient<StripeBillingApi>({
-          links: [httpLink({ url: `${billingConfig.endpoint}/trpc`, fetch })],
+          links: [createTimeoutHTTPLink({ url: `${billingConfig.endpoint}/trpc`, fetch })],
         })
       : null;
 

--- a/packages/services/api/src/modules/policy/providers/schema-policy-api.provider.ts
+++ b/packages/services/api/src/modules/policy/providers/schema-policy-api.provider.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import type { AvailableRulesResponse, SchemaPolicyApi, SchemaPolicyApiInput } from '@hive/policy';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTimeoutHTTPLink } from '@hive/service-common';
+import { createTRPCProxyClient } from '@trpc/client';
 import { sentry } from '../../../shared/sentry';
 import { Logger } from '../../shared/providers/logger';
 import type { SchemaPolicyServiceConfig } from './tokens';
@@ -24,7 +25,7 @@ export class SchemaPolicyApiProvider {
     this.schemaPolicy = config.endpoint
       ? createTRPCProxyClient<SchemaPolicyApi>({
           links: [
-            httpLink({
+            createTimeoutHTTPLink({
               url: `${config.endpoint}/trpc`,
               fetch,
             }),

--- a/packages/services/api/src/modules/rate-limit/providers/rate-limit.provider.ts
+++ b/packages/services/api/src/modules/rate-limit/providers/rate-limit.provider.ts
@@ -1,7 +1,8 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import LRU from 'lru-cache';
 import type { RateLimitApi, RateLimitApiInput } from '@hive/rate-limit';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTimeoutHTTPLink } from '@hive/service-common';
+import { createTRPCProxyClient } from '@trpc/client';
 import { sentry } from '../../../shared/sentry';
 import { Logger } from '../../shared/providers/logger';
 import type { RateLimitServiceConfig } from './tokens';
@@ -31,7 +32,7 @@ export class RateLimitProvider {
     this.rateLimit = rateLimitServiceConfig.endpoint
       ? createTRPCProxyClient<RateLimitApi>({
           links: [
-            httpLink({
+            createTimeoutHTTPLink({
               url: `${rateLimitServiceConfig.endpoint}/trpc`,
               fetch,
             }),

--- a/packages/services/api/src/modules/schema/providers/orchestrators/federation.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrators/federation.ts
@@ -1,5 +1,6 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
 import type { ContractsInputType, SchemaBuilderApi } from '@hive/schema';
+import { createTimeoutHTTPLink } from '@hive/service-common';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
 import { Orchestrator, Project, ProjectType, SchemaObject } from '../../../../shared/entities';
 import { sentry } from '../../../../shared/sentry';
@@ -28,7 +29,7 @@ export class FederationOrchestrator implements Orchestrator {
     this.logger = logger.child({ service: 'FederationOrchestrator' });
     this.schemaService = createTRPCProxyClient<SchemaBuilderApi>({
       links: [
-        httpLink({
+        createTimeoutHTTPLink({
           url: `${serviceConfig.endpoint}/trpc`,
           fetch,
           headers: {

--- a/packages/services/api/src/modules/schema/providers/orchestrators/single.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrators/single.ts
@@ -1,6 +1,7 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
 import type { SchemaBuilderApi } from '@hive/schema';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTimeoutHTTPLink } from '@hive/service-common';
+import { createTRPCProxyClient } from '@trpc/client';
 import { Orchestrator, ProjectType, SchemaObject } from '../../../../shared/entities';
 import { sentry } from '../../../../shared/sentry';
 import { Logger } from '../../../shared/providers/logger';
@@ -23,7 +24,7 @@ export class SingleOrchestrator implements Orchestrator {
     this.logger = logger.child({ service: 'SingleOrchestrator' });
     this.schemaService = createTRPCProxyClient<SchemaBuilderApi>({
       links: [
-        httpLink({
+        createTimeoutHTTPLink({
           url: `${serviceConfig.endpoint}/trpc`,
           fetch,
           headers: {

--- a/packages/services/api/src/modules/schema/providers/orchestrators/stitching.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrators/stitching.ts
@@ -1,6 +1,7 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
 import type { SchemaBuilderApi } from '@hive/schema';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTimeoutHTTPLink } from '@hive/service-common';
+import { createTRPCProxyClient } from '@trpc/client';
 import { Orchestrator, ProjectType, SchemaObject } from '../../../../shared/entities';
 import { sentry } from '../../../../shared/sentry';
 import { Logger } from '../../../shared/providers/logger';
@@ -23,7 +24,7 @@ export class StitchingOrchestrator implements Orchestrator {
     this.logger = logger.child({ service: 'StitchingOrchestrator' });
     this.schemaService = createTRPCProxyClient<SchemaBuilderApi>({
       links: [
-        httpLink({
+        createTimeoutHTTPLink({
           url: `${serviceConfig.endpoint}/trpc`,
           fetch,
           headers: {

--- a/packages/services/api/src/modules/shared/providers/emails.ts
+++ b/packages/services/api/src/modules/shared/providers/emails.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, InjectionToken, Optional } from 'graphql-modules';
 import type { EmailsApi } from '@hive/emails';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTimeoutHTTPLink } from '@hive/service-common';
+import { createTRPCProxyClient } from '@trpc/client';
 
 export const EMAILS_ENDPOINT = new InjectionToken<string>('EMAILS_ENDPOINT');
 
@@ -12,7 +13,7 @@ export class Emails {
     this.api = endpoint
       ? createTRPCProxyClient<EmailsApi>({
           links: [
-            httpLink({
+            createTimeoutHTTPLink({
               url: `${endpoint}/trpc`,
               fetch,
             }),

--- a/packages/services/api/src/modules/token/providers/token-storage.ts
+++ b/packages/services/api/src/modules/token/providers/token-storage.ts
@@ -1,6 +1,7 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
+import { createTimeoutHTTPLink } from '@hive/service-common';
 import type { TokensApi } from '@hive/tokens';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTRPCProxyClient } from '@trpc/client';
 import type { Token } from '../../../shared/entities';
 import { HiveError } from '../../../shared/errors';
 import { atomic } from '../../../shared/helpers';
@@ -45,7 +46,7 @@ export class TokenStorage {
     this.logger = logger.child({ source: 'TokenStorage' });
     this.tokensService = createTRPCProxyClient<TokensApi>({
       links: [
-        httpLink({
+        createTimeoutHTTPLink({
           url: `${tokensConfig.endpoint}/trpc`,
           fetch,
           headers: {

--- a/packages/services/api/src/modules/usage-estimation/providers/usage-estimation.provider.ts
+++ b/packages/services/api/src/modules/usage-estimation/providers/usage-estimation.provider.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
+import { createTimeoutHTTPLink } from '@hive/service-common';
 import type { UsageEstimatorApi, UsageEstimatorApiInput } from '@hive/usage-estimator';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTRPCProxyClient } from '@trpc/client';
 import { sentry } from '../../../shared/sentry';
 import { Logger } from '../../shared/providers/logger';
 import type { UsageEstimationServiceConfig } from './tokens';
@@ -22,7 +23,7 @@ export class UsageEstimationProvider {
     this.usageEstimator = usageEstimationConfig.endpoint
       ? createTRPCProxyClient<UsageEstimatorApi>({
           links: [
-            httpLink({
+            createTimeoutHTTPLink({
               url: `${usageEstimationConfig.endpoint}/trpc`,
               fetch,
             }),

--- a/packages/services/rate-limit/src/emails.ts
+++ b/packages/services/rate-limit/src/emails.ts
@@ -1,12 +1,13 @@
 import type { EmailsApi } from '@hive/emails';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTimeoutHTTPLink } from '@hive/service-common';
+import { createTRPCProxyClient } from '@trpc/client';
 import { env } from './environment';
 
 export function createEmailScheduler(config?: { endpoint: string }) {
   const api = config?.endpoint
     ? createTRPCProxyClient<EmailsApi>({
         links: [
-          httpLink({
+          createTimeoutHTTPLink({
             url: `${config.endpoint}/trpc`,
             fetch,
           }),

--- a/packages/services/rate-limit/src/limiter.ts
+++ b/packages/services/rate-limit/src/limiter.ts
@@ -1,5 +1,5 @@
 import { endOfMonth, startOfMonth } from 'date-fns';
-import type { ServiceLogger } from '@hive/service-common';
+import { createTimeoutHTTPLink, type ServiceLogger } from '@hive/service-common';
 import { createStorage as createPostgreSQLStorage } from '@hive/storage';
 import type { UsageEstimatorApi } from '@hive/usage-estimator';
 import * as Sentry from '@sentry/node';
@@ -63,7 +63,7 @@ export function createRateLimiter(config: {
 }) {
   const rateEstimator = createTRPCProxyClient<UsageEstimatorApi>({
     links: [
-      httpLink({
+      createTimeoutHTTPLink({
         url: `${config.rateEstimator.endpoint}/trpc`,
         fetch,
       }),

--- a/packages/services/service-common/package.json
+++ b/packages/services/service-common/package.json
@@ -7,6 +7,7 @@
   "peerDependencies": {
     "@sentry/node": "^7.0.0",
     "@sentry/utils": "^7.0.0",
+    "@trpc/client": "10.45.1",
     "@trpc/server": "10.45.1"
   },
   "devDependencies": {

--- a/packages/services/usage/src/rate-limit.ts
+++ b/packages/services/usage/src/rate-limit.ts
@@ -1,7 +1,7 @@
 import LRU from 'tiny-lru';
 import type { RateLimitApi, RateLimitApiInput, RateLimitApiOutput } from '@hive/rate-limit';
-import { ServiceLogger } from '@hive/service-common';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTimeoutHTTPLink, ServiceLogger } from '@hive/service-common';
+import { createTRPCProxyClient } from '@trpc/client';
 
 export function createUsageRateLimit(config: { endpoint: string | null; logger: ServiceLogger }) {
   const logger = config.logger;
@@ -18,7 +18,7 @@ export function createUsageRateLimit(config: { endpoint: string | null; logger: 
   const endpoint = config.endpoint.replace(/\/$/, '');
   const rateLimit = createTRPCProxyClient<RateLimitApi>({
     links: [
-      httpLink({
+      createTimeoutHTTPLink({
         url: `${endpoint}/trpc`,
         fetch,
       }),

--- a/packages/services/usage/src/tokens.ts
+++ b/packages/services/usage/src/tokens.ts
@@ -1,7 +1,7 @@
 import LRU from 'tiny-lru';
-import { ServiceLogger } from '@hive/service-common';
+import { createTimeoutHTTPLink, ServiceLogger } from '@hive/service-common';
 import type { TokensApi } from '@hive/tokens';
-import { createTRPCProxyClient, httpLink } from '@trpc/client';
+import { createTRPCProxyClient } from '@trpc/client';
 import { tokenCacheHits, tokenRequests } from './metrics';
 
 export enum TokenStatus {
@@ -23,7 +23,7 @@ export function createTokens(config: { endpoint: string; logger: ServiceLogger }
   const tokens = LRU<Promise<Token>>(1000, 30_000);
   const tokensApi = createTRPCProxyClient<TokensApi>({
     links: [
-      httpLink({
+      createTimeoutHTTPLink({
         url: `${endpoint}/trpc`,
         fetch,
       }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,6 +562,9 @@ importers:
       '@hive/schema':
         specifier: workspace:*
         version: link:../schema
+      '@hive/service-common':
+        specifier: workspace:*
+        version: link:../service-common
       '@hive/storage':
         specifier: workspace:*
         version: link:../storage
@@ -1090,6 +1093,9 @@ importers:
 
   packages/services/service-common:
     dependencies:
+      '@trpc/client':
+        specifier: 10.45.1
+        version: 10.45.1(@trpc/server@10.45.1)
       '@trpc/server':
         specifier: 10.45.1
         version: 10.45.1


### PR DESCRIPTION
### Background

cloudflare aborts the request after 60 seconds. To make it more visible why a request got aborted we can have a timeout for HTTP requests lower than the Cloudflare threshold. That way we can see on sentry if things take longer than expected.

This is not the ideal solution, in theory, we could also pass a long abort signal through everything and cascade cancel every in-flight request. However, this is for another day.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
