### PR TITLE
fix: allow organizations without slack or github integrations to manage integrations

### DIFF
--- a/.changeset/good-actors-pull.md
+++ b/.changeset/good-actors-pull.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Allow organizations without a GitHub or Slack integration to add and manage integrations.

--- a/packages/services/api/src/modules/integrations/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/integrations/resolvers/Organization.ts
@@ -35,10 +35,9 @@ export const Organization: Pick<
     });
   },
   viewerCanModifyGitHubIntegration: async (organization, _arg, { session, injector }) => {
-    const isAvailable = await injector.get(GitHubIntegrationManager).isAvailable({
-      organizationId: organization.id,
-    });
-    if (!isAvailable) {
+    const isEnabled = injector.get(GitHubIntegrationManager).isEnabled();
+
+    if (!isEnabled) {
       return false;
     }
 
@@ -50,14 +49,7 @@ export const Organization: Pick<
       },
     });
   },
-  viewerCanModifySlackIntegration: async (organization, _arg, { session, injector }) => {
-    const isAvailable = await injector.get(SlackIntegrationManager).isAvailable({
-      organizationId: organization.id,
-    });
-    if (!isAvailable) {
-      return false;
-    }
-
+  viewerCanModifySlackIntegration: async (organization, _arg, { session }) => {
     return session.canPerformAction({
       action: 'slackIntegration:modify',
       organizationId: organization.id,


### PR DESCRIPTION
### Background

 Some of our users contacted us saying they could not find the controls for managing Slack and GitHub integrations.

The resolvers for `Organization.viewerCanModifyGitHubIntegration` and `Organization.viewerCanModifySlackIntegration` were implemented faulty within https://github.com/graphql-hive/console/pull/5860. This resulted in users within organizations that did not previously have a GitHub/Slack integration being locked out from managing or adding one in the first place. This did slip our radar as the organizations we used on staging already had such integrations.

### Description

Adjusts the implementation of the `Organization.viewerCanModifyGitHubIntegration` and `Organization.viewerCanModifySlackIntegration` resolvers, so they do not resolve to `false` in case no integration exists for that organization yet.


### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
