### PR TITLE
refactor: remove usage of scopes for CDN access tokens

### DIFF
--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -1013,7 +1013,6 @@ const TargetSettingsPage_OrganizationFragment = graphql(`
     me {
       ...CanAccessTarget_MemberFragment
       ...RegistryAccessTokens_MeFragment
-      ...CDNAccessTokens_MeFragment
     }
   }
 `);
@@ -1072,9 +1071,6 @@ const TargetSettingsPageQuery = graphql(`
         id
         slug
         ...TargetSettingsPage_OrganizationFragment
-        me {
-          ...CDNAccessTokens_MeFragment
-        }
       }
     }
     project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
@@ -1279,7 +1275,6 @@ function TargetSettingsContent(props: {
             ) : null}
             {resolvedPage.key === 'cdn' ? (
               <CDNAccessTokens
-                me={organizationForSettings.me}
                 organizationSlug={props.organizationSlug}
                 projectSlug={props.projectSlug}
                 targetSlug={props.targetSlug}


### PR DESCRIPTION
### Background

There is still some access checks happening using the legacy scopes that we need to remove for https://github.com/graphql-hive/console/pull/6231

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Data protection
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
