### PR TITLE
[Gateway] Refer to the Hive Client docs in the usage reporting section

### DIFF
--- a/packages/web/docs/src/pages/docs/gateway/usage-reporting.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/usage-reporting.mdx
@@ -75,9 +75,21 @@ export const gatewayConfig = defineConfig({
     type: 'hive',
     // The registry token provided by Hive Registry
     token: '<token>'
+    /**
+     * Other options
+     *
+     * selfHosting: { ... },
+     * clientInfo: { ... },
+     *
+     * See more in Hive Client reference
+     */
   }
 })
 ```
+
+If you want to control the usage reporting to the Hive Console like `selfHosting`, `clientInfo` etc,
+please look at the Hive Client documentation to learn more about other options.
+[See more in Hive Client reference](/docs/api-reference/client#configuration)
 
 </Tabs.Tab>
 


### PR DESCRIPTION
It is hard to find out that you can use Hive Client options in `reporting` section.
This PR adds a reference to there.