### PR TITLE
fix: prevent stripe.js from loading automatically

### DIFF
--- a/.changeset/modern-trees-begin.md
+++ b/.changeset/modern-trees-begin.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Prevent stripe.js from loading automatically

--- a/packages/web/app/src/lib/billing/stripe.tsx
+++ b/packages/web/app/src/lib/billing/stripe.tsx
@@ -1,19 +1,27 @@
 import { FC, ReactNode, Suspense, useState } from 'react';
 import { env } from '@/env/frontend';
 import { Elements as ElementsProvider } from '@stripe/react-stripe-js';
-import { loadStripe } from '@stripe/stripe-js';
+// Why not @stripe/stripe-js?
+// `loadStrip` from the main entry loads Stripe.js before the function is called.
+// Yes, you are as confused as I am.
+// The `loadStrip` from `/pure` fixes this issue.
+import { loadStripe } from '@stripe/stripe-js/pure';
 import { getStripePublicKey } from './stripe-public-key';
 
 export const HiveStripeWrapper: FC<{ children: ReactNode }> = ({ children }) => {
+  if (env.nodeEnv !== 'production') {
+    return;
+  }
+
+  const stripePublicKey = getStripePublicKey();
+
+  if (!stripePublicKey) {
+    return null;
+  }
+
   // eslint-disable-next-line react/hook-use-state -- we don't need setter
   const [stripe] = useState<ReturnType<typeof loadStripe> | void>(() => {
-    if (env.nodeEnv !== 'production') {
-      return;
-    }
-    const stripePublicKey = getStripePublicKey();
-    if (stripePublicKey) {
-      return loadStripe(stripePublicKey);
-    }
+    return loadStripe(stripePublicKey);
   });
 
   if (!stripe) {

--- a/packages/web/app/src/lib/billing/stripe.tsx
+++ b/packages/web/app/src/lib/billing/stripe.tsx
@@ -9,23 +9,23 @@ import { loadStripe } from '@stripe/stripe-js/pure';
 import { getStripePublicKey } from './stripe-public-key';
 
 export const HiveStripeWrapper: FC<{ children: ReactNode }> = ({ children }) => {
-  if (env.nodeEnv !== 'production') {
-    return;
-  }
-
-  const stripePublicKey = getStripePublicKey();
-
-  if (!stripePublicKey) {
-    return null;
-  }
-
   // eslint-disable-next-line react/hook-use-state -- we don't need setter
   const [stripe] = useState<ReturnType<typeof loadStripe> | void>(() => {
+    if (env.nodeEnv !== 'production') {
+      return;
+    }
+
+    const stripePublicKey = getStripePublicKey();
+
+    if (!stripePublicKey) {
+      return;
+    }
+
     return loadStripe(stripePublicKey);
   });
 
   if (!stripe) {
-    return children as any;
+    return children;
   }
 
   return (


### PR DESCRIPTION
It affected e2e tests and self-hosters.