### PR TITLE
test: organization member can create a target

### DIFF
--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -29,6 +29,7 @@ import {
   createMemberRole,
   createOrganization,
   createProject,
+  createTarget,
   createToken,
   deleteMemberRole,
   deleteSchema,
@@ -730,6 +731,16 @@ export function initSeed() {
                     },
                     ownerToken,
                   ).then(r => r.expectNoGraphQLErrors());
+                },
+                async createTarget(args?: { slug?: string; accessToken?: string }) {
+                  return createTarget(
+                    {
+                      organizationSlug: orgSlug,
+                      projectSlug: project.slug,
+                      slug: args?.slug ?? generateUnique(),
+                    },
+                    args?.accessToken ?? ownerToken,
+                  );
                 },
               };
             },


### PR DESCRIPTION
### Background

Test for https://github.com/graphql-hive/platform/pull/5899

This just ensures that a organization member can create a target.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
