### PR TITLE
Fix permissions page list rendering

### DIFF
--- a/packages/web/app/src/components/organization/Permissions.tsx
+++ b/packages/web/app/src/components/organization/Permissions.tsx
@@ -150,19 +150,17 @@ export const PermissionScopeItem = <
                   : false;
 
               return (
-                <>
-                  <SelectItem
-                    key={item.value}
-                    value={item.value}
-                    disabled={isDisabled}
-                    data-cy={`select-option-${item.value}`}
-                  >
-                    {item.label}
-                    {isDisabled ? (
-                      <span className="block text-xs italic">Can't downgrade</span>
-                    ) : null}
-                  </SelectItem>
-                </>
+                <SelectItem
+                  key={item.value}
+                  value={item.value}
+                  disabled={isDisabled}
+                  data-cy={`select-option-${item.value}`}
+                >
+                  {item.label}
+                  {isDisabled ? (
+                    <span className="block text-xs italic">Can't downgrade</span>
+                  ) : null}
+                </SelectItem>
               );
             })}
         </SelectContent>


### PR DESCRIPTION
### Background

This page shows a react warning because it prints a list of elements that are missing a `key` attribute. This can cause elements to rerender inefficiently.
<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

Removes the unnecessary empty element from a component so that the root element is keyed.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
