### PR TITLE
Fix missing `/usr/local/lib` in Hive CLI install script

### DIFF
--- a/packages/web/docs/public/install.sh
+++ b/packages/web/docs/public/install.sh
@@ -111,6 +111,7 @@
 
         echo "Downloaded to \$DOWNLOAD_DIR"
 
+        mkdir -p /usr/local/lib
         rm -rf "/usr/local/lib/hive"
         tar xzf "\$DOWNLOAD_DIR/hive.tar.gz" -C /usr/local/lib
         rm -rf "\$DOWNLOAD_DIR"


### PR DESCRIPTION
Closes https://github.com/graphql-hive/console/issues/3292 

The `/usr/local/lib` might not exists, especially if the OS is new and tools like `brew` are not installed yet. 

This ensures that the dir exists before trying to create/update/delete files in it. The `-p` will silently ignore if the dir already exists