### PR TITLE
Added `latest` tag to CLI release flow when published from main

### DIFF
--- a/.github/workflows/dockerize-cli.yaml
+++ b/.github/workflows/dockerize-cli.yaml
@@ -10,6 +10,9 @@ on:
       cliVersion:
         required: true
         type: string
+      publishLatest:
+        default: false
+        type: boolean
 
 jobs:
   build-cli-docker-image:
@@ -64,6 +67,7 @@ jobs:
           RELEASE: ${{ inputs.cliVersion }}
           BUILD_TYPE: 'publish'
           PWD: ${{ github.workspace }}
+          BUILD_STABLE: ${{ inputs.publishLatest && '1' || '' }}
         with:
           # See https://github.com/docker/buildx/issues/1533
           provenance: false

--- a/.github/workflows/release-alpha.yaml
+++ b/.github/workflows/release-alpha.yaml
@@ -134,4 +134,5 @@ jobs:
     if: ${{ needs.extract-cli-version.outputs.published == 'true' }}
     with:
       cliVersion: ${{ needs.extract-cli-version.outputs.version }}
+      publishLatest: false
     secrets: inherit

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -108,4 +108,5 @@ jobs:
     if: ${{ needs.publish.outputs.publish == 'true' }}
     with:
       cliVersion: ${{ needs.publish.outputs.version }}
+      publishLatest: true
     secrets: inherit


### PR DESCRIPTION
This change propagates `publishLatest` to the dockerize action of the CLI. When executed from `main`, it will pass `true`, and then `BUILD_STABLE` will be set to `1`. The Docker HCL file will then tag the image as `latest` in addition to the versioned number.

Closes https://github.com/graphql-hive/console/issues/6102