### PR TITLE
Extend debug information of the CLI

### DIFF
--- a/.changeset/tame-apes-impress.md
+++ b/.changeset/tame-apes-impress.md
@@ -1,0 +1,6 @@
+---
+'@graphql-hive/cli': patch
+---
+
+Extends debug information. Prints a list of files of the script directory and a path of included
+node binary. To enable debug mode, pass DEBUG=1 environment variable when running the CLI.

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
       "got@14.4.5": "patches/got@14.4.5.patch",
       "slonik@30.4.4": "patches/slonik@30.4.4.patch",
       "@oclif/core@3.26.6": "patches/@oclif__core@3.26.6.patch",
-      "oclif@4.13.6": "patches/oclif@4.13.6.patch",
+      "oclif": "patches/oclif.patch",
       "graphiql": "patches/graphiql.patch",
       "@graphiql/react": "patches/@graphiql__react.patch",
       "countup.js": "patches/countup.js.patch",

--- a/patches/oclif.patch
+++ b/patches/oclif.patch
@@ -226,10 +226,10 @@ index 2769337ddf0effe5f397300972b989db20616b4a..d725cd670207e4c8b125eef8d74d0a5d
  }
  exports.default = UploadWin;
 diff --git a/lib/tarballs/bin.js b/lib/tarballs/bin.js
-index 5740bb13522fdad4c65554534bfa286b6dd94f11..619b510d75605a28de2063df316fcbd0890935c6 100644
+index 5740bb13522fdad4c65554534bfa286b6dd94f11..79c43972b86773c0d28d1e159d1c0d284a66f7ef 100644
 --- a/lib/tarballs/bin.js
 +++ b/lib/tarballs/bin.js
-@@ -30,77 +30,38 @@ const path = __importStar(require("node:path"));
+@@ -30,77 +30,43 @@ const path = __importStar(require("node:path"));
  const node_util_1 = require("node:util");
  const exec = (0, node_util_1.promisify)(node_child_process_1.exec);
  async function writeBinScripts({ baseWorkspace, config, nodeOptions, nodeVersion, }) {
@@ -311,7 +311,12 @@ index 5740bb13522fdad4c65554534bfa286b6dd94f11..619b510d75605a28de2063df316fcbd0
 -  "\$NODE" ${`${nodeOptions.join(' ')} `}"\$DIR/run" "\$@"
 +NODE="\$DIR/node"
 +if [ "\$DEBUG" = "1" ]; then
++  echo "--DEBUG--"
 +  echo "script_dir: \$DIR"
++  echo "node: \$NODE"
++  echo "list of files:"
++  ls \$DIR
++  echo "--DEBUG--"
  fi
 +"\$NODE" ${`${nodeOptions.join(' ')} `}"\$DIR/run" "\$@"
  `, { mode: 0o755 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,9 @@ patchedDependencies:
   mjml-core@4.14.0:
     hash: zxxsxbqejjmcwuzpigutzzq6wa
     path: patches/mjml-core@4.14.0.patch
-  oclif@4.13.6:
-    hash: fkmkpwec6wqhte6g47j3tlprse
-    path: patches/oclif@4.13.6.patch
+  oclif:
+    hash: kmdoz5rhsd4tek3w4wmt7vygge
+    path: patches/oclif.patch
   slonik@30.4.4:
     hash: jxrvl4xmdvyktjijg7yfdkb34i
     path: patches/slonik@30.4.4.patch
@@ -453,7 +453,7 @@ importers:
         version: 3.1.4
       oclif:
         specifier: 4.13.6
-        version: 4.13.6(patch_hash=fkmkpwec6wqhte6g47j3tlprse)
+        version: 4.13.6(patch_hash=kmdoz5rhsd4tek3w4wmt7vygge)
       rimraf:
         specifier: 4.4.1
         version: 4.4.1
@@ -30695,7 +30695,7 @@ snapshots:
 
   obuf@1.1.2: {}
 
-  oclif@4.13.6(patch_hash=fkmkpwec6wqhte6g47j3tlprse):
+  oclif@4.13.6(patch_hash=kmdoz5rhsd4tek3w4wmt7vygge):
     dependencies:
       '@aws-sdk/client-cloudfront': 3.596.0
       '@aws-sdk/client-s3': 3.717.0


### PR DESCRIPTION
Prints a list of files of the script directory and a file path to the included node binary.