### PR TITLE
chore: wake up clickhouse before publishing app deployment

### DIFF
--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -280,6 +280,13 @@ if (hiveAppPersistedDocumentsAbsolutePath) {
       commit: imagesTag,
     },
     persistedDocumentsPath: hiveAppPersistedDocumentsAbsolutePath,
+    wakeupClickhouse:
+      environment.envName !== 'production'
+        ? {
+            clickhouse: clickhouse.secret,
+            dockerSecret: docker.secret,
+          }
+        : null,
     // We need to wait until the new GraphQL schema is published before we can publish the app deployment.
     dependsOn: [publishGraphQLSchemaCommand],
   });

--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -280,13 +280,12 @@ if (hiveAppPersistedDocumentsAbsolutePath) {
       commit: imagesTag,
     },
     persistedDocumentsPath: hiveAppPersistedDocumentsAbsolutePath,
-    wakeupClickhouse:
-      environment.envName !== 'production'
-        ? {
-            clickhouse: clickhouse.secret,
-            dockerSecret: docker.secret,
-          }
-        : null,
+    wakeupClickhouse: environment.isProduction
+      ? null
+      : {
+          clickhouse: clickhouse.secret,
+          dockerSecret: docker.secret,
+        },
     // We need to wait until the new GraphQL schema is published before we can publish the app deployment.
     dependsOn: [publishGraphQLSchemaCommand],
   });

--- a/deployment/utils/pod-builder.ts
+++ b/deployment/utils/pod-builder.ts
@@ -3,12 +3,18 @@ import * as kx from '@pulumi/kubernetesx';
 import * as pulumi from '@pulumi/pulumi';
 
 export function normalizeEnv(env: kx.types.Container['env']): any[] {
-  return Array.isArray(env)
-    ? env
-    : Object.keys(env as kx.types.EnvMap).map(name => ({
-        name,
-        value: (env as kx.types.EnvMap)[name],
-      }));
+  if (env == null) {
+    return [];
+  }
+
+  if (Array.isArray(env)) {
+    return env;
+  }
+
+  return Object.keys(env).map(name => ({
+    name,
+    value: (env as kx.types.EnvMap)[name],
+  }));
 }
 
 export class PodBuilder extends kx.PodBuilder {

--- a/deployment/utils/publish-app-deployment.ts
+++ b/deployment/utils/publish-app-deployment.ts
@@ -31,8 +31,8 @@ export function publishAppDeployment(args: {
             'curl',
             // wait a maximum amount of 40 seconds (according to docs it takes 30 seconds for waking up)
             '--max-time',
-            '40',
-            '$CLICKHOUSE_PROTOCOL://$CLICKHOUSE_USERNAME:$CLICKHOUSE_PASSWORD@$CLICKHOUSE_HOST:$CLICKHOUSE_PORT?query=SELECT%201',
+            '60',
+            '$(CLICKHOUSE_PROTOCOL)://$(CLICKHOUSE_USERNAME):$(CLICKHOUSE_PASSWORD)@$(CLICKHOUSE_HOST):$(CLICKHOUSE_PORT)?query=SELECT%201',
           ],
         },
         args.dependsOn,

--- a/deployment/utils/publish-app-deployment.ts
+++ b/deployment/utils/publish-app-deployment.ts
@@ -58,7 +58,7 @@ export function publishAppDeployment(args: {
         ` --name ${args.appName} --version ${args.version.commit} ./persisted-documents.json`,
     },
     {
-      dependsOn: wakeupCommandJob ?? args.dependsOn,
+      dependsOn: [wakeupCommandJob, ...(args.dependsOn || [])].filter(v => v !== null),
     },
   );
 

--- a/deployment/utils/publish-app-deployment.ts
+++ b/deployment/utils/publish-app-deployment.ts
@@ -1,8 +1,10 @@
 import { local } from '@pulumi/command';
-import { ResourceOptions } from '@pulumi/pulumi';
+import { Secret } from '@pulumi/kubernetes/core/v1';
+import { Resource } from '@pulumi/pulumi';
+import { ClickhouseConnectionSecret } from '../services/clickhouse';
+import { ServiceDeployment } from './service-deployment';
 
-const dockerImage =
-  'ghcr.io/kamilkisiela/graphql-hive/cli:0.40.0-alpha-20240725065155-e240576ec49b275715015567ce1f9c4a77a51f89';
+const dockerImage = 'ghcr.io/graphql-hive/cli:0.44.4';
 
 /** Publish API GraphQL schema to Hive schema registry. */
 export function publishAppDeployment(args: {
@@ -12,8 +14,37 @@ export function publishAppDeployment(args: {
     commit: string;
   };
   persistedDocumentsPath: string;
-  dependsOn?: ResourceOptions['dependsOn'];
+  wakeupClickhouse: {
+    clickhouse: ClickhouseConnectionSecret;
+    dockerSecret: Secret;
+  } | null;
+  dependsOn?: Array<Resource>;
 }) {
+  // Step 0: Wake up ClickHouse on staging and dev
+  let wakeupCommandJob = args.wakeupClickhouse
+    ? new ServiceDeployment(
+        'wake-up-clickhouse',
+        {
+          image: 'alpine/curl',
+          imagePullSecret: args.wakeupClickhouse.dockerSecret,
+          command: [
+            'curl',
+            // wait a maximum amount of 40 seconds (according to docs it takes 30 seconds for waking up)
+            '--max-time',
+            '40',
+            '$CLICKHOUSE_PROTOCOL://$CLICKHOUSE_USERNAME:$CLICKHOUSE_PASSWORD@$CLICKHOUSE_HOST:$CLICKHOUSE_PORT?query=SELECT%201',
+          ],
+        },
+        args.dependsOn,
+      )
+        .withSecret('CLICKHOUSE_PROTOCOL', args.wakeupClickhouse.clickhouse, 'protocol')
+        .withSecret('CLICKHOUSE_HOST', args.wakeupClickhouse.clickhouse, 'host')
+        .withSecret('CLICKHOUSE_PORT', args.wakeupClickhouse.clickhouse, 'port')
+        .withSecret('CLICKHOUSE_USERNAME', args.wakeupClickhouse.clickhouse, 'username')
+        .withSecret('CLICKHOUSE_PASSWORD', args.wakeupClickhouse.clickhouse, 'password')
+        .deployAsJob().job
+    : null;
+
   // Step 1: Create app deployment
   const createCommand = new local.Command(
     `create-app-deployment-${args.appName}`,
@@ -27,7 +58,7 @@ export function publishAppDeployment(args: {
         ` --name ${args.appName} --version ${args.version.commit} ./persisted-documents.json`,
     },
     {
-      dependsOn: args.dependsOn,
+      dependsOn: wakeupCommandJob ?? args.dependsOn,
     },
   );
 

--- a/deployment/utils/publish-graphql-schema.ts
+++ b/deployment/utils/publish-graphql-schema.ts
@@ -1,6 +1,8 @@
 import { local } from '@pulumi/command';
 import type { GraphQL } from '../services/graphql';
 
+const dockerImage = 'ghcr.io/graphql-hive/cli:0.44.4';
+
 /** Publish API GraphQL schema to Hive schema registry. */
 export function publishGraphQLSchema(args: {
   graphql: GraphQL;
@@ -19,7 +21,7 @@ export function publishGraphQLSchema(args: {
     'publish-graphql-schema',
     {
       create:
-        `docker run --name "publish-graphql-schema" -v ${args.schemaPath}:/usr/src/app/schema.graphqls ghcr.io/kamilkisiela/graphql-hive/cli:0.36.0 ` +
+        `docker run --name "publish-graphql-schema" -v ${args.schemaPath}:/usr/src/app/schema.graphqls ${dockerImage} ` +
         command,
     },
     {


### PR DESCRIPTION
Closes https://github.com/graphql-hive/deployment/issues/1425 

### Background

Deployments on staging and dev often fail because the app deployment publishes times out due to click house being in rest mode.

### Description

This change will send a dummy query (`SELECT 1`) to the clickhouse instance on dev and staging to make sure it responds in time for the app deployment publish.

