### PR TITLE
Add /partners to landing pages list

### DIFF
--- a/packages/web/docs/src/components/navigation-menu/index.tsx
+++ b/packages/web/docs/src/components/navigation-menu/index.tsx
@@ -16,5 +16,12 @@ export function NavigationMenu(props: ComponentPropsWithoutRef<typeof Navbar>) {
   );
 }
 
-const landingLikePages = ['/', '/pricing', '/federation', '/oss-friends', '/ecosystem'];
+const landingLikePages = [
+  '/',
+  '/pricing',
+  '/federation',
+  '/oss-friends',
+  '/ecosystem',
+  '/partners',
+];
 export const isLandingPage = (route: string) => landingLikePages.includes(route);


### PR DESCRIPTION
### Description

We forgot to add `/partners`.
Root cause will be fixed when we migrate to route groups, and we'll just put the page next to the others in a directory.