### PR TITLE
fix serverless deploy link

### DIFF
--- a/packages/web/docs/src/pages/docs/gateway/other-features/performance/index.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/other-features/performance/index.mdx
@@ -14,9 +14,9 @@ gateway. Hive Gateway provides a shared caching storage that can be used across 
 subgraph execution and remote schema caching.
 
 <Callout>
-  If you are running Hive Gateway [serverless on the edge](/gateway/deployment/serverless), you're
-  highly advised to provide a cache. Aside from all of the aforementioned benefits, the biggest one
-  is caching the remote schema so that it does not get pulled on each request.
+  If you are running Hive Gateway [serverless on the edge](/docs/gateway/deployment/serverless),
+  you're highly advised to provide a cache. Aside from all of the aforementioned benefits, the
+  biggest one is caching the remote schema so that it does not get pulled on each request.
 </Callout>
 
 ## Providing Cache Storage


### PR DESCRIPTION
was missing `/doc/` prefix.