### PR TITLE
fix: schema check approval, schema version approval and laboratory pe…

### DIFF
--- a/.changeset/chilled-pears-jump.md
+++ b/.changeset/chilled-pears-jump.md
@@ -1,0 +1,6 @@
+---
+'hive': patch
+---
+
+Require "registry write" permissions for approving failed schema checks, schema versions, and the
+laboratory.

--- a/packages/services/api/src/modules/auth/lib/supertokens-strategy.ts
+++ b/packages/services/api/src/modules/auth/lib/supertokens-strategy.ts
@@ -283,22 +283,15 @@ function transformOrganizationMemberLegacyScopes(args: {
       case TargetAccessScope.READ: {
         policies.push({
           effect: 'allow',
-          action: [
-            'appDeployment:describe',
-            'laboratory:describe',
-            'laboratory:modify',
-            'schemaCheck:approve',
-            'schemaVersion:approve',
-            'target:create',
-          ],
+          action: ['appDeployment:describe', 'laboratory:describe', 'target:create'],
           resource: [`hrn:${args.organizationId}:organization/${args.organizationId}`],
         });
         break;
       }
-      case TargetAccessScope.TOKENS_READ: {
+      case TargetAccessScope.REGISTRY_WRITE: {
         policies.push({
           effect: 'allow',
-          action: [],
+          action: ['schemaCheck:approve', 'schemaVersion:approve', 'laboratory:modify'],
           resource: [`hrn:${args.organizationId}:organization/${args.organizationId}`],
         });
         break;


### PR DESCRIPTION
…rmissions

### Background

Everyone with target read access can approve schema checks, schema versions and modify the laboratory.

This is a simple change to change that behaviour until we have the new permission system.


### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
