### PR TITLE
Recommend @graphql-hive/gateway-runtime for programmatic usage

### DIFF
--- a/packages/web/docs/src/pages/docs/gateway/deployment/index.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/index.mdx
@@ -29,7 +29,7 @@ this case, we will show here how to pass the request information from your envir
 then get the response for your environment back.
 
 ```ts
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 import type {
   ImaginaryEnvironmentRequest,
   ImaginaryEnvironmentServerContext

--- a/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/express.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/express.mdx
@@ -16,7 +16,7 @@ easily integrate Hive Gateway into your Express application with a few lines of 
 
 ```ts
 import express from 'express'
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 const app = express()
 
@@ -59,7 +59,7 @@ Gateway endpoint.
 ```ts
 import express from 'express'
 import helmet from 'helmet'
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 const app = express()
 

--- a/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/fastify.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/fastify.mdx
@@ -20,7 +20,7 @@ So you can benefit from the powerful plugins of Fastify ecosystem with Hive Gate
 
 ```ts
 import fastify, { FastifyReply, FastifyRequest } from 'fastify'
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 // This is the fastify instance you have created
 const app = fastify({ logger: true })

--- a/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/hapi.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/hapi.mdx
@@ -13,7 +13,7 @@ of code.
 ```ts
 import http from 'node:http'
 import { Readable } from 'node:stream'
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 import Hapi from '@hapi/hapi'
 import { schema } from './my-graphql-schema'
 

--- a/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/index.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/index.mdx
@@ -4,8 +4,8 @@ import { Callout } from '@theguild/components'
 
 We highly recommend to use Hive Gateway with the CLI in Node.js as described in
 [Node.js guide](/docs/gateway/deployment/runtimes/nodejs). But if you want to use Hive Gateway with
-a Node.js framework, you can use the `createGatewayRuntime` function from `@graphql-hive/gateway`
-package.
+a Node.js framework, you can use the `createGatewayRuntime` function from
+`@graphql-hive/gateway-runtime` package.
 
 In this case, you have to pass your serve configuration inside `createGatewayRuntime` instead of
 exporting it `gatewayConfig` from `gateway.config.ts` file.

--- a/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/koa.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/koa.mdx
@@ -19,7 +19,7 @@ code.
 
 ```ts
 import Koa from 'koa'
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 const app = new Koa()
 

--- a/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/nextjs.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/nextjs.mdx
@@ -17,7 +17,7 @@ Hive Gateway can be integrated with Next.js easily as
 ```ts
 // Next.js Custom Route Handler: https://nextjs.org/docs/app/building-your-application/routing/router-handlers
 
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 const { handleRequest } = createGatewayRuntime({
   /* Your configuration here before the following required settings */

--- a/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/sveltekit.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/sveltekit.mdx
@@ -27,7 +27,7 @@ create a new server route in `my-project/src/routes/graphql/+server.ts` to expos
 at `/graphql` and implement using the Hive Gateway runtime like this:
 
 ```ts filename="my-project/src/routes/graphql/+server.ts"
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 const serve = createGatewayRuntime({
   supergraph: 'supergraph.graphql', // working directory is root of the project

--- a/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/uwebsockets.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/node-frameworks/uwebsockets.mdx
@@ -24,7 +24,7 @@ with a simple configuration.
 
 ```ts filename="index.ts"
 import { App, HttpRequest, HttpResponse } from 'uWebSockets.js'
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 interface ServerContext {
   req: HttpRequest
@@ -52,7 +52,7 @@ npm i graphql-ws
 import { execute, ExecutionArgs, subscribe } from 'graphql'
 import { makeBehavior } from 'graphql-ws/lib/use/uWebSockets'
 import { App, HttpRequest, HttpResponse } from 'uWebSockets.js'
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 interface ServerContext {
   req: HttpRequest

--- a/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/bun.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/bun.mdx
@@ -16,7 +16,7 @@ other JS runtime with Hive Gateway;
 The following code is a simple example of how to use Hive Gateway with Bun.
 
 ```ts
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 const gatewayRuntime = createGatewayRuntime(/* Your configuration */)
 

--- a/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/deno.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/deno.mdx
@@ -33,7 +33,7 @@ Create a `deno-hive-gateway.ts` file:
 
 ```ts filename="deno-hive-gateway.ts"
 import { serve } from 'https://deno.land/std@0.157.0/http/server.ts'
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 const gatewayRuntime = createGatewayRuntime(/* Your configuration */)
 

--- a/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/index.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/index.mdx
@@ -5,7 +5,7 @@ import { Callout } from '@theguild/components'
 For Node.js and other Node-compliant environments, you can use Gateway CLI as described in the
 [Node.js guide](/docs/gateway/deployment/runtimes/nodejs). But if you want to use Hive Gateway with
 a server-side JavaScript environment that is not compatible with Node.js API, you can use the
-`createGatewayRuntime` function from `@graphql-hive/gateway` package.
+`createGatewayRuntime` function from `@graphql-hive/gateway-runtime` package.
 
 In this case, you have to pass your serve configuration inside `createGatewayRuntime` instead of
 exporting it `gatewayConfig` from `gateway.config.ts` file.

--- a/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/nodejs.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/nodejs.mdx
@@ -6,7 +6,7 @@ Node.js is the most common runtime for JavaScript.
 
 If you have Node.js environment, we highly recommend to use Hive Gateway with the CLI as described
 in the [introduction](/docs/gateway). If you really want to use the runtime in a customized way. You
-can use the `createGatewayRuntime` function from `@graphql-hive/gateway` package.
+can use the `createGatewayRuntime` function from `@graphql-hive/gateway-runtime` package.
 
 ## Hive Gateway CLI
 
@@ -19,7 +19,7 @@ most cases.
 
 ```ts
 import { createServer } from 'http'
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 const serveRuntime = createGatewayRuntime(/* Your configuration */)
 const server = createServer(serveRuntime)

--- a/packages/web/docs/src/pages/docs/gateway/deployment/serverless/aws-lambda.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/serverless/aws-lambda.mdx
@@ -14,7 +14,7 @@ See [Bundling Problems](/docs/gateway/deployment/serverless#bundling-problem) fo
 how to load the supergraph and `transports` option.
 
 ```js filename="gateway.ts"
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 import http from '@graphql-mesh/transport-http'
 import supergraph from './supergraph.js'
 

--- a/packages/web/docs/src/pages/docs/gateway/deployment/serverless/azure-functions.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/serverless/azure-functions.mdx
@@ -15,7 +15,7 @@ how to load the supergraph and `transports` option.
 
 ```ts
 import { app } from '@azure/functions'
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 import http from '@graphql-mesh/transport-http'
 import supergraph from './supergraph'
 

--- a/packages/web/docs/src/pages/docs/gateway/deployment/serverless/cloudflare-workers.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/serverless/cloudflare-workers.mdx
@@ -24,7 +24,7 @@ this makes sure that the Hive Gateway is gracefully and properly disposed before
 worker.
 
 ```ts filename="index.js"
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 import http from '@graphql-mesh/transport-http'
 import supergraph from './supergraph'
 

--- a/packages/web/docs/src/pages/docs/gateway/deployment/serverless/index.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/serverless/index.mdx
@@ -6,7 +6,7 @@ Hive Gateway can be deployed on the edge. This means that you can deploy your Hi
 serverless environment like AWS Lambda, Cloudflare Workers, or Azure Functions.
 
 For Serverless environments, you cannot use Gateway CLI `hive-gateway` but you can use the
-`createGatewayRuntime` function from `@graphql-hive/gateway` package.
+`createGatewayRuntime` function from `@graphql-hive/gateway-runtime` package.
 
 <Callout>
   Please read carefully following sections, most importantly [Bundling
@@ -24,7 +24,7 @@ See
 for more details.
 
 ```js filename="index.js"
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 
 const gateway = createGatewayRuntime({
   // Here any config available in `gateway.config.ts`.
@@ -64,7 +64,7 @@ transports needed to comunicate with your upstream services. This way, the trans
 statically referenced and will be included into the bundle.
 
 ```ts filename="index.ts"
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 import http from '@graphql-mesh/transport-http'
 import supergraph from './supergraph'
 
@@ -88,7 +88,7 @@ For this, we will need to have our supergraph SDL in a `.js` or a `.ts` file, so
 it in our script.
 
 ```ts
-import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 import http from '@graphql-mesh/transport-http'
 import supergraph from './supergraph.js'
 

--- a/packages/web/docs/src/pages/docs/gateway/other-features/performance/index.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/other-features/performance/index.mdx
@@ -86,18 +86,27 @@ Gateway. [Learn more about KV](https://developers.cloudflare.com/workers/runtime
   documentation](/docs/gateway/deployment/serverless/cloudflare-workers).
 </Callout>
 
-```ts filename="gateway.config.ts"
-import { defineConfig } from '@graphql-hive/gateway'
+```ts filename="index.ts"
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
+import CloudflareKVCacheStorage from '@graphql-mesh/cache-cfw-kv'
 
-export const gatewayConfig = defineConfig({
-  cache: {
-    type: 'cfw-kv',
-    namespace: 'HiveGateway' // The namespace of the KV
+export default {
+  fetch(request, env, ctx) {
+    const gateway = createGatewayRuntime({
+      supergraph,
+      transports: { http },
+      responseCaching: {
+        session: () => null
+      },
+      cache: new CloudflareKVCacheStorage({
+        logger,
+        namespace: env.HiveGateway
+      })
+    })
+    ctx.waitUntil(gateway[Symbol.asyncDispose]())
+    return gateway(request, env, ctx)
   }
-  responseCaching: {
-    session: () => null
-  }
-})
+}
 ```
 
 ## Custom Cache Storage

--- a/packages/web/docs/src/pages/docs/gateway/other-features/performance/index.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/other-features/performance/index.mdx
@@ -100,7 +100,7 @@ export default {
       },
       cache: new CloudflareKVCacheStorage({
         logger,
-        namespace: env.HiveGateway
+        namespace: env.NAMESPACE
       })
     })
     ctx.waitUntil(gateway[Symbol.asyncDispose]())


### PR DESCRIPTION
The index of Hive Gateway re-exports stuff that is Node-centric, like the [CLI stuff](https://github.com/graphql-hive/gateway/blob/ae84d49f71a72c331f66ff81cea092a791ddc019/packages/gateway/src/index.ts#L1) and various [CLI built-in plugins](https://github.com/graphql-hive/gateway/blob/ae84d49f71a72c331f66ff81cea092a791ddc019/packages/gateway/src/index.ts#L7-L15).

Because of that, the `createGatewayRuntime` from `@graphql-hive/gateway` is not tailored for the edge. You have to run your edge workers in Node compat mode.

However, using `createGatewayRuntime` from `@graphql-hive/gateway-runtime` works without any Node shims or compat modes. It should be the recommended way of running the Hive Gateway on the edge.

At the moment, all other alternatives of fixing the index exports are breaking changes. So the only thing we can do is simply advise users to use the runtime package instead.