### PR TITLE
refactor(cli): env helpers

### DIFF
--- a/packages/libraries/cli/src/base-command.ts
+++ b/packages/libraries/cli/src/base-command.ts
@@ -77,28 +77,6 @@ export default abstract class BaseCommand<T extends typeof Command> extends Comm
       .replace(findDoubleQuotes, (_: string, value: string) => colors.bold(value));
   }
 
-  maybe<TArgs extends Record<string, any>, TKey extends keyof TArgs>({
-    key,
-    env,
-    args,
-  }: {
-    key: TKey;
-    env: string;
-    args: TArgs;
-  }) {
-    if (args[key] != null) {
-      return args[key];
-    }
-
-    // eslint-disable-next-line no-process-env
-    if (env && process.env[env]) {
-      // eslint-disable-next-line no-process-env
-      return process.env[env];
-    }
-
-    return undefined;
-  }
-
   /**
    * Get a value from arguments or flags first, then from env variables,
    * then fallback to config.

--- a/packages/libraries/cli/src/commands/schema/publish.ts
+++ b/packages/libraries/cli/src/commands/schema/publish.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import { GraphQLError, print } from 'graphql';
-import { orEnvar } from 'src/helpers/env';
+import { orEnvar } from '../../helpers/env';
 import { transformCommentsToDescriptions } from '@graphql-tools/utils';
 import { Args, Errors, Flags } from '@oclif/core';
 import Command from '../../base-command';

--- a/packages/libraries/cli/src/commands/schema/publish.ts
+++ b/packages/libraries/cli/src/commands/schema/publish.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import { GraphQLError, print } from 'graphql';
+import { orEnvar } from 'src/helpers/env';
 import { transformCommentsToDescriptions } from '@graphql-tools/utils';
 import { Args, Errors, Flags } from '@oclif/core';
 import Command from '../../base-command';
@@ -204,16 +205,8 @@ export default class SchemaPublish extends Command<typeof SchemaPublish> {
       const metadata = this.resolveMetadata(flags.metadata);
       const usesGitHubApp = flags.github;
 
-      let commit: string | undefined | null = this.maybe({
-        key: 'commit',
-        args: flags,
-        env: 'HIVE_COMMIT',
-      });
-      let author: string | undefined | null = this.maybe({
-        key: 'author',
-        args: flags,
-        env: 'HIVE_AUTHOR',
-      });
+      let commit = orEnvar(flags.commit, 'HIVE_COMMIT');
+      let author = orEnvar(flags.author, 'HIVE_AUTHOR');
 
       let gitHub: null | {
         repository: string;

--- a/packages/libraries/cli/src/commands/schema/publish.ts
+++ b/packages/libraries/cli/src/commands/schema/publish.ts
@@ -1,11 +1,11 @@
 import { existsSync, readFileSync } from 'fs';
 import { GraphQLError, print } from 'graphql';
-import { orEnvar } from '../../helpers/env';
 import { transformCommentsToDescriptions } from '@graphql-tools/utils';
 import { Args, Errors, Flags } from '@oclif/core';
 import Command from '../../base-command';
 import { DocumentType, graphql } from '../../gql';
 import { graphqlEndpoint } from '../../helpers/config';
+import { orEnvar } from '../../helpers/env';
 import { ACCESS_TOKEN_MISSING } from '../../helpers/errors';
 import { gitInfo } from '../../helpers/git';
 import { loadSchema, minifySchema, renderChanges, renderErrors } from '../../helpers/schema';

--- a/packages/libraries/cli/src/helpers/env.ts
+++ b/packages/libraries/cli/src/helpers/env.ts
@@ -1,0 +1,17 @@
+/**
+ * Look up a value in the environment if the given value is undefined or null.
+ */
+export const orEnvar = <$Value>(
+  value: $Value,
+  envarName: string,
+): Exclude<$Value, null | undefined> | string | null => {
+  if (value !== null && value !== undefined) return value as any;
+
+  // eslint-disable-next-line no-process-env
+  if (envarName && process.env[envarName]) {
+    // eslint-disable-next-line no-process-env
+    return process.env[envarName];
+  }
+
+  return null;
+};


### PR DESCRIPTION
Progresses toward #6122 

Simplify `BaseCommand` class by removing a function-like method.