### PR TITLE
feat: swap primary s3 storage

### DIFF
--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -86,8 +86,10 @@ const s3 = deployS3();
 const s3Mirror = deployS3Mirror();
 
 const cdn = deployCFCDN({
-  s3,
-  s3Mirror,
+  // making AWS the primary and CF secondary source
+  s3: s3Mirror,
+  s3Mirror: s3,
+  // ----------------------------------------------
   sentry,
   environment,
 });


### PR DESCRIPTION
### Background

we get a [ton of timeout messages](https://the-guild-z4.sentry.io/issues/5969539635/?alert_rule_id=5155401&alert_type=issue&frontend_events=%7B%22event_name%22%3A%22Sign%20Up%22%2C%22event_label%22%3A%22okta%22%7D&notification_uuid=f1a98dde-273e-4742-a7f8-fb64f61d1d6a&project=5691450&referrer=slack) on the CDN worker.

![CleanShot 2024-11-25 at 12 47 49@2x](https://github.com/user-attachments/assets/9ad1a1f6-e0ac-47a1-bf54-dda37ba621b6)

### Description

Given all the reads from our R2 when it fails go to S3. With this change I am making the S3 deployed storage as a primary and R2 becomes fallback. I am hoping that with this change we can reduce these timeouts...