### PR TITLE
fix: escape double quotes for clickhouse queries

### DIFF
--- a/packages/services/api/src/modules/audit-logs/providers/audit-log-recorder.ts
+++ b/packages/services/api/src/modules/audit-logs/providers/audit-log-recorder.ts
@@ -43,7 +43,7 @@ export class AuditLogRecorder {
       const eventTime = formatToClickhouseDateTime(new Date());
       const id = randomUUID();
 
-      await this.clickHouse.query({
+      await this.clickHouse.postQuery({
         query: sql`
           INSERT INTO "audit_logs" (
             "id",

--- a/packages/services/api/src/modules/audit-logs/providers/audit-logs-types.ts
+++ b/packages/services/api/src/modules/audit-logs/providers/audit-logs-types.ts
@@ -31,7 +31,7 @@ export const AuditLogModel = z.union([
     eventType: z.literal('ORGANIZATION_POLICY_UPDATED'),
     metadata: z.object({
       allowOverrides: z.boolean(),
-      updatedFields: z.string(),
+      policy: z.string(),
     }),
   }),
   z.object({

--- a/packages/services/api/src/modules/audit-logs/resolvers/Mutation/exportOrganizationAuditLog.ts
+++ b/packages/services/api/src/modules/audit-logs/resolvers/Mutation/exportOrganizationAuditLog.ts
@@ -4,10 +4,9 @@ import type { MutationResolvers } from './../../../../__generated__/types';
 export const exportOrganizationAuditLog: NonNullable<
   MutationResolvers['exportOrganizationAuditLog']
 > = async (_parent, arg, ctx) => {
-  const organizationId = arg.input.selector.organizationSlug;
   const auditLogManager = ctx.injector.get(AuditLogManager);
 
-  const result = await auditLogManager.exportAndSendEmail(organizationId, {
+  const result = await auditLogManager.exportAndSendEmail(arg.input.selector.organizationSlug, {
     endDate: arg.input.filter.endDate,
     startDate: arg.input.filter.startDate,
   });

--- a/packages/services/api/src/modules/operations/providers/sql.ts
+++ b/packages/services/api/src/modules/operations/providers/sql.ts
@@ -326,13 +326,17 @@ function printValue(value: Value): string {
   throw new Error('sql: Unexpected value. Expected a string or an array of strings.');
 }
 
+function escapeDoubleQuotes(value: string) {
+  return value.replaceAll(`\"`, `\\\"`);
+}
+
 function stringifyValue(value: Value): string {
   if (typeof value === 'string') {
-    return value;
+    return escapeDoubleQuotes(value);
   }
 
   if (Array.isArray(value)) {
-    return `[${value.map(v => `'${v}'`).join(', ')}]`;
+    return escapeDoubleQuotes(`[${value.map(v => `'${v}'`).join(', ')}]`);
   }
 
   throw new Error('sql: Unexpected value. Expected a string or an array of strings.');

--- a/packages/services/api/src/modules/policy/providers/schema-policy.provider.ts
+++ b/packages/services/api/src/modules/policy/providers/schema-policy.provider.ts
@@ -146,9 +146,7 @@ export class SchemaPolicyProvider {
       organizationId: selector.organizationId,
       metadata: {
         allowOverrides: allowOverrides,
-        updatedFields: JSON.stringify({
-          policy: policy,
-        }),
+        policy: JSON.stringify(policy),
       },
     });
 

--- a/packages/web/app/src/pages/organization-settings.tsx
+++ b/packages/web/app/src/pages/organization-settings.tsx
@@ -468,7 +468,7 @@ const SettingsPageRenderer = (props: {
                     Export Audit Logs
                   </Button>
                   <AuditLogsOrganizationModal
-                    organization={organization.id}
+                    organizationSlug={organization.slug}
                     isOpen={isAuditLogsModalOpen}
                     toggleModalOpen={toggleAuditLogsModalOpen}
                   />
@@ -666,9 +666,9 @@ const AuditLogsSchema = z.object({
 function AuditLogsOrganizationModal(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
-  organization: string;
+  organizationSlug: string;
 }) {
-  const { organization } = props;
+  const { organizationSlug: organization } = props;
   const { toast } = useToast();
   const [, exportAuditLogs] = useMutation(AuditLogsOrganizationSettingsPageMutation);
 


### PR DESCRIPTION
### Background

Bug introduced in https://github.com/graphql-hive/console/pull/5530

### Description

- Properly escape `JSON.stringify({ foo: JSON.stringify({ foo: true }) })` when inserting into clickhouse
- Also fixes the wrong usage of `organization.id` as `organizationSlug`...

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
