### PR TITLE
Remove 'Bearer ' prefix from authorization token in Sentry plugin

### DIFF
--- a/packages/services/service-common/src/sentry.ts
+++ b/packages/services/service-common/src/sentry.ts
@@ -10,7 +10,7 @@ const plugin: FastifyPluginAsync = async server => {
     Sentry.withScope(scope => {
       scope.setUser({ ip_address: req.ip });
       const requestId = cleanRequestId(req.headers['x-request-id']);
-      const tokenHeader = req.headers['x-api-token'] || req.headers.authorization;
+      const tokenHeader = req.headers['x-api-token'] || req.headers.authorization?.replace('Bearer ', '');
       const maskedToken = typeof tokenHeader === 'string' ? maskToken(tokenHeader) : null;
       if (requestId) {
         scope.setTag('request_id', requestId);


### PR DESCRIPTION
In case of `Authorization: Bearer 1234567890`, the masked token would be: `Bea***********890`
