### PR TITLE
chore(cli): idiomatic build script with watch

### DIFF
--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -30,11 +30,11 @@
     "graphql"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build --clean && tsc --build",
+    "build:watch": "tsc --build --watch",
     "oclif:pack": "npm pack && pnpm oclif pack tarballs --no-xz",
     "oclif:upload": "pnpm oclif upload tarballs --no-xz",
     "postpack": "rm -f oclif.manifest.json",
-    "prebuild": "rimraf dist",
     "prepack": "node scripts/replace-workspace.mjs rimraf lib && tsc -b && oclif manifest && oclif readme",
     "prepublishOnly": "oclif manifest && oclif readme",
     "schema:check:federation": "pnpm start schema:check examples/federation.graphql --service reviews",


### PR DESCRIPTION
progresses #6122 

Integration tests run against the _built_ packages. This PR introduces a watch script for CLI to make it easy to work on CLI and integration tests at the same time.

Also, this PR updates the build script to use the idiomatic `--clean` flag. It will remove the output directories according to what is configured in the `tsconfig.json`. This keeps config DRY. Our current approach uses `rm -rf` duplicating config about which dir is for the TS output.