### PR TITLE
chore(prettier): ignore snapshot files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@
 dist/
 .next/
 __generated__/
+__snapshots__/
 
 /.turbo/
 /integration-tests/testkit/gql/


### PR DESCRIPTION
Progresses toward: https://github.com/graphql-hive/console/pull/6122

Vitest supports snapshot files like "foo.json". Regardless of the file type, prettier should always ignore snapshot files.