### PR TITLE
feat(performance): added missing index for `getSchemaChangesForVersion` 

### DIFF
--- a/.changeset/little-hats-smile.md
+++ b/.changeset/little-hats-smile.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Added missing index for postgres db field "schema_version_changes.schema_version_id"

--- a/packages/migrations/src/actions/2024.12.24T00-00-00.improve-version-index-2.ts
+++ b/packages/migrations/src/actions/2024.12.24T00-00-00.improve-version-index-2.ts
@@ -1,0 +1,12 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+export default {
+  name: '2024.12.24T00-00-00.improve-version-index-2.ts',
+  noTransaction: true,
+  run: ({ sql }) => [
+    {
+      name: `create "schema_version_changes"."schema_version_id" lookup index`,
+      query: sql`CREATE INDEX idx_schema_version_changes_id ON schema_version_changes(schema_version_id);`,
+    },
+  ],
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2024.12.24T00-00-00.improve-version-index-2.ts
+++ b/packages/migrations/src/actions/2024.12.24T00-00-00.improve-version-index-2.ts
@@ -6,7 +6,7 @@ export default {
   run: ({ sql }) => [
     {
       name: `create "schema_version_changes"."schema_version_id" lookup index`,
-      query: sql`CREATE INDEX idx_schema_version_changes_id ON schema_version_changes(schema_version_id);`,
+      query: sql`CREATE INDEX CONCURRENTLY idx_schema_version_changes_id ON schema_version_changes(schema_version_id);`,
     },
   ],
 } satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -148,5 +148,6 @@ export const runPGMigrations = async (args: { slonik: DatabasePool; runTo?: stri
       await import('./actions/2024.11.12T00-00-00.supertokens-9.2'),
       await import('./actions/2024.11.12T00-00-00.supertokens-9.3'),
       await import('./actions/2024.12.23T00-00-00.improve-version-index'),
+      await import('./actions/2024.12.24T00-00-00.improve-version-index-2'),
     ],
   });


### PR DESCRIPTION
Seems like the `schema_version_changes` table is also missing an index for querying by `schema_version_id` field. 

```sql
  SELECT
          "change_type" as "type",
          "meta",
          "severity_level" as "severityLevel",
          "is_safe_based_on_usage" as "isSafeBasedOnUsage"
        FROM
          "schema_version_changes"
        WHERE
          "schema_version_id" = '2145210e-7762-4d2d-9f21-74a364054123';
```

And the plan: 
```
Gather  (cost=1000.00..260174.97 rows=523 width=113)
  Workers Planned: 2
  ->  Parallel Seq Scan on schema_version_changes  (cost=0.00..259122.67 rows=218 width=113)
        Filter: (schema_version_id = '2145210e-7762-4d2d-9f21-74a364054123'::uuid)
```

This should eliminate the parallel seq scan and just use the index instead. 