### PR TITLE
Fix `integrationId` value validation in `ORGANIZATION_UPDATED_INTEGRATION` audit log event

### DIFF
--- a/packages/services/api/src/modules/audit-logs/providers/audit-logs-types.ts
+++ b/packages/services/api/src/modules/audit-logs/providers/audit-logs-types.ts
@@ -275,7 +275,7 @@ export const AuditLogModel = z.union([
   z.object({
     eventType: z.literal('ORGANIZATION_UPDATED_INTEGRATION'),
     metadata: z.object({
-      integrationId: z.string().uuid().nullable(),
+      integrationId: z.string().nullable(),
       integrationType: z.enum(['SLACK', 'GITHUB']),
       integrationStatus: z.enum(['ENABLED', 'DISABLED']),
     }),


### PR DESCRIPTION


Fixes https://github.com/graphql-hive/console/issues/6243 