### PR TITLE
[Gateway] Mention default polling interval in the docs

### DIFF
--- a/packages/services/storage/src/tokens.ts
+++ b/packages/services/storage/src/tokens.ts
@@ -89,7 +89,7 @@ export async function createTokenStorage(
             )})
           RETURNING *
         `,
-      )
+      );
 
       return transformToken(row);
     },

--- a/packages/web/docs/src/pages/docs/gateway/index.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/index.mdx
@@ -216,16 +216,6 @@ npx hive-gateway proxy https://localhost:3000/graphql \
 By default, Hive Gateway will start a server on port 4000. You can customize that behavior. For that
 please refer to our [Gateway documentation](/docs/api-reference/gateway-cli).
 
-<Callout>
-If you use a source like Hive CDN or a custom URL as a source for the supergraph schema,
-CLI will automatically poll the source for changes and update the schema accordingly with 10 seconds interval.
-If you want to change this behavior by setting the `--polling=10s` flag or `polling` in the configuration file.
-
-[Learn more about the configuration file](/docs/api-reference/gateway-config)
-[Learn more about the CLI flags](/docs/api-reference/gateway-cli)
-
-</Callout>
-
 ## Configuration File
 
 The Hive Gateway config file `gateway.config.ts` is used for enabling additional features such as

--- a/packages/web/docs/src/pages/docs/gateway/index.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/index.mdx
@@ -216,6 +216,16 @@ npx hive-gateway proxy https://localhost:3000/graphql \
 By default, Hive Gateway will start a server on port 4000. You can customize that behavior. For that
 please refer to our [Gateway documentation](/docs/api-reference/gateway-cli).
 
+<Callout>
+If you use a source like Hive CDN or a custom URL as a source for the supergraph schema,
+CLI will automatically poll the source for changes and update the schema accordingly with 10 seconds interval.
+If you want to change this behavior by setting the `--polling=10s` flag or `polling` in the configuration file.
+
+[Learn more about the configuration file](/docs/api-reference/gateway-config)
+[Learn more about the CLI flags](/docs/api-reference/gateway-cli)
+
+</Callout>
+
 ## Configuration File
 
 The Hive Gateway config file `gateway.config.ts` is used for enabling additional features such as

--- a/packages/web/docs/src/pages/docs/gateway/supergraph-proxy-source.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/supergraph-proxy-source.mdx
@@ -212,10 +212,20 @@ export const gatewayConfig = defineConfig({
   supergraph: {
     /* Supergraph Configuration */
   },
-  // Poll the schema registry every 10 seconds
-  pollingInterval: 10_000
+  // By default it polls the schema registry every 10 seconds
+  polling: '10s'
 })
 ```
+
+<Callout>
+If you use a source like Hive CDN or a custom URL as a source for the supergraph schema,
+CLI will automatically poll the source for changes and update the schema accordingly with 10 seconds interval.
+If you want to change this behavior by setting the `--polling=10s` flag or `polling` in the configuration file.
+
+[Learn more about the configuration file](/docs/api-reference/gateway-config)
+[Learn more about the CLI flags](/docs/api-reference/gateway-cli)
+
+</Callout>
 
 ## Proxy
 

--- a/packages/web/docs/src/pages/docs/gateway/supergraph-proxy-source.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/supergraph-proxy-source.mdx
@@ -213,14 +213,14 @@ export const gatewayConfig = defineConfig({
     /* Supergraph Configuration */
   },
   // By default it polls the schema registry every 10 seconds
-  polling: '10s'
+  pollingInterval: 10_000
 })
 ```
 
 <Callout>
 If you use a source like Hive CDN or a custom URL as a source for the supergraph schema,
 CLI will automatically poll the source for changes and update the schema accordingly with 10 seconds interval.
-If you want to change this behavior by setting the `--polling=10s` flag or `polling` in the configuration file.
+If you want to change this behavior by setting the `--polling=10s` flag or `pollingInterval` in the configuration file.
 
 [Learn more about the configuration file](/docs/api-reference/gateway-config)
 [Learn more about the CLI flags](/docs/api-reference/gateway-cli)

--- a/packages/web/docs/src/pages/docs/gateway/supergraph-proxy-source.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/supergraph-proxy-source.mdx
@@ -2,7 +2,7 @@
 title: 'Gateway: Supergraph schema'
 ---
 
-import { Tabs } from '@theguild/components'
+import { Callout, Tabs } from '@theguild/components'
 
 # Supergraph / Proxy Source
 


### PR DESCRIPTION
Mention the default polling interval "10 seconds" in the docs