### PR TITLE
Use redpandadata/redpanda in integration tests

### DIFF
--- a/integration-tests/docker-compose.integration.yaml
+++ b/integration-tests/docker-compose.integration.yaml
@@ -193,7 +193,7 @@ services:
       GRAPHQL_PUBLIC_ORIGIN: http://localhost:8082
 
   broker:
-    image: vectorized/redpanda:latest
+    image: redpandadata/redpanda:latest
     hostname: broker
     networks:
       - 'stack'


### PR DESCRIPTION
`vectorized/redpanda` was deprecated and now it's gone