### PR TITLE
Remove container_name from docker compose files

### DIFF
--- a/docker/docker-compose.community.yml
+++ b/docker/docker-compose.community.yml
@@ -41,7 +41,6 @@ services:
 
   broker:
     image: redpandadata/redpanda:v23.3.21
-    container_name: broker
     hostname: broker
     networks:
       - 'stack'

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -96,7 +96,6 @@ services:
     image: redpandadata/redpanda:v23.3.21
     mem_limit: 300m
     mem_reservation: 100m
-    container_name: broker
     hostname: broker
     networks:
       - 'stack'
@@ -145,7 +144,6 @@ services:
 
   oidc-server-mock:
     image: ghcr.io/soluto/oidc-server-mock:0.8.6
-    container_name: oidc-server-mock
     mem_limit: 150m
     ports:
       - '7043:80'

--- a/docker/docker-compose.end2end.yml
+++ b/docker/docker-compose.end2end.yml
@@ -2,7 +2,6 @@ version: '3.8'
 name: 'hive-e2e'
 services:
   oidc-server-mock:
-    container_name: oidc-server-mock
     image: ghcr.io/soluto/oidc-server-mock:0.8.6
     ports:
       - '7043:80'


### PR DESCRIPTION
This should help with "container name is already used" error when doing integration testing or local development