### PR TITLE
For Bun integration, Recommend Hive GW CLI

### DIFF
--- a/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/bun.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/bun.mdx
@@ -17,7 +17,7 @@ other JS runtime with Hive Gateway;
 
 You can follow the introduction page directly to use Hive Gateway CLI. [See here](/docs/gateway)
 
-Since Bun has the compatibility layer for Node.js, even Node specific features are available in Bun.
+Since Bun has the compatibility layer for Node.js, all Node specific features are available in Bun.
 
 ## Hive Gateway Runtime (advanced-only)
 

--- a/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/bun.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/bun.mdx
@@ -13,7 +13,16 @@ platform besides Node.js. [Bun](https://bun.sh) is a modern JavaScript runtime l
 and it supports Fetch API as a first class citizen. So the configuration is really simple like any
 other JS runtime with Hive Gateway;
 
-The following code is a simple example of how to use Hive Gateway with Bun.
+## Hive Gateway CLI
+
+You can follow the introduction page directly to use Hive Gateway CLI. [See here](/docs/gateway)
+
+Since Bun has the compatibility layer for Node.js, even Node specific features are available in Bun.
+
+## Hive Gateway Runtime (advanced-only)
+
+Use this method only if you know what you are doing. It is recommended to use Hive Gateway CLI for
+most cases.
 
 ```ts
 import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'

--- a/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/bun.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/bun.mdx
@@ -15,7 +15,7 @@ other JS runtime with Hive Gateway;
 
 ## Hive Gateway CLI
 
-You can follow the introduction page directly to use Hive Gateway CLI. [See here](/docs/gateway)
+You can follow the introduction page directly to [use Hive Gateway CLI](/docs/gateway#installation).
 
 Since Bun has the compatibility layer for Node.js, all Node specific features are available in Bun.
 

--- a/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/bun.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/runtimes/bun.mdx
@@ -19,7 +19,7 @@ You can follow the introduction page directly to [use Hive Gateway CLI](/docs/ga
 
 Since Bun has the compatibility layer for Node.js, all Node specific features are available in Bun.
 
-## Hive Gateway Runtime (advanced-only)
+## Hive Gateway Runtime
 
 Use this method only if you know what you are doing. It is recommended to use Hive Gateway CLI for
 most cases.

--- a/packages/web/docs/src/pages/docs/gateway/index.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/index.mdx
@@ -83,6 +83,11 @@ environment. Then, you can install Hive Gateway CLI with your preferred package 
 npm i @graphql-hive/gateway
 ```
 
+<Callout>
+  You can also use [Bun](https://bun.sh) as a runtime to run the JavaScript package with the same
+  installation steps.
+</Callout>
+
 </Tabs.Tab>
 
 </Tabs>


### PR DESCRIPTION
Hive GW CLI is fully compatible with Bun just like Node.js.
So this PR does
- Mention Bun as a compatible runtime for CLI
- Recommend to use CLI on Bun instead of programmatic API

Note: This doesn't recommend using Bun over Node. It recommends CLI over programmatic API for Bun. Because previously for Bun runtime, only programmatic API was recommended. Now we mention that CLI is compatible with Bun so if you want to use Bun, you can use CLI directly.