### PR TITLE
limit memory on usage service

### DIFF
--- a/deployment/services/usage.ts
+++ b/deployment/services/usage.ts
@@ -62,6 +62,7 @@ export function deployUsage({
       exposesMetrics: true,
       port: 4000,
       pdb: true,
+      memoryLimit: '1Gi',
       autoScaling: {
         cpu: {
           cpuAverageToScale: 60,


### PR DESCRIPTION
Right now the way it is working in production one pod keeps growing memory forever. This way we restrict pod budget so we don't grow infinitely. I am hoping that it will instead scale pods out when we hit limits.

![CleanShot 2024-12-05 at 12 35 52@2x](https://github.com/user-attachments/assets/fa1ce946-0919-4442-ade2-982b7298bb91)
