### PR TITLE
Revert "Revert "refactor: decode user in storage" (#6064)"

### DIFF
--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -1014,9 +1014,8 @@ export class SchemaManager {
       return null;
     }
 
-    return this.storage.getOrganizationUser({
-      organizationId: args.organizationId,
-      userId: args.userId,
+    return this.storage.getUserById({
+      id: args.userId,
     });
   }
 

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -69,7 +69,6 @@ export interface Storage {
   isReady(): Promise<boolean>;
   ensureUserExists(_: {
     superTokensUserId: string;
-    externalAuthUserId?: string | null;
     email: string;
     oidcIntegration: null | {
       id: string;
@@ -847,11 +846,6 @@ export interface Storage {
   }): Promise<Map<string, SchemaChangeType>>;
 
   getTargetBreadcrumbForTargetId(_: { targetId: string }): Promise<TargetBreadcrumb | null>;
-
-  /**
-   * Get an user that belongs to a specific organization by id.
-   */
-  getOrganizationUser(_: { organizationId: string; userId: string }): Promise<User | null>;
 
   // Zendesk
   setZendeskUserId(_: { userId: string; zendeskId: string }): Promise<void>;

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -192,6 +192,7 @@ export interface Organization {
     appDeployments: boolean;
   };
   zendeskId: string | null;
+  ownerId: string;
 }
 
 export interface OrganizationInvitation {
@@ -339,7 +340,6 @@ export interface User {
   provider: AuthProvider;
   superTokensUserId: string | null;
   isAdmin: boolean;
-  externalAuthUserId: string | null;
   oidcIntegrationId: string | null;
   zendeskId: string | null;
 }


### PR DESCRIPTION
This reverts commit c273883bf3be7615e89358b56b28419355caa6c8.

### Background

We no longer have legacy users within our database after https://github.com/graphql-hive/console/pull/6066.
We had to revert this change earlier in https://github.com/graphql-hive/console/pull/6064.

### Description

We can now ship this change as there are no longer any users without a supertokens user id within our database.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
