### PR TITLE
Prevent indexing app.graphql-hive.com

### DIFF
--- a/packages/web/app/index.html
+++ b/packages/web/app/index.html
@@ -17,7 +17,8 @@
       href="/just-logo.svg"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GraphQL Hive</title>
+    <title>Hive Console</title>
+    <meta name="robots" content="noindex, nofollow" />
     <script src="/__env.js"></script>
   </head>
   <body>


### PR DESCRIPTION
It may be confusing for Google to see graphql-hive.com and the-guild.dev/graphql/hive, that's one reason. We also don't need that page to be indexed, it has 0 relevant content.