### PR TITLE
fix: add missing return statement for early return block

### DIFF
--- a/packages/services/schema/src/lib/federation-tag-extraction.ts
+++ b/packages/services/schema/src/lib/federation-tag-extraction.ts
@@ -502,7 +502,7 @@ export function applyTagFilterOnSubgraphs<
   });
 
   if (!intersectionOfTypesWhereAllFieldsAreInaccessible.size) {
-    filteredSubgraphs;
+    return filteredSubgraphs;
   }
 
   return filteredSubgraphs.map(subgraph => ({


### PR DESCRIPTION
### Background

Spotted by @hasparus [here](https://guild-oss.slack.com/archives/C07DYCW4NUD/p1733242685490739).

### Description

This block should return early to avoid unnecessary traversals and loops when not needed. Because not returning early here is just a slight performance improvement, this caused no issues before.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
