### PR TITLE
Make content of landing page visible to crawlers

### DIFF
--- a/packages/web/docs/src/components/ecosystem-management/index.tsx
+++ b/packages/web/docs/src/components/ecosystem-management/index.tsx
@@ -291,6 +291,7 @@ function Illustration(props: { className?: string }) {
               key={i}
               className={cn(
                 'absolute inset-0',
+                // Makes it accessible by crawlers.
                 highlightedEdge !== null && highlightedEdge - 1 === i ? 'visible' : 'invisible',
               )}
             >
@@ -298,9 +299,6 @@ function Illustration(props: { className?: string }) {
             </span>
           );
         })}
-        {/* <span className="absolute inset-0">
-          {highlightedEdge !== null ? edgeTexts[highlightedEdge - 1] : null}
-        </span> */}
       </p>
     </div>
   );

--- a/packages/web/docs/src/components/ecosystem-management/index.tsx
+++ b/packages/web/docs/src/components/ecosystem-management/index.tsx
@@ -285,9 +285,22 @@ function Illustration(props: { className?: string }) {
       <p className={cn('relative text-white/80', styles.text)}>
         {/* We use the longest text to ensure we have enough space. */}
         <span className="invisible">{longestEdgeText}</span>
-        <span className="absolute inset-0">
+        {edgeTexts.map((text, i) => {
+          return (
+            <span
+              key={i}
+              className={cn(
+                'absolute inset-0',
+                highlightedEdge !== null && highlightedEdge - 1 === i ? 'visible' : 'invisible',
+              )}
+            >
+              {text}
+            </span>
+          );
+        })}
+        {/* <span className="absolute inset-0">
           {highlightedEdge !== null ? edgeTexts[highlightedEdge - 1] : null}
-        </span>
+        </span> */}
       </p>
     </div>
   );

--- a/packages/web/docs/src/components/feature-tabs.tsx
+++ b/packages/web/docs/src/components/feature-tabs.tsx
@@ -128,7 +128,12 @@ export function FeatureTabs({ className }: { className?: string }) {
         </Tabs.List>
         <div className="grid grid-cols-1 lg:grid-cols-2">
           <>
-            <Tabs.Content value="Schema Registry" tabIndex={-1}>
+            <Tabs.Content
+              value="Schema Registry"
+              forceMount
+              className="data-[state=inactive]:hidden"
+              tabIndex={-1}
+            >
               <Feature
                 title="Schema Registry"
                 documentationLink="/docs/schema-registry"
@@ -137,7 +142,12 @@ export function FeatureTabs({ className }: { className?: string }) {
                 setActiveHighlight={setActiveHighlight}
               />
             </Tabs.Content>
-            <Tabs.Content value="GraphQL Observability" tabIndex={-1}>
+            <Tabs.Content
+              value="GraphQL Observability"
+              forceMount
+              className="data-[state=inactive]:hidden"
+              tabIndex={-1}
+            >
               <Feature
                 title="GraphQL Observability"
                 documentationLink="/docs/schema-registry/usage-reporting"
@@ -146,7 +156,12 @@ export function FeatureTabs({ className }: { className?: string }) {
                 setActiveHighlight={setActiveHighlight}
               />
             </Tabs.Content>
-            <Tabs.Content value="Schema Management" tabIndex={-1}>
+            <Tabs.Content
+              value="Schema Management"
+              forceMount
+              className="data-[state=inactive]:hidden"
+              tabIndex={-1}
+            >
               <Feature
                 title="Schema Management"
                 documentationLink="/docs/schema-registry/schema-policy"

--- a/packages/web/docs/src/components/feature-tabs.tsx
+++ b/packages/web/docs/src/components/feature-tabs.tsx
@@ -130,7 +130,7 @@ export function FeatureTabs({ className }: { className?: string }) {
           <>
             <Tabs.Content
               value="Schema Registry"
-              {/* Make it accessible to crawlers, otherwise there's no DOM element */}
+              // Make it accessible to crawlers, otherwise there's no DOM element to index
               forceMount
               className="data-[state=inactive]:hidden"
               tabIndex={-1}

--- a/packages/web/docs/src/components/feature-tabs.tsx
+++ b/packages/web/docs/src/components/feature-tabs.tsx
@@ -130,6 +130,7 @@ export function FeatureTabs({ className }: { className?: string }) {
           <>
             <Tabs.Content
               value="Schema Registry"
+              {/* Make it accessible to crawlers, otherwise there's no DOM element */}
               forceMount
               className="data-[state=inactive]:hidden"
               tabIndex={-1}

--- a/packages/web/docs/src/components/frequently-asked-questions/index.tsx
+++ b/packages/web/docs/src/components/frequently-asked-questions/index.tsx
@@ -54,16 +54,19 @@ export function FrequentlyAskedQuestions({ className }: { className?: string }) 
               <Accordion.Item
                 asChild
                 value={question}
-                className="rdx-state-open:pb-4 relative pb-0 transition-all duration-500 ease-[ease] focus-within:z-10"
+                className="rdx-state-open:pb-4 relative pb-0 focus-within:z-10"
               >
                 <li>
                   <Accordion.Header>
                     <Accordion.Trigger className="hive-focus hover:bg-beige-100/80 -mx-2 my-1 flex w-[calc(100%+1rem)] items-center justify-between rounded-xl bg-white px-2 py-3 text-left font-medium transition-colors duration-[.8s] md:my-2 md:py-4">
                       {question}
-                      <ChevronDownIcon className="size-5 transition duration-500 ease-in [[data-state='open']_&]:[transform:rotateX(180deg)]" />
+                      <ChevronDownIcon className="size-5 [[data-state='open']_&]:[transform:rotateX(180deg)]" />
                     </Accordion.Trigger>
                   </Accordion.Header>
-                  <Accordion.Content className="rdx-state-open:motion-safe:animate-accordion-down rdx-state-closed:motion-safe:animate-accordion-up overflow-hidden bg-white text-green-800 transition-all">
+                  <Accordion.Content
+                    forceMount
+                    className="overflow-hidden bg-white text-green-800 data-[state=closed]:hidden"
+                  >
                     {answer}
                   </Accordion.Content>
                 </li>


### PR DESCRIPTION
Tabs, FAQ and the diagram content did not have mounted DOM elements.
The only sacrifice is the animation in FAQ, but honestly, I prefer it without it, as you click and wait a second to read what's in there.