### PR TITLE
Adds lab.prompt to Preflight Script

### DIFF
--- a/.changeset/flat-planes-hunt.md
+++ b/.changeset/flat-planes-hunt.md
@@ -1,0 +1,5 @@
+---
+'hive': minor
+---
+
+Adds `lab.prompt(message, defaultValue)` to Preflight Script API

--- a/packages/web/app/src/lib/preflight-sandbox/preflight-script-worker.ts
+++ b/packages/web/app/src/lib/preflight-sandbox/preflight-script-worker.ts
@@ -6,12 +6,23 @@ import { WorkerEvents } from './shared-types';
 
 export type LogMessage = string | Error;
 
+/**
+ * Unique id for each prompt request.
+ * Incremented each time a prompt is requested.
+ */
+let promptId = 0;
+/**
+ * Map of promptId to the callback that should be called when the prompt is resolved.
+ * The callback is Promise.resolve of the prompt request of a given id.
+ */
+let promptCallbacks = new Map<number, (result: string | null) => void>();
+
 function sendMessage(data: WorkerEvents.Outgoing.EventData) {
   postMessage(data);
 }
 
-self.onmessage = async event => {
-  await execute(event.data);
+self.onmessage = async (ev: WorkerEvents.Incoming.MessageEvent) => {
+  await execute(ev.data);
 };
 
 self.addEventListener('unhandledrejection', event => {
@@ -19,18 +30,24 @@ self.addEventListener('unhandledrejection', event => {
   sendMessage({ type: WorkerEvents.Outgoing.Event.error, error });
 });
 
-async function execute(args: {
-  environmentVariables: Record<string, JSONPrimitive>;
-  script: string;
-}): Promise<void> {
-  const { environmentVariables, script } = args;
-  const inWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope;
-  // Confirm the build pipeline worked and this is running inside a worker and not the main thread
-  if (!inWorker) {
-    throw new Error(
-      'Preflight script must always be run in web workers, this is a problem with laboratory not user input',
-    );
+async function execute(args: WorkerEvents.Incoming.EventData): Promise<void> {
+  if (args.type === WorkerEvents.Incoming.Event.promptResponse) {
+    // When a prompt response is received, resolve the promise, so `await lab.prompt` can return the value.
+    const callback = promptCallbacks.get(args.promptId);
+    if (!callback) {
+      postMessage({
+        type: WorkerEvents.Outgoing.Event.error,
+        error: new Error('Prompt callback not found'),
+      });
+      return;
+    }
+    promptCallbacks.delete(args.promptId);
+    // resolve
+    callback(args.value);
+    return;
   }
+
+  const { environmentVariables, script } = args;
 
   // When running in worker `environmentVariables` will not be a reference to the main thread value
   // but sometimes this will be tested outside the worker, so we don't want to mutate the input in that case
@@ -109,6 +126,20 @@ async function execute(args: {
           workingEnvironmentVariables[key] = validValue;
         }
       },
+    },
+    /**
+     * Mimics the `prompt` function in the browser, by sending a message to the main thread
+     * and waiting for a response.
+     */
+    prompt(message: string, defaultValue: string) {
+      return new Promise<string | null>(resolve => {
+        // Increment the promptId so we can match the response to the request
+        promptId++;
+        // Store the resolve function so we can call it when the response is received
+        promptCallbacks.set(promptId, resolve);
+        // Send the prompt request to the main thread
+        postMessage({ type: 'prompt', promptId, message, defaultValue });
+      });
     },
   });
 

--- a/packages/web/app/src/lib/preflight-sandbox/preflight-script-worker.ts
+++ b/packages/web/app/src/lib/preflight-sandbox/preflight-script-worker.ts
@@ -1,7 +1,7 @@
 import CryptoJS from 'crypto-js';
 import CryptoJSPackageJson from 'crypto-js/package.json';
 import { ALLOWED_GLOBALS } from './allowed-globals';
-import { isJSONPrimitive, JSONPrimitive } from './json';
+import { isJSONPrimitive } from './json';
 import { WorkerEvents } from './shared-types';
 
 export type LogMessage = string | Error;
@@ -15,7 +15,7 @@ let promptId = 0;
  * Map of promptId to the callback that should be called when the prompt is resolved.
  * The callback is Promise.resolve of the prompt request of a given id.
  */
-let promptCallbacks = new Map<number, (result: string | null) => void>();
+const promptCallbacks = new Map<number, (result: string | null) => void>();
 
 function sendMessage(data: WorkerEvents.Outgoing.EventData) {
   postMessage(data);

--- a/packages/web/app/src/lib/preflight-sandbox/preflight-worker-embed.ts
+++ b/packages/web/app/src/lib/preflight-sandbox/preflight-worker-embed.ts
@@ -61,10 +61,20 @@ function handleRunEvent(data: IFrameEvents.Incoming.RunEventData) {
         console.log('received event from worker', ev.data);
         if (ev.data.type === WorkerEvents.Outgoing.Event.ready) {
           worker.postMessage({
+            type: WorkerEvents.Incoming.Event.run,
             script: data.script,
             environmentVariables: data.environmentVariables,
-          } satisfies WorkerEvents.Incoming.MessageData);
+          } satisfies WorkerEvents.Incoming.EventData);
           return;
+        }
+
+        if (ev.data.type === WorkerEvents.Outgoing.Event.prompt) {
+          const promptResult = window.parent.prompt(ev.data.message, ev.data.defaultValue);
+          worker.postMessage({
+            type: WorkerEvents.Incoming.Event.promptResponse,
+            promptId: ev.data.promptId,
+            value: promptResult,
+          } satisfies WorkerEvents.Incoming.EventData);
         }
 
         if (ev.data.type === WorkerEvents.Outgoing.Event.result) {

--- a/packages/web/app/src/lib/preflight-sandbox/shared-types.ts
+++ b/packages/web/app/src/lib/preflight-sandbox/shared-types.ts
@@ -81,21 +81,48 @@ export namespace WorkerEvents {
       log = 'log',
       result = 'result',
       error = 'error',
+      prompt = 'prompt',
     }
 
     type LogEventData = { type: Event.log; message: string };
     type ErrorEventData = { type: Event.error; error: Error };
+    type PromptEventData = {
+      type: Event.prompt;
+      promptId: number;
+      message: string;
+      defaultValue: string;
+    };
     type ResultEventData = { type: Event.result; environmentVariables: Record<string, unknown> };
     type ReadyEventData = { type: Event.ready };
 
-    export type EventData = ResultEventData | LogEventData | ErrorEventData | ReadyEventData;
+    export type EventData =
+      | ResultEventData
+      | LogEventData
+      | ErrorEventData
+      | ReadyEventData
+      | PromptEventData;
     export type MessageEvent = _MessageEvent<EventData>;
   }
 
   export namespace Incoming {
-    export type MessageData = {
+    export const enum Event {
+      run = 'run',
+      promptResponse = 'promptResponse',
+    }
+
+    type PromptResponseEventData = {
+      type: Event.promptResponse;
+      promptId: number;
+      value: string | null;
+    };
+
+    type RunEventData = {
+      type: Event.run;
       script: string;
       environmentVariables: Record<string, unknown>;
     };
+
+    export type EventData = PromptResponseEventData | RunEventData;
+    export type MessageEvent = _MessageEvent<EventData>;
   }
 }

--- a/packages/web/docs/src/pages/docs/dashboard/laboratory/preflight-scripts.mdx
+++ b/packages/web/docs/src/pages/docs/dashboard/laboratory/preflight-scripts.mdx
@@ -52,7 +52,7 @@ lab.environment.set('myKey', myValue)
 
 ### CryptoJS
 
-Additionally, you can access [the CryptoJS library](https://github.com/brix/crypto-js) by accessing
+Additionally, you can access [the CryptoJS library](https://cryptojs.gitbook.io/docs) by accessing
 the `CryptoJS` property on the `lab` global variable.
 
 <Screenshot>![](./crypto-js.png)</Screenshot>


### PR DESCRIPTION
```js
const emal = await lab.prompt('Enter email', /* 'default@email.here' */);
```

The `lab.prompt` function sends a message from the Worker to the Client.
The Client executes real `prompt(...)`.
Client sends a message to the Worker with the response.
Worker resolves a promise.
If something goes wrong and promise is never resolved, the Worker hits its 30s execution limit and is terminated.