### PR TITLE
Align `GitHub Integration` buttons UI

### DIFF
--- a/packages/web/app/src/pages/organization-settings.tsx
+++ b/packages/web/app/src/pages/organization-settings.tsx
@@ -76,7 +76,7 @@ function GitHubIntegrationSection(props: {
   );
 
   return organization.hasGitHubIntegration ? (
-    <>
+    <div className="flex flex-row justify-start gap-3">
       <Button
         variant="destructive"
         disabled={deleteGitHubMutation.fetching}
@@ -94,7 +94,7 @@ function GitHubIntegrationSection(props: {
       <Button variant="destructive" asChild>
         <a href={`/api/github/connect/${organization.slug}`}>Adjust permissions</a>
       </Button>
-    </>
+    </div>
   ) : (
     <Button variant="default" asChild>
       <a href={`/api/github/connect/${organization.slug}`}>


### PR DESCRIPTION
### Background
Notice that buttons are not aligned on production. See images.

Before (Prod)
<img width="490" alt="Screenshot 2024-12-10 at 12 41 46" src="https://github.com/user-attachments/assets/8b80028a-bfd1-4786-8779-9fb90a744469">

After
<img width="500" alt="Screenshot 2024-12-10 at 12 41 38" src="https://github.com/user-attachments/assets/19d899a5-c23b-49cc-8e70-14cb8ed3836f">

