### PR TITLE
Use structured logging and log validation errors in usage service

### DIFF
--- a/.changeset/nice-birds-mate.md
+++ b/.changeset/nice-birds-mate.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Move information about target and organization to logger's metadata in usage service

--- a/packages/services/usage/src/index.ts
+++ b/packages/services/usage/src/index.ts
@@ -150,6 +150,12 @@ async function main() {
           return;
         }
 
+        const authenticatedRequestLogger = req.log.child({
+          token: maskedToken,
+          target: tokenInfo.target,
+          organization: tokenInfo.organization,
+        });
+
         stopTokensDurationTimer({
           status: 'success',
         });
@@ -163,8 +169,8 @@ async function main() {
               entityType: 'target',
             })
             .catch(error => {
-              req.log.error('Failed to check rate limit (target=%s)', tokenInfo.target);
-              req.log.error(error);
+              authenticatedRequestLogger.error('Failed to check rate limit');
+              authenticatedRequestLogger.error(error);
               Sentry.captureException(error, {
                 level: 'error',
               });
@@ -176,8 +182,8 @@ async function main() {
           droppedReports
             .labels({ targetId: tokenInfo.target, orgId: tokenInfo.organization })
             .inc();
-          req.log.info(
-            'Rate limited (token=%s, target=%s, organization=%s)',
+          authenticatedRequestLogger.info(
+            'Rate limited',
             maskedToken,
             tokenInfo.target,
             tokenInfo.organization,
@@ -189,7 +195,7 @@ async function main() {
 
         const retentionInfo =
           (await rateLimit?.getRetentionForTargetId?.(tokenInfo.target).catch(error => {
-            req.log.error(error);
+            authenticatedRequestLogger.error(error);
             Sentry.captureException(error, {
               level: 'error',
             });
@@ -197,18 +203,13 @@ async function main() {
           })) || null;
 
         if (typeof retentionInfo !== 'number') {
-          req.log.error(
-            'Failed to get retention info (token=%s, target=%s, organization=%s)',
-            maskedToken,
-            tokenInfo.target,
-            tokenInfo.organization,
-          );
+          authenticatedRequestLogger.error('Failed to get retention info');
         }
 
         const stopTimer = collectDuration.startTimer();
         try {
           if (readiness() === false) {
-            req.log.warn('Not ready to collect report (token=%s)', maskedToken);
+            authenticatedRequestLogger.warn('Not ready to collect report');
             stopTimer({
               status: 'not_ready',
             });
@@ -236,6 +237,11 @@ async function main() {
               stopTimer({
                 status: 'error',
               });
+              authenticatedRequestLogger.info(
+                'Report validation failed (errors=%j)',
+                result.errors.map(error => error.path + ': ' + error.message),
+              );
+
               void res.status(400).send({
                 errors: result.errors,
               });
@@ -251,6 +257,7 @@ async function main() {
               operations: result.operations,
             });
           } else {
+            authenticatedRequestLogger.debug("Invalid 'x-api-version' header value.");
             stopTimer({
               status: 'error',
             });
@@ -260,13 +267,8 @@ async function main() {
           stopTimer({
             status: 'error',
           });
-          req.log.error(
-            'Failed to collect report (token=%s, target=%s, organization=%s)',
-            maskedToken,
-            tokenInfo.target,
-            tokenInfo.organization,
-          );
-          req.log.error(error, 'Failed to collect');
+          authenticatedRequestLogger.error('Failed to collect report');
+          authenticatedRequestLogger.error(error, 'Failed to collect');
           Sentry.captureException(error, {
             level: 'error',
           });


### PR DESCRIPTION
Instead of passing `(target=%s)` over and over again, we now have a context aware logger instance.
This PR adds also a log message with errors when a report decoding is not successful.