### PR TITLE
improve Crate publish flow

### DIFF
--- a/.changeset/tricky-ravens-share.md
+++ b/.changeset/tricky-ravens-share.md
@@ -1,0 +1,5 @@
+---
+'hive-apollo-router-plugin': patch
+---
+
+Fixes for Crate publishing flow

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -36,6 +36,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
       - name: publish stable
         id: changesets
         uses: changesets/action@v1.4.9
@@ -90,11 +94,6 @@ jobs:
           VERSION=`echo $(jq -r '.[] | select(.name | endswith("hive-apollo-router-plugin")).version' published.json)`
           echo "crate_version=$VERSION" >> $GITHUB_OUTPUT
           echo "crate_publish=true" >> $GITHUB_OUTPUT
-
-      - uses: dtolnay/rust-toolchain@stable
-        if: steps.rust-crate.outputs.crate_publish == 'true'
-        with:
-          toolchain: stable
 
       - name: release hive-apollo-router-plugin to Crates.io
         if: steps.rust-crate.outputs.crate_publish == 'true'

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: changesets/action@v1.4.9
         with:
           publish: pnpm release
+          version: pnpm changeset version && pnpm --filter hive-apollo-router-plugin sync-cargo-file
           commit: 'chore(release): update monorepo packages versions'
           title: 'Upcoming Release Changes'
         env:
@@ -98,11 +99,7 @@ jobs:
       - name: release hive-apollo-router-plugin to Crates.io
         if: steps.rust-crate.outputs.crate_publish == 'true'
         run: |
-          cargo install set-cargo-version
-          set-cargo-version packages/libraries/router/Cargo.toml ${{ steps.rust-crate.outputs.crate_version }}
-
           cd packages/libraries/router
-
           cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish --allow-dirty --no-verify
 

--- a/packages/libraries/router/Cargo.toml
+++ b/packages/libraries/router/Cargo.toml
@@ -5,7 +5,6 @@ repository = "https://github.com/graphql-hive/console/"
 edition = "2021"
 license = "MIT"
 publish = true
-# Set by CI during publish flow.
 version = "0.0.0"
 description = "Apollo-Router Plugin for Hive"
 

--- a/packages/libraries/router/package.json
+++ b/packages/libraries/router/package.json
@@ -1,5 +1,8 @@
 {
   "name": "hive-apollo-router-plugin",
   "version": "0.1.0",
-  "private": true
+  "private": true,
+  "scripts": {
+    "sync-cargo-file": "./sync-cargo-file.sh"
+  }
 }

--- a/packages/libraries/router/sync-cargo-file.sh
+++ b/packages/libraries/router/sync-cargo-file.sh
@@ -1,5 +1,14 @@
 #/bin/bash
 
+# The following script syncs the "version" field in package.json to the "package.version" field in Cargo.toml
+# This main versioning flow is managed by Changeset.
+# This file is executed during "changeset version" (when the version is bumped and release PR is created)
+# to sync the version in Cargo.toml
+
+# References:
+# .github/workflows/publish-rust.yaml - The GitHub action that runs this script (after "changeset version")
+# .github/workflows/main-rust.yaml - The GitHub action that does the actual publishing, if a changeset is declared to this package/crate
+
 npm_version=$(node -p "require('./package.json').version")
 cargo install set-cargo-version
 set-cargo-version ./Cargo.toml $npm_version

--- a/packages/libraries/router/sync-cargo-file.sh
+++ b/packages/libraries/router/sync-cargo-file.sh
@@ -1,0 +1,5 @@
+#/bin/bash
+
+npm_version=$(node -p "require('./package.json').version")
+cargo install set-cargo-version
+set-cargo-version ./Cargo.toml $npm_version


### PR DESCRIPTION
This PR integrates the `changeset version` script with the Crate publishing. 

When a changeset is created and merged to the fake-`package.json`, it will also update the Crates.toml file with the version number. 
Later, merging the changeset PR into  `main` will trigger a workflow to cut a release to Crates.io. 