### PR TITLE
Point people from /federation to Hive and Crisp

### DIFF
--- a/packages/web/docs/src/components/federation-page.tsx
+++ b/packages/web/docs/src/components/federation-page.tsx
@@ -4,7 +4,7 @@ import { Anchor, CallToAction, Heading } from '@theguild/components';
 import { cn } from '../lib';
 import { ArrowIcon } from './arrow-icon';
 import { FrequentlyAskedFederationQuestions } from './frequently-asked-questions';
-import { Hero } from './hero';
+import { Hero, HeroLinks } from './hero';
 import { InfoCard } from './info-card';
 import { Page } from './page';
 import federationDiagram from '../../public/federation-diagram.png';
@@ -30,6 +30,24 @@ export function FederationPage(): ReactElement {
           into one unified API (supergraph), and serve data from a single endpoint using a GraphQL
           gateway.
         </p>
+        <HeroLinks>
+          <CallToAction
+            variant="primary-inverted"
+            href="/"
+            title="Learn about our Open-Source GraphQL Federation Solution - Hive"
+          >
+            Try Hive for Federation
+          </CallToAction>
+          <CallToAction
+            variant="secondary"
+            title="Contact our experts to learn more about GraphQL Federation"
+            onClick={() => {
+              (window as any).$crisp?.push(['do', 'chat:open']);
+            }}
+          >
+            Contact an Expert
+          </CallToAction>
+        </HeroLinks>
       </Hero>
       <Intro />
       <WhyFederation />


### PR DESCRIPTION
The path to Hive is missing (it's there, but near the footer), I also thought about adding a secondary CTA button where people could ask us questions.