### PR TITLE
Show total unused fields

### DIFF
--- a/packages/web/app/src/pages/target-explorer-unused.tsx
+++ b/packages/web/app/src/pages/target-explorer-unused.tsx
@@ -13,6 +13,7 @@ import { Subtitle, Title } from '@/components/ui/page';
 import { QueryError } from '@/components/ui/query-error';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { FragmentType, graphql, useFragment } from '@/gql';
+import { GraphQlInputObjectType, GraphQlInterfaceType, GraphQlObjectType } from '@/gql/graphql';
 import { useDateRangeController } from '@/lib/hooks/use-date-range-controller';
 import { cn } from '@/lib/utils';
 import { TypeRenderer, TypeRenderFragment } from './target-explorer-type';
@@ -97,8 +98,29 @@ const UnusedSchemaView = memo(function _UnusedSchemaView(props: {
     return null;
   }
 
+  const unusedTypes = types.length ?? 0;
+  const unusedFields = types.reduce((a, b) => {
+    if (b.__typename === 'GraphQLObjectType') {
+      return a + (b as GraphQlObjectType).fields.length;
+    }
+    if (b.__typename === 'GraphQLInterfaceType') {
+      return a + (b as GraphQlInterfaceType).fields.length;
+    }
+    if (b.__typename === 'GraphQLInputObjectType') {
+      return a + (b as GraphQlInputObjectType).fields.length;
+    }
+
+    return a;
+  }, 0);
+
   return (
     <div className="space-y-6">
+      <div>
+        <p className="text-sm text-gray-500">
+          You have a total of {unusedFields} unused fields within {unusedTypes} different types in
+          the selected time period
+        </p>
+      </div>
       <div>
         <TooltipProvider>
           {letters.map(letter => (


### PR DESCRIPTION
### Background

#5870 

I would like to see the total unused fields so I can see if my team is improving over time with cleaning-up their unused fields/types. If you do not see added value then let me know. 

### Description

Affects the web app only as it is only display changes.

This is how I made it look:
![Scherm­afbeelding 2024-11-08 om 15 34 22](https://github.com/user-attachments/assets/15ea1e7e-f68c-4e7d-85bc-328b3815f40e)

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

Only display changes which should not affect the security of the system in any way. 
