### PR TITLE
fix(policy): added a new read access for schema policy linting

### DIFF
--- a/integration-tests/tests/api/policy/policy-access.spec.ts
+++ b/integration-tests/tests/api/policy/policy-access.spec.ts
@@ -100,7 +100,10 @@ describe('Policy Access', () => {
             policy: VALID_POLICY,
           },
           authToken: memberToken,
-        }).then(r => r.expectGraphQLErrors());
+        }).then(r => r.expectNoGraphQLErrors());
+        expect(result.updateSchemaPolicyForProject.error?.message).toBe(
+          'No access (reason: "Missing permission for performing \'schemaLinting:modifyProjectRules\' on resource")',
+        );
       },
     );
 
@@ -230,7 +233,10 @@ describe('Policy Access', () => {
             allowOverrides: true,
           },
           authToken: memberToken,
-        }).then(r => r.expectGraphQLErrors());
+        }).then(r => r.expectNoGraphQLErrors());
+        expect(result.updateSchemaPolicyForOrganization.error?.message).toBe(
+          'No access (reason: "Missing permission for performing \'schemaLinting:modifyOrganizationRules\' on resource")',
+        );
       },
     );
 
@@ -238,10 +244,13 @@ describe('Policy Access', () => {
       'should successfully fetch Organization.schemaPolicy if the user has access to read:org',
       async ({ expect }) => {
         const { createOrg } = await initSeed().createOwner();
-        const { organization, inviteAndJoinMember } = await createOrg();
+        const { organization, inviteAndJoinMember, setOrganizationSchemaPolicy } =
+          await createOrg();
+        await setOrganizationSchemaPolicy(VALID_POLICY, true);
+
         const { memberToken } = await inviteAndJoinMember();
 
-        await execute({
+        const result = await execute({
           document: query,
           variables: {
             selector: {
@@ -249,7 +258,8 @@ describe('Policy Access', () => {
             },
           },
           authToken: memberToken,
-        }).then(r => r.expectGraphQLErrors());
+        }).then(r => r.expectNoGraphQLErrors());
+        expect(result.organization?.organization.schemaPolicy?.id).not.toBeNull();
       },
     );
   });

--- a/integration-tests/tests/api/policy/policy-access.spec.ts
+++ b/integration-tests/tests/api/policy/policy-access.spec.ts
@@ -1,6 +1,7 @@
 import { ProjectType } from 'testkit/gql/graphql';
 import { graphql } from '../../../testkit/gql';
 import { execute } from '../../../testkit/graphql';
+import { VALID_POLICY } from '../../../testkit/schema-policy';
 import { initSeed } from '../../../testkit/seed';
 
 describe('Policy Access', () => {
@@ -15,8 +16,40 @@ describe('Policy Access', () => {
       }
     `);
 
+    const mutation = graphql(`
+      mutation UpdateSchemaPolicyForProject(
+        $selector: ProjectSelectorInput!
+        $policy: SchemaPolicyInput!
+      ) {
+        updateSchemaPolicyForProject(selector: $selector, policy: $policy) {
+          error {
+            message
+          }
+          ok {
+            project {
+              id
+              schemaPolicy {
+                id
+              }
+            }
+            updatedPolicy {
+              id
+              updatedAt
+              rules {
+                rule {
+                  id
+                }
+                severity
+                configuration
+              }
+            }
+          }
+        }
+      }
+    `);
+
     test.concurrent(
-      'should successfully fetch Project.schemaPolicy if the user has access to SETTINGS',
+      'should successfully update Project.schemaPolicy if the user has access to SETTINGS',
       async ({ expect }) => {
         const { createOrg } = await initSeed().createOwner();
         const { organization, createProject, inviteAndJoinMember } = await createOrg();
@@ -34,6 +67,52 @@ describe('Policy Access', () => {
         });
 
         const result = await execute({
+          document: mutation,
+          variables: {
+            selector: {
+              organizationSlug: organization.slug,
+              projectSlug: project.slug,
+            },
+            policy: VALID_POLICY,
+          },
+          authToken: memberToken,
+        }).then(r => r.expectNoGraphQLErrors());
+
+        expect(result.updateSchemaPolicyForProject.ok?.updatedPolicy.id).toBeTruthy();
+      },
+    );
+
+    test.concurrent(
+      'should fail to update Project.schemaPolicy if the user lacks access to SETTINGS',
+      async ({ expect }) => {
+        const { createOrg } = await initSeed().createOwner();
+        const { organization, createProject, inviteAndJoinMember } = await createOrg();
+        const { project } = await createProject(ProjectType.Single);
+        const { memberToken } = await inviteAndJoinMember();
+
+        const result = await execute({
+          document: mutation,
+          variables: {
+            selector: {
+              organizationSlug: organization.slug,
+              projectSlug: project.slug,
+            },
+            policy: VALID_POLICY,
+          },
+          authToken: memberToken,
+        }).then(r => r.expectGraphQLErrors());
+      },
+    );
+
+    test.concurrent(
+      'should successfully fetch Project.schemaPolicy if the user has access to read:project',
+      async ({ expect }) => {
+        const { createOrg } = await initSeed().createOwner();
+        const { organization, createProject, inviteAndJoinMember } = await createOrg();
+        const { project } = await createProject(ProjectType.Single);
+        const { memberToken } = await inviteAndJoinMember();
+
+        const result = await execute({
           document: query,
           variables: {
             selector: {
@@ -45,27 +124,6 @@ describe('Policy Access', () => {
         }).then(r => r.expectNoGraphQLErrors());
 
         expect(result.project?.schemaPolicy?.id).not.toBeNull();
-      },
-    );
-
-    test.concurrent(
-      'should fail to fetch Project.schemaPolicy if the user lacks access to SETTINGS',
-      async ({ expect }) => {
-        const { createOrg } = await initSeed().createOwner();
-        const { organization, createProject, inviteAndJoinMember } = await createOrg();
-        const { project, target } = await createProject(ProjectType.Single);
-        const { memberToken } = await inviteAndJoinMember();
-
-        await execute({
-          document: query,
-          variables: {
-            selector: {
-              organizationSlug: organization.slug,
-              projectSlug: project.slug,
-            },
-          },
-          authToken: memberToken,
-        }).then(r => r.expectGraphQLErrors());
       },
     );
   });
@@ -82,8 +140,45 @@ describe('Policy Access', () => {
         }
       }
     `);
+    const mutation = graphql(`
+      mutation UpdateSchemaPolicyForOrganization(
+        $selector: OrganizationSelectorInput!
+        $policy: SchemaPolicyInput!
+        $allowOverrides: Boolean!
+      ) {
+        updateSchemaPolicyForOrganization(
+          selector: $selector
+          policy: $policy
+          allowOverrides: $allowOverrides
+        ) {
+          error {
+            message
+          }
+          ok {
+            organization {
+              id
+              schemaPolicy {
+                id
+              }
+            }
+            updatedPolicy {
+              id
+              allowOverrides
+              updatedAt
+              rules {
+                rule {
+                  id
+                }
+                severity
+                configuration
+              }
+            }
+          }
+        }
+      }
+    `);
     test.concurrent(
-      'should successfully fetch Organization.schemaPolicy if the user has access to SETTINGS',
+      'should successfully update Organization.schemaPolicy if the user has access to SETTINGS',
       async ({ expect }) => {
         const { createOrg } = await initSeed().createOwner();
         const { organization, inviteAndJoinMember } = await createOrg();
@@ -100,21 +195,47 @@ describe('Policy Access', () => {
         });
 
         const result = await execute({
-          document: query,
+          document: mutation,
           variables: {
             selector: {
               organizationSlug: organization.slug,
             },
+            policy: VALID_POLICY,
+            allowOverrides: true,
           },
           authToken: memberToken,
         }).then(r => r.expectNoGraphQLErrors());
 
-        expect(result.organization?.organization.schemaPolicy?.id).not.toBeNull();
+        expect(
+          result.updateSchemaPolicyForOrganization.ok?.organization?.schemaPolicy?.id,
+        ).not.toBeNull();
       },
     );
 
     test.concurrent(
-      'should fail to fetch Organization.schemaPolicy if the user lacks access to SETTINGS',
+      'should fail to update Organization.schemaPolicy if the user lacks access to SETTINGS',
+      async ({ expect }) => {
+        const { createOrg } = await initSeed().createOwner();
+        const { organization, inviteAndJoinMember } = await createOrg();
+
+        const { memberToken } = await inviteAndJoinMember();
+
+        const result = await execute({
+          document: mutation,
+          variables: {
+            selector: {
+              organizationSlug: organization.slug,
+            },
+            policy: VALID_POLICY,
+            allowOverrides: true,
+          },
+          authToken: memberToken,
+        }).then(r => r.expectGraphQLErrors());
+      },
+    );
+
+    test.concurrent(
+      'should successfully fetch Organization.schemaPolicy if the user has access to read:org',
       async ({ expect }) => {
         const { createOrg } = await initSeed().createOwner();
         const { organization, inviteAndJoinMember } = await createOrg();

--- a/packages/services/api/src/modules/policy/providers/schema-policy.provider.ts
+++ b/packages/services/api/src/modules/policy/providers/schema-policy.provider.ts
@@ -182,7 +182,7 @@ export class SchemaPolicyProvider {
 
   async getOrganizationPolicy(selector: OrganizationSelector) {
     await this.session.assertPerformAction({
-      action: 'schemaLinting:modifyOrganizationRules',
+      action: 'organization:describe',
       organizationId: selector.organizationId,
       params: {
         organizationId: selector.organizationId,
@@ -194,7 +194,7 @@ export class SchemaPolicyProvider {
 
   async getOrganizationPolicyForProject(selector: ProjectSelector) {
     await this.session.assertPerformAction({
-      action: 'schemaLinting:modifyProjectRules',
+      action: 'project:describe',
       organizationId: selector.organizationId,
       params: {
         organizationId: selector.organizationId,
@@ -207,7 +207,7 @@ export class SchemaPolicyProvider {
 
   async getProjectPolicy(selector: ProjectSelector) {
     await this.session.assertPerformAction({
-      action: 'schemaLinting:modifyProjectRules',
+      action: 'project:describe',
       organizationId: selector.organizationId,
       params: {
         organizationId: selector.organizationId,

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -9,7 +9,6 @@
 
 export type alert_channel_type = 'MSTEAMS_WEBHOOK' | 'SLACK' | 'WEBHOOK';
 export type alert_type = 'SCHEMA_CHANGE_NOTIFICATIONS';
-export type breaking_change_formula = 'PERCENTAGE' | 'REQUEST_COUNT';
 export type schema_policy_resource = 'ORGANIZATION' | 'PROJECT';
 export type user_role = 'ADMIN' | 'MEMBER';
 
@@ -366,12 +365,10 @@ export interface targets {
   id: string;
   name: string;
   project_id: string;
-  validation_breaking_change_formula: breaking_change_formula;
   validation_enabled: boolean;
   validation_excluded_clients: Array<string> | null;
   validation_percentage: number;
   validation_period: number;
-  validation_request_count: number;
 }
 
 export interface tokens {

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -9,6 +9,7 @@
 
 export type alert_channel_type = 'MSTEAMS_WEBHOOK' | 'SLACK' | 'WEBHOOK';
 export type alert_type = 'SCHEMA_CHANGE_NOTIFICATIONS';
+export type breaking_change_formula = 'PERCENTAGE' | 'REQUEST_COUNT';
 export type schema_policy_resource = 'ORGANIZATION' | 'PROJECT';
 export type user_role = 'ADMIN' | 'MEMBER';
 
@@ -365,10 +366,12 @@ export interface targets {
   id: string;
   name: string;
   project_id: string;
+  validation_breaking_change_formula: breaking_change_formula;
   validation_enabled: boolean;
   validation_excluded_clients: Array<string> | null;
   validation_percentage: number;
   validation_period: number;
+  validation_request_count: number;
 }
 
 export interface tokens {

--- a/packages/web/app/src/components/layouts/organization.tsx
+++ b/packages/web/app/src/components/layouts/organization.tsx
@@ -157,16 +157,14 @@ export function OrganizationLayout({
                     </Link>
                   </TabsTrigger>
                 )}
-                {currentOrganization.viewerCanModifySchemaPolicy && (
-                  <TabsTrigger variant="menu" value={Page.Policy} asChild>
-                    <Link
-                      to="/$organizationSlug/view/policy"
-                      params={{ organizationSlug: currentOrganization.slug }}
-                    >
-                      Policy
-                    </Link>
-                  </TabsTrigger>
-                )}
+                <TabsTrigger variant="menu" value={Page.Policy} asChild>
+                  <Link
+                    to="/$organizationSlug/view/policy"
+                    params={{ organizationSlug: currentOrganization.slug }}
+                  >
+                    Policy
+                  </Link>
+                </TabsTrigger>
                 {currentOrganization.viewerCanAccessSettings && (
                   <TabsTrigger variant="menu" value={Page.Settings} asChild>
                     <Link

--- a/packages/web/app/src/components/layouts/project.tsx
+++ b/packages/web/app/src/components/layouts/project.tsx
@@ -151,21 +151,17 @@ export function ProjectLayout({
                         </Link>
                       </TabsTrigger>
                     )}
-                    {currentProject.viewerCanModifySchemaPolicy && (
-                      <>
-                        <TabsTrigger variant="menu" value={Page.Policy} asChild>
-                          <Link
-                            to="/$organizationSlug/$projectSlug/view/policy"
-                            params={{
-                              organizationSlug: props.organizationSlug,
-                              projectSlug: props.projectSlug,
-                            }}
-                          >
-                            Policy
-                          </Link>
-                        </TabsTrigger>
-                      </>
-                    )}
+                    <TabsTrigger variant="menu" value={Page.Policy} asChild>
+                      <Link
+                        to="/$organizationSlug/$projectSlug/view/policy"
+                        params={{
+                          organizationSlug: props.organizationSlug,
+                          projectSlug: props.projectSlug,
+                        }}
+                      >
+                        Policy
+                      </Link>
+                    </TabsTrigger>
                     {currentProject.viewerCanModifySettings && (
                       <TabsTrigger variant="menu" value={Page.Settings} asChild>
                         <Link

--- a/packages/web/app/src/components/policy/policy-list-item.tsx
+++ b/packages/web/app/src/components/policy/policy-list-item.tsx
@@ -36,6 +36,7 @@ function extractBaseSchema(configJsonSchema: JSONSchema | null | undefined): JSO
 }
 
 export function PolicyListItem(props: {
+  disabled?: boolean;
   ruleInfo: FragmentType<typeof PolicyListItem_RuleInfoFragment>;
   overridingParentRule: boolean;
 }): ReactElement {
@@ -55,6 +56,7 @@ export function PolicyListItem(props: {
               id={ruleInfo.id}
               value={ruleInfo.id}
               checked={enabled}
+              disabled={props.disabled}
               onCheckedChange={newState => toggleRuleState(newState as boolean)}
             />
           </div>

--- a/packages/web/app/src/components/policy/policy-settings.tsx
+++ b/packages/web/app/src/components/policy/policy-settings.tsx
@@ -54,7 +54,7 @@ function PolicySettingsListForm({
   saving?: boolean;
   rulesInParent?: string[];
   error?: string;
-  onSave?: (values: SchemaPolicyInput, allowOverrides: boolean) => Promise<void>;
+  onSave: null | ((values: SchemaPolicyInput, allowOverrides: boolean) => Promise<void>);
   availableRules: AvailableRulesList;
   currentState?: PolicySettings_SchemaPolicyFragmentFragment | null;
   children?: (form: FormikProps<PolicyFormValues>) => ReactElement;
@@ -154,7 +154,7 @@ export function PolicySettings({
   saving?: boolean;
   rulesInParent?: string[];
   currentState?: null | FragmentType<typeof PolicySettings_SchemaPolicyFragment>;
-  onSave?: (values: SchemaPolicyInput, allowOverrides: boolean) => Promise<void>;
+  onSave: null | ((values: SchemaPolicyInput, allowOverrides: boolean) => Promise<void>);
   error?: string;
   children?: (form: FormikProps<PolicyFormValues>) => ReactElement;
 }): ReactElement {

--- a/packages/web/app/src/components/policy/policy-settings.tsx
+++ b/packages/web/app/src/components/policy/policy-settings.tsx
@@ -54,7 +54,7 @@ function PolicySettingsListForm({
   saving?: boolean;
   rulesInParent?: string[];
   error?: string;
-  onSave: (values: SchemaPolicyInput, allowOverrides: boolean) => Promise<void>;
+  onSave?: (values: SchemaPolicyInput, allowOverrides: boolean) => Promise<void>;
   availableRules: AvailableRulesList;
   currentState?: PolicySettings_SchemaPolicyFragmentFragment | null;
   children?: (form: FormikProps<PolicyFormValues>) => ReactElement;
@@ -74,7 +74,7 @@ function PolicySettingsListForm({
           })),
       };
 
-      void onSave(asInput, values.allowOverrides).then(() => formikHelpers.resetForm());
+      void onSave?.(asInput, values.allowOverrides).then(() => formikHelpers.resetForm());
     },
   );
   const validationSchema = useMemo(() => buildValidationSchema(availableRules), [availableRules]);
@@ -112,7 +112,7 @@ function PolicySettingsListForm({
             {props.dirty ? <p className="pr-2 text-sm text-gray-500">Unsaved changes</p> : null}
 
             <Button
-              disabled={!props.dirty || saving || !props.isValid}
+              disabled={!props.dirty || saving || !props.isValid || !onSave}
               type="submit"
               variant="default"
               onClick={() => props.submitForm()}
@@ -130,6 +130,7 @@ function PolicySettingsListForm({
           <div className="grid grid-cols-1 divide-y divide-gray-800">
             {availableRules.map(availableRule => (
               <PolicyListItem
+                disabled={!onSave}
                 overridingParentRule={rulesInParent?.includes(availableRule.id) ?? false}
                 key={availableRule.id}
                 ruleInfo={availableRule}
@@ -153,7 +154,7 @@ export function PolicySettings({
   saving?: boolean;
   rulesInParent?: string[];
   currentState?: null | FragmentType<typeof PolicySettings_SchemaPolicyFragment>;
-  onSave: (values: SchemaPolicyInput, allowOverrides: boolean) => Promise<void>;
+  onSave?: (values: SchemaPolicyInput, allowOverrides: boolean) => Promise<void>;
   error?: string;
   children?: (form: FormikProps<PolicyFormValues>) => ReactElement;
 }): ReactElement {
@@ -164,19 +165,22 @@ export function PolicySettings({
   const activePolicy = useFragment(PolicySettings_SchemaPolicyFragment, currentState);
 
   return (
-    <DataWrapper query={availableRules} organizationSlug={null}>
-      {query => (
-        <PolicySettingsListForm
-          saving={saving}
-          rulesInParent={rulesInParent}
-          currentState={activePolicy}
-          onSave={onSave}
-          error={error}
-          availableRules={query.data.schemaPolicyRules}
-        >
-          {children}
-        </PolicySettingsListForm>
-      )}
-    </DataWrapper>
+    <>
+      {!onSave && 'You have read only access to this policy.'}
+      <DataWrapper query={availableRules} organizationSlug={null}>
+        {query => (
+          <PolicySettingsListForm
+            saving={saving}
+            rulesInParent={rulesInParent}
+            currentState={activePolicy}
+            onSave={onSave}
+            error={error}
+            availableRules={query.data.schemaPolicyRules}
+          >
+            {children}
+          </PolicySettingsListForm>
+        )}
+      </DataWrapper>
+    </>
   );
 }

--- a/packages/web/app/src/pages/organization-policy.tsx
+++ b/packages/web/app/src/pages/organization-policy.tsx
@@ -183,7 +183,7 @@ function PolicyPageContent(props: { organizationSlug: string }) {
                           })
                           .catch();
                       }
-                    : undefined
+                    : null
                 }
                 currentState={currentOrganization.schemaPolicy}
               >

--- a/packages/web/app/src/pages/organization-policy.tsx
+++ b/packages/web/app/src/pages/organization-policy.tsx
@@ -11,7 +11,6 @@ import { QueryError } from '@/components/ui/query-error';
 import { useToast } from '@/components/ui/use-toast';
 import { graphql } from '@/gql';
 import { RegistryModel } from '@/gql/graphql';
-import { useRedirect } from '@/lib/access/common';
 
 const OrganizationPolicyPageQuery = graphql(`
   query OrganizationPolicyPageQuery($selector: OrganizationSelectorInput!) {
@@ -83,23 +82,6 @@ function PolicyPageContent(props: { organizationSlug: string }) {
     p => p.registryModel === RegistryModel.Legacy,
   );
 
-  useRedirect({
-    canAccess: currentOrganization?.viewerCanModifySchemaPolicy === true,
-    redirectTo: router => {
-      void router.navigate({
-        to: '/$organizationSlug',
-        params: {
-          organizationSlug: props.organizationSlug,
-        },
-      });
-    },
-    entity: currentOrganization,
-  });
-
-  if (currentOrganization?.viewerCanModifySchemaPolicy === false) {
-    return null;
-  }
-
   if (query.error) {
     return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
@@ -169,33 +151,40 @@ function PolicyPageContent(props: { organizationSlug: string }) {
                   mutation.error?.message ||
                   mutation.data?.updateSchemaPolicyForOrganization.error?.message
                 }
-                onSave={async (newPolicy, allowOverrides) => {
-                  await mutate({
-                    selector: {
-                      organizationSlug: props.organizationSlug,
-                    },
-                    policy: newPolicy,
-                    allowOverrides,
-                  })
-                    .then(result => {
-                      if (result.data?.updateSchemaPolicyForOrganization.error || result.error) {
-                        toast({
-                          variant: 'destructive',
-                          title: 'Error',
-                          description:
-                            result.data?.updateSchemaPolicyForOrganization.error?.message ||
-                            result.error?.message,
-                        });
-                      } else {
-                        toast({
-                          variant: 'default',
-                          title: 'Success',
-                          description: 'Policy updated successfully',
-                        });
+                onSave={
+                  currentOrganization.viewerCanModifySchemaPolicy
+                    ? async (newPolicy, allowOverrides) => {
+                        await mutate({
+                          selector: {
+                            organizationSlug: props.organizationSlug,
+                          },
+                          policy: newPolicy,
+                          allowOverrides,
+                        })
+                          .then(result => {
+                            if (
+                              result.data?.updateSchemaPolicyForOrganization.error ||
+                              result.error
+                            ) {
+                              toast({
+                                variant: 'destructive',
+                                title: 'Error',
+                                description:
+                                  result.data?.updateSchemaPolicyForOrganization.error?.message ||
+                                  result.error?.message,
+                              });
+                            } else {
+                              toast({
+                                variant: 'default',
+                                title: 'Success',
+                                description: 'Policy updated successfully',
+                              });
+                            }
+                          })
+                          .catch();
                       }
-                    })
-                    .catch();
-                }}
+                    : undefined
+                }
                 currentState={currentOrganization.schemaPolicy}
               >
                 {form => (
@@ -205,6 +194,7 @@ function PolicyPageContent(props: { organizationSlug: string }) {
                       checked={form.values.allowOverrides}
                       value="allowOverrides"
                       onCheckedChange={newValue => form.setFieldValue('allowOverrides', newValue)}
+                      disabled={!currentOrganization.viewerCanModifySchemaPolicy}
                     />
                     <label
                       htmlFor="allowOverrides"

--- a/packages/web/app/src/pages/project-policy.tsx
+++ b/packages/web/app/src/pages/project-policy.tsx
@@ -9,7 +9,6 @@ import { QueryError } from '@/components/ui/query-error';
 import { useToast } from '@/components/ui/use-toast';
 import { graphql } from '@/gql';
 import { RegistryModel } from '@/gql/graphql';
-import { useRedirect } from '@/lib/access/common';
 
 const ProjectPolicyPageQuery = graphql(`
   query ProjectPolicyPageQuery($organizationSlug: String!, $projectSlug: String!) {

--- a/packages/web/app/src/pages/project-policy.tsx
+++ b/packages/web/app/src/pages/project-policy.tsx
@@ -172,7 +172,7 @@ function ProjectPolicyContent(props: { organizationSlug: string; projectSlug: st
                           }
                         });
                       }
-                    : undefined
+                    : null
                 }
                 currentState={currentProject.schemaPolicy}
               />

--- a/packages/web/app/src/pages/project-policy.tsx
+++ b/packages/web/app/src/pages/project-policy.tsx
@@ -83,24 +83,6 @@ function ProjectPolicyContent(props: { organizationSlug: string; projectSlug: st
   const currentOrganization = query.data?.organization?.organization;
   const currentProject = query.data?.project;
 
-  useRedirect({
-    canAccess: currentProject?.viewerCanModifySchemaPolicy === true,
-    redirectTo: router => {
-      void router.navigate({
-        to: '/$organizationSlug/$projectSlug',
-        params: {
-          organizationSlug: props.organizationSlug,
-          projectSlug: props.projectSlug,
-        },
-      });
-    },
-    entity: currentProject,
-  });
-
-  if (currentProject?.viewerCanModifySchemaPolicy === false) {
-    return null;
-  }
-
   if (query.error) {
     return (
       <QueryError
@@ -164,31 +146,35 @@ function ProjectPolicyContent(props: { organizationSlug: string; projectSlug: st
                   mutation.error?.message ||
                   mutation.data?.updateSchemaPolicyForProject.error?.message
                 }
-                onSave={async newPolicy => {
-                  await mutate({
-                    selector: {
-                      organizationSlug: props.organizationSlug,
-                      projectSlug: props.projectSlug,
-                    },
-                    policy: newPolicy,
-                  }).then(result => {
-                    if (result.error || result.data?.updateSchemaPolicyForProject.error) {
-                      toast({
-                        variant: 'destructive',
-                        title: 'Error',
-                        description:
-                          result.error?.message ||
-                          result.data?.updateSchemaPolicyForProject.error?.message,
-                      });
-                    } else {
-                      toast({
-                        variant: 'default',
-                        title: 'Success',
-                        description: 'Policy updated successfully',
-                      });
-                    }
-                  });
-                }}
+                onSave={
+                  currentProject?.viewerCanModifySchemaPolicy
+                    ? async newPolicy => {
+                        await mutate({
+                          selector: {
+                            organizationSlug: props.organizationSlug,
+                            projectSlug: props.projectSlug,
+                          },
+                          policy: newPolicy,
+                        }).then(result => {
+                          if (result.error || result.data?.updateSchemaPolicyForProject.error) {
+                            toast({
+                              variant: 'destructive',
+                              title: 'Error',
+                              description:
+                                result.error?.message ||
+                                result.data?.updateSchemaPolicyForProject.error?.message,
+                            });
+                          } else {
+                            toast({
+                              variant: 'default',
+                              title: 'Success',
+                              description: 'Policy updated successfully',
+                            });
+                          }
+                        });
+                      }
+                    : undefined
+                }
                 currentState={currentProject.schemaPolicy}
               />
             ) : (


### PR DESCRIPTION
### Background

Closes https://github.com/graphql-hive/console/issues/5861
<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

Adds read access to linting configuration.
I reused the organization:describe and project:describe permissions to determine if the user has access to read the policy.
<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
<img width="1170" alt="Screenshot 2025-01-01 at 1 12 33 PM" src="https://github.com/user-attachments/assets/3d4ac2e2-d916-4184-9b75-702fd55c7da1" />

For the implementation, I overloaded onSave to indicate whether or not this is readonly. If onSave is undefined, then this is considered readonly and all settings will be disabled.

I'm open to adding a separate attribute instead of that's preferred.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [x] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [x] Access control
- [ ] Cryptographic practices
- [x] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [x] Testing
