### PR TITLE
Run certain migrations only in production

### DIFF
--- a/deployment/services/db-migrations.ts
+++ b/deployment/services/db-migrations.ts
@@ -40,6 +40,7 @@ export function deployDbMigrations({
         MIGRATOR: 'up',
         CLICKHOUSE_MIGRATOR: 'up',
         CLICKHOUSE_MIGRATOR_GRAPHQL_HIVE_CLOUD: '1',
+        GRAPHQL_HIVE_ENVIRONMENT: environment.envVars.ENVIRONMENT,
         TS_NODE_TRANSPILE_ONLY: 'true',
         RUN_S3_LEGACY_CDN_KEY_IMPORT: '1',
         // Change to this env var will lead to force rerun of the migration job

--- a/packages/migrations/src/clickhouse-actions/002-add-hash-to-clients_daily.ts
+++ b/packages/migrations/src/clickhouse-actions/002-add-hash-to-clients_daily.ts
@@ -13,7 +13,7 @@
  */
 import type { Action } from '../clickhouse';
 
-const action: Action = async (exec, _query, isGraphQLHiveCloud) => {
+const action: Action = async (exec, _query, hiveCloudEnvironment) => {
   // Create materialized views
   await Promise.all(
     [
@@ -72,7 +72,7 @@ const action: Action = async (exec, _query, isGraphQLHiveCloud) => {
   );
 
   // Run the rest of the migration only for self-hosted instances, not for Cloud.
-  if (isGraphQLHiveCloud) {
+  if (hiveCloudEnvironment === 'prod') {
     console.log('Detected GraphQL Hive Cloud. Skipping the rest of the migration.');
     // In case of Cloud, we need to perform it in a different, more complicated way.
     // We need to insert partition by partition, because otherwise it will take too much time and resources.

--- a/packages/migrations/src/clickhouse-actions/002-add-hash-to-clients_daily.ts
+++ b/packages/migrations/src/clickhouse-actions/002-add-hash-to-clients_daily.ts
@@ -153,10 +153,8 @@ const action: Action = async (exec, _query, hiveCloudEnvironment) => {
       expires_at
   `);
 
-  await Promise.all([
-    exec(`RENAME TABLE default.clients_daily TO default.clients_daily_old`),
-    exec(`RENAME TABLE default.clients_daily_new TO default.clients_daily`),
-  ]);
+  await exec(`RENAME TABLE default.clients_daily TO default.clients_daily_old`);
+  await exec(`RENAME TABLE default.clients_daily_new TO default.clients_daily`);
 
   await Promise.all([
     exec(`DROP VIEW default.clients_daily_old`),

--- a/packages/migrations/src/clickhouse-actions/002-add-hash-to-clients_daily.ts
+++ b/packages/migrations/src/clickhouse-actions/002-add-hash-to-clients_daily.ts
@@ -153,9 +153,10 @@ const action: Action = async (exec, _query, hiveCloudEnvironment) => {
       expires_at
   `);
 
-  await exec(`
-    RENAME TABLE default.clients_daily TO default.clients_daily_old, default.clients_daily_new TO default.clients_daily
-  `);
+  await Promise.all([
+    exec(`RENAME TABLE default.clients_daily TO default.clients_daily_old`),
+    exec(`RENAME TABLE default.clients_daily_new TO default.clients_daily`),
+  ]);
 
   await Promise.all([
     exec(`DROP VIEW default.clients_daily_old`),

--- a/packages/migrations/src/clickhouse-actions/003-add-client-name-to-operations-tables.ts
+++ b/packages/migrations/src/clickhouse-actions/003-add-client-name-to-operations-tables.ts
@@ -271,16 +271,15 @@ const action: Action = async (exec, _query, hiveCloudEnvironment) => {
       expires_at
   `);
 
-  await Promise.all([
-    exec(`
-      RENAME TABLE
-        default.operations_hourly TO default.operations_hourly_old
-    `),
-    exec(`
-      RENAME TABLE
-        default.operations_hourly_new TO default.operations_hourly
-    `),
-  ]);
+  await exec(`
+    RENAME TABLE
+      default.operations_hourly TO default.operations_hourly_old
+  `);
+
+  await exec(`
+    RENAME TABLE
+      default.operations_hourly_new TO default.operations_hourly
+  `);
 
   await Promise.all([
     exec(`DROP VIEW default.operations_daily_old`),

--- a/packages/migrations/src/clickhouse-actions/003-add-client-name-to-operations-tables.ts
+++ b/packages/migrations/src/clickhouse-actions/003-add-client-name-to-operations-tables.ts
@@ -226,16 +226,15 @@ const action: Action = async (exec, _query, hiveCloudEnvironment) => {
       expires_at
   `);
 
-  await Promise.all([
-    exec(`
+  await exec(`
     RENAME TABLE
       default.operations_daily TO default.operations_daily_old
-    `),
-    exec(`
-      RENAME TABLE
-        default.operations_daily_new TO default.operations_daily
-    `),
-  ]);
+    `);
+
+  await exec(`
+    RENAME TABLE
+      default.operations_daily_new TO default.operations_daily
+  `);
 
   await exec(`
     INSERT INTO

--- a/packages/migrations/src/clickhouse-actions/003-add-client-name-to-operations-tables.ts
+++ b/packages/migrations/src/clickhouse-actions/003-add-client-name-to-operations-tables.ts
@@ -1,6 +1,6 @@
 import type { Action } from '../clickhouse';
 
-const action: Action = async (exec, _query, isGraphQLHiveCloud) => {
+const action: Action = async (exec, _query, hiveCloudEnvironment) => {
   // Create materialized views
   await Promise.all(
     [
@@ -96,7 +96,7 @@ const action: Action = async (exec, _query, isGraphQLHiveCloud) => {
   );
 
   // Run the rest of the migration only for self-hosted instances, not for Cloud.
-  if (isGraphQLHiveCloud) {
+  if (hiveCloudEnvironment === 'prod') {
     console.log('Detected GraphQL Hive Cloud. Skipping the rest of the migration.');
     // You need to run these two queries and then execute all the statements they output
 

--- a/packages/migrations/src/clickhouse-actions/003-add-client-name-to-operations-tables.ts
+++ b/packages/migrations/src/clickhouse-actions/003-add-client-name-to-operations-tables.ts
@@ -226,11 +226,16 @@ const action: Action = async (exec, _query, hiveCloudEnvironment) => {
       expires_at
   `);
 
-  await exec(`
+  await Promise.all([
+    exec(`
     RENAME TABLE
-      default.operations_daily TO default.operations_daily_old,
-      default.operations_daily_new TO default.operations_daily
-  `);
+      default.operations_daily TO default.operations_daily_old
+    `),
+    exec(`
+      RENAME TABLE
+        default.operations_daily_new TO default.operations_daily
+    `),
+  ]);
 
   await exec(`
     INSERT INTO
@@ -266,11 +271,16 @@ const action: Action = async (exec, _query, hiveCloudEnvironment) => {
       expires_at
   `);
 
-  await exec(`
-    RENAME TABLE
-      default.operations_hourly TO default.operations_hourly_old,
-      default.operations_hourly_new TO default.operations_hourly
-  `);
+  await Promise.all([
+    exec(`
+      RENAME TABLE
+        default.operations_hourly TO default.operations_hourly_old
+    `),
+    exec(`
+      RENAME TABLE
+        default.operations_hourly_new TO default.operations_hourly
+    `),
+  ]);
 
   await Promise.all([
     exec(`DROP VIEW default.operations_daily_old`),

--- a/packages/migrations/src/clickhouse-actions/004-version-2.ts
+++ b/packages/migrations/src/clickhouse-actions/004-version-2.ts
@@ -162,7 +162,7 @@ const SystemSettingsModel = z.array(
   }),
 );
 
-export const action: Action = async (exec, query, isHiveCloud) => {
+export const action: Action = async (exec, query, hiveCloudEnvironment) => {
   const allowExperimentalAlterMaterializedViewStructure = await query(
     `
       SELECT value 
@@ -407,7 +407,7 @@ export const action: Action = async (exec, query, isHiveCloud) => {
 
   const isBig = sizeOfOperationsTable === 'big';
 
-  if (isHiveCloud || isBig) {
+  if (hiveCloudEnvironment === 'prod' || isBig) {
     console.log(
       `${
         isBig ? 'Detected more than 50M rows in operations table.' : 'Detected ClickHouse Cloud.'

--- a/packages/migrations/src/clickhouse-actions/006-monthly-operations-log.ts
+++ b/packages/migrations/src/clickhouse-actions/006-monthly-operations-log.ts
@@ -7,11 +7,11 @@ const MigrationRequirements = zod.object({
     .regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD format required'),
 });
 
-export const action: Action = async (exec, _query, isHiveCloud) => {
+export const action: Action = async (exec, _query, hiveCloudEnvironment) => {
   let insertAfterDate: string | null = null;
   let where = 'notEmpty(organization)';
 
-  if (isHiveCloud) {
+  if (hiveCloudEnvironment === 'prod') {
     // eslint-disable-next-line no-process-env
     const { CLICKHOUSE_MIGRATION_006_DATE } = MigrationRequirements.parse(process.env);
 
@@ -25,7 +25,7 @@ export const action: Action = async (exec, _query, isHiveCloud) => {
     insertAfterDate = CLICKHOUSE_MIGRATION_006_DATE;
   }
 
-  if (isHiveCloud) {
+  if (hiveCloudEnvironment === 'prod') {
     // Hive Cloud needs to perform a migration and insert data from previous months.
     // This is not needed for Hive On-Premise, as the data is only relevant for rate-limiting and billing.
     //

--- a/packages/migrations/src/clickhouse-actions/007-james-bond-aggregates-hourly-and-minutely.ts
+++ b/packages/migrations/src/clickhouse-actions/007-james-bond-aggregates-hourly-and-minutely.ts
@@ -1,9 +1,9 @@
 import type { Action } from '../clickhouse';
 
-export const action: Action = async (exec, _query, isHiveCloud) => {
+export const action: Action = async (exec, _query, hiveCloudEnvironment) => {
   let where = '';
 
-  if (isHiveCloud) {
+  if (hiveCloudEnvironment === 'prod') {
     // Starts aggregating data the next day of the migration (deployment)
     const tomorrow = new Date();
     tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);

--- a/packages/migrations/src/clickhouse-actions/008-daily-operations-log.ts
+++ b/packages/migrations/src/clickhouse-actions/008-daily-operations-log.ts
@@ -1,9 +1,9 @@
 import type { Action } from '../clickhouse';
 
-export const action: Action = async (exec, _query, isHiveCloud) => {
+export const action: Action = async (exec, _query, hiveCloudEnvironment) => {
   let where = 'WHERE notEmpty(organization)';
 
-  if (isHiveCloud) {
+  if (hiveCloudEnvironment === 'prod') {
     // Starts aggregating data the next day of the migration (deployment)
     const tomorrow = new Date();
     tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);

--- a/packages/migrations/src/clickhouse-actions/009-ttl-1-year.ts
+++ b/packages/migrations/src/clickhouse-actions/009-ttl-1-year.ts
@@ -9,8 +9,8 @@ const SystemTablesModel = z.array(
 );
 
 // This migration sets TTL for all tables to at least (read comments) 1 year.
-export const action: Action = async (exec, query, isHiveCloud) => {
-  if (!isHiveCloud) {
+export const action: Action = async (exec, query, hiveCloudEnvironment) => {
+  if (hiveCloudEnvironment === 'prod') {
     console.log('Skipping ClickHouse migration');
     // This migration is only for Hive Cloud, self-hosted Hive depends on the user's configuration of data retention.
     return;

--- a/packages/migrations/src/clickhouse.ts
+++ b/packages/migrations/src/clickhouse.ts
@@ -21,12 +21,13 @@ interface QueryResponse<T> {
 export type Action = (
   exec: (query: string, settings?: Record<string, string>) => Promise<void>,
   query: (queryString: string) => Promise<QueryResponse<unknown>>,
-  isGraphQLHiveCloud: boolean,
+  hiveCloudEnvironment: 'prod' | 'staging' | 'dev' | null,
 ) => Promise<void>;
 
 export async function migrateClickHouse(
   isClickHouseMigrator: boolean,
   isHiveCloud: boolean,
+  hiveCloudEnvironment: 'prod' | 'staging' | 'dev' | null,
   clickhouse: {
     protocol: string;
     host: string;
@@ -47,6 +48,7 @@ export async function migrateClickHouse(
   console.log('Username:          ', clickhouse.username);
   console.log('Password:          ', clickhouse.password.length);
   console.log('isGraphQLHiveCloud:', isHiveCloud);
+  console.log('Hive Environment  :', hiveCloudEnvironment);
 
   // Warm up ClickHouse instance.
   // This is needed because ClickHouse takes a while to start up
@@ -183,7 +185,7 @@ export async function migrateClickHouse(
           await exec(query, settings);
         },
         query,
-        isHiveCloud,
+        hiveCloudEnvironment,
       );
     } catch (error) {
       console.error(error);

--- a/packages/migrations/src/environment.ts
+++ b/packages/migrations/src/environment.ts
@@ -34,6 +34,7 @@ const EnvironmentModel = zod.object({
   CLICKHOUSE_MIGRATOR_GRAPHQL_HIVE_CLOUD: zod
     .union([zod.literal('1'), zod.literal('0')])
     .optional(),
+  GRAPHQL_HIVE_ENVIRONMENT: emptyString(zod.enum(['prod', 'staging', 'dev']).optional()),
 });
 
 const PostgresModel = zod.object({
@@ -114,4 +115,5 @@ export const env = {
   isMigrator: base.MIGRATOR === 'up',
   isClickHouseMigrator: base.CLICKHOUSE_MIGRATOR === 'up',
   isHiveCloud: base.CLICKHOUSE_MIGRATOR_GRAPHQL_HIVE_CLOUD === '1',
+  hiveCloudEnvironment: base.GRAPHQL_HIVE_ENVIRONMENT ?? null,
 } as const;

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -31,7 +31,12 @@ try {
   console.log('Running the UP migrations');
   await runPGMigrations({ slonik });
   if (env.clickhouse) {
-    await migrateClickHouse(env.isClickHouseMigrator, env.isHiveCloud, env.clickhouse);
+    await migrateClickHouse(
+      env.isClickHouseMigrator,
+      env.isHiveCloud,
+      env.hiveCloudEnvironment,
+      env.clickhouse,
+    );
   }
   process.exit(0);
 } catch (error) {


### PR DESCRIPTION
Treat `dev` and `staging` ClickHose instances as we treat `self-hosted` Hive and perform the same migrations. This allows to nuke them and start from scratch.