### PR TITLE
feat: remove the transition for accordions

### DIFF
--- a/packages/web/app/src/components/ui/accordion.tsx
+++ b/packages/web/app/src/components/ui/accordion.tsx
@@ -23,7 +23,7 @@ const AccordionTrigger = React.forwardRef<
   <AccordionTriggerPrimitive
     ref={ref}
     className={cn(
-      'flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180',
+      'flex flex-1 items-center justify-between py-4 font-medium hover:underline [&[data-state=open]>svg]:rotate-180',
       className,
     )}
     {...props}
@@ -40,7 +40,7 @@ const AccordionContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}
-    className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm transition-all"
+    className="overflow-hidden text-sm data-[state=closed]:hidden"
     {...props}
   >
     <div className={cn('pb-4 pt-0', className)}>{children}</div>


### PR DESCRIPTION
### Background

It is slow and laggy. We don't need it.

https://github.com/user-attachments/assets/9d392abe-5138-4941-9a19-c84ba77a4639

###

This modifies the shadcn components, which we never want to do. But I guess in this case it is fine.