### PR TITLE
fix: `scrollIntoView` is not a function in lab page

### DIFF
--- a/packages/web/app/src/lib/hooks/laboratory/use-operation-collections-plugin.tsx
+++ b/packages/web/app/src/lib/hooks/laboratory/use-operation-collections-plugin.tsx
@@ -298,8 +298,11 @@ export function Content() {
     setAccordionValue([initialSelectedCollection]);
     setTimeout(() => {
       const link = containerRef.current!.querySelector(`a[href$="${queryParamsOperationId}"]`);
-      link!.scrollIntoView();
-      setIsScrolled(true);
+
+      if (link) {
+        link.scrollIntoView();
+        setIsScrolled(true);
+      }
     }, 150);
   }, [initialSelectedCollection]);
 


### PR DESCRIPTION
This seems like a race-condition in the animation/scroll-to effect. I was not able to fully reproduce it locally 🤔  

Fixed https://github.com/graphql-hive/console/issues/6263 