### PR TITLE
Retry calls to Github (check-runs) and inform user about Github API having issues

### DIFF
--- a/.changeset/great-needles-guess.md
+++ b/.changeset/great-needles-guess.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Retry calls to Github API when creating check-runs

--- a/.changeset/short-candles-clap.md
+++ b/.changeset/short-candles-clap.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Inform users about Github API issues when creating check runs

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -27,6 +27,7 @@
     "@hive/webhooks": "workspace:*",
     "@octokit/app": "14.1.0",
     "@octokit/core": "5.2.0",
+    "@octokit/plugin-retry": "6.0.1",
     "@octokit/request-error": "6.1.5",
     "@sentry/node": "7.120.0",
     "@sentry/types": "7.120.0",

--- a/packages/services/api/src/modules/integrations/providers/github-integration-manager.ts
+++ b/packages/services/api/src/modules/integrations/providers/github-integration-manager.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, InjectionToken, Scope } from 'graphql-modules';
 import { App } from '@octokit/app';
 import { Octokit } from '@octokit/core';
+import { retry } from '@octokit/plugin-retry';
 import { RequestError } from '@octokit/request-error';
 import type { GitHubIntegration } from '../../../__generated__/types';
 import { HiveError } from '../../../shared/errors';
@@ -17,13 +18,17 @@ export const GITHUB_APP_CONFIG = new InjectionToken<GitHubApplicationConfig>(
   'GitHubApplicationConfig',
 );
 
+type Constructor<T> = new (...args: any[]) => T;
+
 @Injectable({
   scope: Scope.Operation,
   global: true,
 })
 export class GitHubIntegrationManager {
   private logger: Logger;
-  private app?: App;
+  private app?: App<{
+    Octokit: typeof Octokit & Constructor<ReturnType<typeof retry>>;
+  }>;
 
   constructor(
     logger: Logger,
@@ -40,7 +45,7 @@ export class GitHubIntegrationManager {
         appId: this.config.appId,
         privateKey: this.config.privateKey,
         log: this.logger,
-        Octokit: Octokit.defaults({
+        Octokit: Octokit.plugin(retry).defaults({
           request: {
             fetch,
           },
@@ -144,7 +149,7 @@ export class GitHubIntegrationManager {
     return installationId;
   }
 
-  private async getOctokitForOrganization(selector: OrganizationSelector): Promise<Octokit | null> {
+  private async getOctokitForOrganization(selector: OrganizationSelector) {
     const installationId = await this.getInstallationId(selector);
 
     if (!installationId) {

--- a/packages/services/api/src/modules/integrations/providers/github-integration-manager.ts
+++ b/packages/services/api/src/modules/integrations/providers/github-integration-manager.ts
@@ -300,6 +300,13 @@ export class GitHubIntegrationManager {
           };
         }
 
+        if (error.status >= 500) {
+          return {
+            success: false,
+            error: `GitHub API couldn't respond to your request in time. Please check Github status page for more information.`,
+          };
+        }
+
         return {
           success: false,
           error:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,6 +698,9 @@ importers:
       '@octokit/core':
         specifier: 5.2.0
         version: 5.2.0
+      '@octokit/plugin-retry':
+        specifier: 6.0.1
+        version: 6.0.1(@octokit/core@5.2.0)
       '@octokit/request-error':
         specifier: 6.1.5
         version: 6.1.5
@@ -3849,6 +3852,7 @@ packages:
 
   '@fastify/vite@6.0.7':
     resolution: {integrity: sha512-+dRo9KUkvmbqdmBskG02SwigWl06Mwkw8SBDK1zTNH6vd4DyXbRvI7RmJEmBkLouSU81KTzy1+OzwHSffqSD6w==}
+    bundledDependencies: []
 
   '@floating-ui/core@1.2.6':
     resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}
@@ -5092,6 +5096,12 @@ packages:
 
   '@octokit/plugin-paginate-rest@9.1.5':
     resolution: {integrity: sha512-WKTQXxK+bu49qzwv4qKbMMRXej1DU2gq017euWyKVudA6MldaSSQuxtz+vGbhxV4CjxpUxjZu6rM2wfc1FiWVg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=5'
+
+  '@octokit/plugin-retry@6.0.1':
+    resolution: {integrity: sha512-SKs+Tz9oj0g4p28qkZwl/topGcb0k0qPNX/i7vBKmDsjoeqnVfFUquqrE/O9oJY7+oLzdCtkiWSXLpLjvl6uog==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@octokit/core': '>=5'
@@ -8483,6 +8493,9 @@ packages:
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
@@ -20545,6 +20558,13 @@ snapshots:
       '@octokit/core': 5.2.0
       '@octokit/types': 12.4.0
 
+  '@octokit/plugin-retry@6.0.1(@octokit/core@5.2.0)':
+    dependencies:
+      '@octokit/core': 5.2.0
+      '@octokit/request-error': 5.1.0
+      '@octokit/types': 12.4.0
+      bottleneck: 2.19.5
+
   '@octokit/request-error@5.1.0':
     dependencies:
       '@octokit/types': 13.1.0
@@ -24817,6 +24837,8 @@ snapshots:
   boolbase@1.0.0: {}
 
   boolean@3.2.0: {}
+
+  bottleneck@2.19.5: {}
 
   bowser@2.11.0: {}
 


### PR DESCRIPTION
### Background

Currently, the requests to Github API are not retried in case of failures. This PR adds retries.

Uses Octokit's defaults
```
retryAfterBaseValue: 1000,
doNotRetry: [400, 401, 403, 404, 422, 451],
retries: 3,
```

In case of 5XX errors, user is now informed about Github API struggling to resolve the request. We also point the user to visit  github's status page.