### PR TITLE
product update and docs for apollo-router custom build versioning

### DIFF
--- a/.changeset/warm-peas-melt.md
+++ b/.changeset/warm-peas-melt.md
@@ -1,0 +1,5 @@
+---
+'hive-apollo-router-plugin': major
+---
+
+Release v1 of Hive plugin for apollo-router

--- a/packages/web/docs/public/apollo-router-download.sh
+++ b/packages/web/docs/public/apollo-router-download.sh
@@ -11,7 +11,7 @@ parse_args() {
     key="$1"
 
     case $key in
-      -c | --commit)
+      -c | --commit | -v | --version)
         COMMIT="$2"
         shift # past commit argument
         shift # past commit value

--- a/packages/web/docs/src/pages/docs/other-integrations/apollo-router.mdx
+++ b/packages/web/docs/src/pages/docs/other-integrations/apollo-router.mdx
@@ -47,11 +47,19 @@ will be used for authenticating the supergraph polling from the CDN.
 
 <Tabs items={['Binary', 'Docker', 'Custom']}>
   <Tabs.Tab>
-    Download Apollo Router for Linux (`x86_64`), MacOS (`x86_64`) or Windows (`x86_64`):
+    Download Apollo Router for Linux (`x86_64`), MacOS (`x86_64`) or Windows (`x86_64`). To download the latest version of the router, use the following script:
 
     ```bash
     curl -fsSL https://graphql-hive.com/apollo-router-download.sh | bash
     ```
+
+    To download a specfic version of the router, use the `-v` or `--version` flag:
+
+    ```bash
+    curl -fsSL https://graphql-hive.com/apollo-router-download.sh | bash -s -- --version router1.57.1-plugin1.0.0
+    ```
+
+    > The full list of releases can be found in the [releases registry page](https://github.com/graphql-hive/console/pkgs/container/apollo-router)
 
     Start the router:
 
@@ -63,14 +71,16 @@ will be used for authenticating the supergraph polling from the CDN.
 
   </Tabs.Tab>
   <Tabs.Tab>
-      Running Apollo Router with Hive's Schema Registry:
+      To run Apollo Router with Hive plugin, use the following Docker command.
+
+      Make sure to replace `IMAGE_TAG_HERE` with the image tag. You can use `latest` for development, or pick a specific version for production from the [releases registry page](https://github.com/graphql-hive/console/pkgs/container/apollo-router).
 
       ```bash
       docker run -p 4000:4000 \
         --env HIVE_CDN_ENDPOINT="..." \ # The endpoint of your CDN access token
         --env HIVE_CDN_KEY="..." \ # The CDN access token
         --rm \
-        ghcr.io/graphql-hive/apollo-router:latest
+        ghcr.io/graphql-hive/apollo-router:IMAGE_TAG_HERE
       ```
 
       Passing command-line arguments:
@@ -80,7 +90,7 @@ will be used for authenticating the supergraph polling from the CDN.
         --env HIVE_CDN_ENDPOINT="..." \ # The endpoint of your CDN access token
         --env HIVE_CDN_KEY="..." \ # The CDN access token
         --rm \
-        ghcr.io/graphql-hive/apollo-router:latest --log debug
+        ghcr.io/graphql-hive/apollo-router:IMAGE_TAG_HERE --log debug
       ```
 
   </Tabs.Tab>
@@ -133,6 +143,18 @@ will be used for authenticating the supergraph polling from the CDN.
   </Tabs.Tab>
 </Tabs>
 
+### Version Structure
+
+The Docker image's and the binary artifact's versioning follows the pattern
+`routerX.Y.Z-pluginX.Y.Z`, combining both the core
+[Apollo Router](https://crates.io/crates/apollo-router) and
+[Hive plugin](https://crates.io/crates/hive-apollo-router-plugin) versions.
+
+For example: `router1.57.1-plugin1.0.0`.
+
+You can find the list of releases in the
+[releases registry page](https://github.com/graphql-hive/console/pkgs/container/apollo-router).
+
 ## Configuration
 
 - `HIVE_CDN_ENDPOINT` - the endpoint Hive generated for you in the previous step
@@ -172,7 +194,10 @@ You can send usage reporting to Hive registry by enabling `hive.usage` plugin in
 
   </Tabs.Tab>
   <Tabs.Tab>
-      Running Apollo Router with Hive's Schema Registry and Usage Reporting:
+      To run Apollo Router with Hive plugin with usage reporting, use the following Docker command.
+
+      Make sure to replace `IMAGE_TAG_HERE` with the image tag. You can use `latest` for development, or pick a specific version for production from the [releases registry page](https://github.com/graphql-hive/console/pkgs/container/apollo-router).
+
 
       ```bash
       docker run -p 4000:4000 \
@@ -181,7 +206,7 @@ You can send usage reporting to Hive registry by enabling `hive.usage` plugin in
         --env HIVE_CDN_KEY="..." \
         --mount "type=bind,source=/home/usr/src/hive/router.yaml,target=/dist/config/router.yaml" \
         --rm \
-        ghcr.io/graphql-hive/apollo-router:latest
+        ghcr.io/graphql-hive/apollo-router:IMAGE_TAG_HERE
       ```
 
       To follow the same convention as Apollo Router's official Docker image, the config file is also located at `/dist/config/router.yaml`.

--- a/packages/web/docs/src/pages/product-updates/2024-11-19-apollo-router-hive-versioning.mdx
+++ b/packages/web/docs/src/pages/product-updates/2024-11-19-apollo-router-hive-versioning.mdx
@@ -1,0 +1,84 @@
+---
+title: Hive Plugin for Apollo Router - Stable v1 Release
+description:
+  The stable build of Apollo Router with Hive plugin is now available. Learn how to integrate it
+  with your Federation projects.
+date: 2024-11-19
+authors: [dotan]
+---
+
+We've recently released a stable `v1` release of our Hive plugin for Apollo Router!
+
+For detailed integration instructions, visit our
+[Apollo Router integration documentation](/docs/other-integrations/apollo-router).
+
+## Version Structure
+
+Our versioning follows the pattern `routerX.Y.Z-pluginX.Y.Z`, combining both the core
+[Apollo Router](https://crates.io/crates/apollo-router) and
+[Hive plugin](https://crates.io/crates/hive-apollo-router-plugin) versions. For example:
+`router1.57.1-plugin1.0.0`.
+
+## Installation Options
+
+### Docker Image
+
+Pull from our GitHub Packages registry:
+
+```bash
+# Latest version
+docker pull ghcr.io/graphql-hive/apollo-router:latest
+
+# Specific version (recommended for production)
+docker pull ghcr.io/graphql-hive/apollo-router:router1.57.1-plugin1.0.0
+```
+
+> **Important:** For production deployments, always use a specific version tag rather than `latest`
+> to ensure stability and predictability.
+
+Browse all available versions in our
+[releases registry](https://github.com/graphql-hive/console/pkgs/container/apollo-router).
+
+For running instructions, see our [Docker usage guide](/docs/other-integrations/apollo-router).
+
+### Binary Installation
+
+Download Apollo Router with Hive plugin for Linux (`x86_64`), MacOS (`x86_64`), or Windows
+(`x86_64`):
+
+```bash
+curl -fsSL https://graphql-hive.com/apollo-router-download.sh | bash
+```
+
+You may also specify a version using the `-v` or `--version` flag:
+
+```bash
+curl -fsSL https://graphql-hive.com/apollo-router-download.sh | bash -s -- --version router1.57.1-plugin1.0.0
+```
+
+For setup instructions, see our [binary deployment guide](/docs/other-integrations/apollo-router).
+
+Browse all available versions in our
+[releases registry](https://github.com/graphql-hive/console/pkgs/container/apollo-router).
+
+### Rust Integration (Crate)
+
+The Hive plugin is available as a standalone crate:
+
+```toml
+[dependencies]
+hive-apollo-router-plugin = "1.0.0"  # Replace with latest version
+```
+
+If you were previously using the Hive plugin crate via `git`, update it to the latest version:
+
+```toml
+[dependencies]
+# Before:
+# hive-apollo-router-plugin = { git = "...", branch = "main", rev = "..." }
+# After:
+hive-apollo-router-plugin = "1.0.0"
+```
+
+Find the package and all release versions on
+[Crates.io](https://crates.io/crates/hive-apollo-router-plugin).


### PR DESCRIPTION
Closes https://github.com/graphql-hive/console/issues/3314 

## TODO 

- [x] fix build https://github.com/graphql-hive/console/pull/5940 
- [x] validate actual release from `main` (https://github.com/graphql-hive/console/pull/5938)
- [x] product update
- [x] changeset to cut v1 release of the hive plugin
- [x] update docs