### PR TITLE
Showcase `@defer` and `@stream` in docs/gateway/defer-stream

### DIFF
--- a/packages/web/docs/src/pages/docs/gateway/defer-stream.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/defer-stream.mdx
@@ -38,4 +38,28 @@ export const gatewayConfig = defineConfig({
 })
 ```
 
-[See more](https://the-guild.dev/graphql/yoga-server/docs/features/defer-stream#using-defer)
+## Using Defer
+
+The `@defer` directive allows you to post-pone the delivery of one or more (slow) fields grouped in
+an inlined or spread fragment.
+
+```graphql filename="GraphQL Operation using @defer" {2}
+query SlowAndFastFieldWithDefer {
+  ... on Query @defer {
+    slowField
+  }
+  fastField
+}
+```
+
+## Using Stream
+
+The `@stream` directive allows you to stream the individual items of a field of the list type as the
+items are available.
+
+```graphql filename="GraphQL Operation using @stream" {2}
+query StreamAlphabet {
+  alphabet @stream
+}
+```
+

--- a/packages/web/docs/src/pages/docs/gateway/defer-stream.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/defer-stream.mdx
@@ -62,4 +62,3 @@ query StreamAlphabet {
   alphabet @stream
 }
 ```
-


### PR DESCRIPTION
We have `See more` link at the end that points to Yoga, where we tell people how to configure Yoga and run queries via cURL or GraphiQL.  It's a bit weird given the gateway talks to subgraphs, so those instructions makes no sense.

I copied part of Yoga docs to show example queries and expected behavior.