### PR TITLE
Assign custom roles to members without a role

### DIFF
--- a/.changeset/asd-asd-asd.md
+++ b/.changeset/asd-asd-asd.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Assigns custom roles to members without a role to complete https://the-guild.dev/graphql/hive/product-updates/2023-12-05-member-roles

--- a/packages/migrations/src/actions/2025.01.09T00-00-00.legacy-member-scopes.ts
+++ b/packages/migrations/src/actions/2025.01.09T00-00-00.legacy-member-scopes.ts
@@ -25,7 +25,7 @@ export default {
   async run({ sql, connection }) {
     const queryResult = await connection.query(sql`
       SELECT
-        organization_id as "organizationId"
+        organization_id as "organizationId",
         sorted_scopes as "sortedScopes",
         ARRAY_AGG(user_id) AS "userIds"
       FROM (

--- a/packages/migrations/src/actions/2025.01.09T00-00-00.legacy-member-scopes.ts
+++ b/packages/migrations/src/actions/2025.01.09T00-00-00.legacy-member-scopes.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+import { type MigrationExecutor } from '../pg-migrator';
+
+const QUERY_RESULT = z.array(z.object({
+  organization_id: z.string(),
+  sorted_scopes: z.array(z.string()),
+  user_ids: z.array(z.string()),
+}));
+
+/**
+ * This migration is going to create a new role for each group of members
+ * that have the same scopes but no role assigned.
+ * 
+ * The role will be named "Auto Role {counter}".
+ * The counter will be reset for each organization.
+ * 
+ * Completes:
+ * https://the-guild.dev/graphql/hive/product-updates/2023-12-05-member-roles
+ * 
+ * Users won't be affected by this change, as they will still have the same scopes.
+ */
+export default {
+  name: '2025.01.09T00-00-00.legacy-member-scopes.ts',
+  noTransaction: true,
+  async run({ sql, connection }) {
+    const queryResult = await connection.query(sql`
+      SELECT
+        organization_id,
+        sorted_scopes,
+        ARRAY_AGG(user_id) AS user_ids
+      FROM (
+          SELECT
+              organization_id,
+              user_id,
+              ARRAY_AGG(scope ORDER BY scope) AS sorted_scopes
+          FROM (
+              SELECT
+                  organization_id,
+                  user_id,
+                  UNNEST(scopes) AS scope
+              FROM organization_member
+          ) unnested
+          GROUP BY organization_id, user_id
+      ) sorted_scopes_per_user
+      GROUP BY organization_id, sorted_scopes
+      ORDER BY organization_id;
+    `);
+  
+    if (queryResult.rowCount === 0) {
+      console.log('No members without role_id found.');
+      return;
+    }
+
+    // rows are sorted by organization_id
+    // and grouped by scopes
+    // so we can process them in order
+    const rows = QUERY_RESULT.parse(queryResult.rows);
+
+    let counter = 1;
+    let previousOrganizationId: string | null = null;
+    for (let index = 0; index < rows.length; index++) {
+      const row = rows[index];
+      if (previousOrganizationId !== row.organization_id) {
+        previousOrganizationId = row.organization_id;
+        // reset counter as we are starting a new organization
+        counter = 1;
+      }
+
+      console.log(
+        `processing organization_id="${row.organization_id}" (${counter}) with ${row.user_ids.length} users | ${index}/${queryResult.rowCount}`,
+      );
+
+      const startedAt = Date.now();
+
+      await connection.query(sql`
+        WITH new_role AS (
+          INSERT INTO organization_member_roles (
+            organization_id, name, description, scopes
+          )
+          VALUES (
+            ${row.organization_id},
+            ${`Auto Role ${counter}`},
+            'Auto generated role to assign to members without a role',
+            ${row.sorted_scopes}
+          )
+          RETURNING id
+        )
+        UPDATE organization_member
+        SET role_id = (SELECT id FROM new_role)
+        WHERE organization_id = ${row.organization_id} AND user_id = ANY(${row.user_ids})
+      `);
+
+      console.log(`finished after ${Date.now() - startedAt}ms`);
+
+      counter++;
+    }
+  },
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2025.01.09T00-00-00.legacy-member-scopes.ts
+++ b/packages/migrations/src/actions/2025.01.09T00-00-00.legacy-member-scopes.ts
@@ -1,22 +1,24 @@
 import { z } from 'zod';
 import { type MigrationExecutor } from '../pg-migrator';
 
-const QUERY_RESULT = z.array(z.object({
-  organizationId: z.string(),
-  sortedScopes: z.array(z.string()),
-  userIds: z.array(z.string()),
-}));
+const QUERY_RESULT = z.array(
+  z.object({
+    organizationId: z.string(),
+    sortedScopes: z.array(z.string()),
+    userIds: z.array(z.string()),
+  }),
+);
 
 /**
  * This migration is going to create a new role for each group of members
  * that have the same scopes but no role assigned.
- * 
+ *
  * The role will be named "Auto Role {counter}".
  * The counter will be reset for each organization.
- * 
+ *
  * Completes:
  * https://the-guild.dev/graphql/hive/product-updates/2023-12-05-member-roles
- * 
+ *
  * Users won't be affected by this change, as they will still have the same scopes.
  */
 export default {
@@ -45,7 +47,7 @@ export default {
       GROUP BY organization_id, sorted_scopes
       ORDER BY organization_id;
     `);
-  
+
     if (queryResult.rowCount === 0) {
       console.log('No members without role_id found.');
       return;

--- a/packages/migrations/src/actions/2025.01.09T00-00-00.legacy-member-scopes.ts
+++ b/packages/migrations/src/actions/2025.01.09T00-00-00.legacy-member-scopes.ts
@@ -79,7 +79,7 @@ export default {
           )
           VALUES (
             ${row.organization_id},
-            ${`Auto Role ${counter}`},
+            'Auto Role ' || substring(uuid_generate_v4()::text FROM 1 FOR 8),
             'Auto generated role to assign to members without a role',
             ${row.sorted_scopes}
           )

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -152,5 +152,6 @@ export const runPGMigrations = async (args: { slonik: DatabasePool; runTo?: stri
       await import('./actions/2024.12.27T00.00.00.create-preflight-scripts'),
       await import('./actions/2025.01.02T00-00-00.cascade-deletion-indices'),
       await import('./actions/2025.01.02T00-00-00.legacy-user-org-cleanup'),
+      await import('./actions/2025.01.09T00-00-00.legacy-member-scopes'),
     ],
   });

--- a/packages/migrations/test/2025.01.09T00-00-00.legacy-member-scopes.test.ts
+++ b/packages/migrations/test/2025.01.09T00-00-00.legacy-member-scopes.test.ts
@@ -133,7 +133,7 @@ await describe('migration: legacy-member-socpes', async () => {
       );
 
       // run the next migrations
-      await runTo('2025.01.02T00-00-00.legacy-user-org-cleanup.ts')
+      await runTo('2025.01.02T00-00-00.legacy-user-org-cleanup.ts');
 
       // assert scopes are still in place and identical
       assert.deepStrictEqual(
@@ -162,7 +162,7 @@ await describe('migration: legacy-member-socpes', async () => {
       );
 
       // assert assigned roles have identical scopes
-      
+
       const adminRole = await db.one<{
         scopes: string[];
         id: string;
@@ -172,10 +172,7 @@ await describe('migration: legacy-member-socpes', async () => {
         LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
         WHERE om.user_id = ${admin.id} AND omr.organization_id = ${organization.id}
       `);
-      assert.deepStrictEqual(
-        adminRole.scopes,
-        adminScopes,
-      );
+      assert.deepStrictEqual(adminRole.scopes, adminScopes);
 
       const contributorRole = await db.one<{
         scopes: string[];
@@ -186,11 +183,8 @@ await describe('migration: legacy-member-socpes', async () => {
         LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
         WHERE om.user_id = ${contributor.id} AND omr.organization_id = ${organization.id}
         `);
-      assert.deepStrictEqual(
-        contributorRole,
-        contributorScopes,
-      );
-      
+      assert.deepStrictEqual(contributorRole, contributorScopes);
+
       // assert no role user has no role
       assert.strictEqual(
         await db.oneFirst(sql`
@@ -296,12 +290,9 @@ await describe('migration: legacy-member-socpes', async () => {
         FROM organization_member as om
         LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
         WHERE om.user_id = ${noRoleUser.id} AND omr.organization_id = ${organization.id}
-      `)
-      
-      assert.deepStrictEqual(
-        previouslyNoRoleUser.scopes,
-        noRoleUserScopes,
-      );
+      `);
+
+      assert.deepStrictEqual(previouslyNoRoleUser.scopes, noRoleUserScopes);
 
       // assert that the role has the correct name
       assert.match(previouslyNoRoleUser.name, /^Auto Role /);

--- a/packages/migrations/test/2025.01.09T00-00-00.legacy-member-scopes.test.ts
+++ b/packages/migrations/test/2025.01.09T00-00-00.legacy-member-scopes.test.ts
@@ -39,9 +39,46 @@ await describe('migration: legacy-member-socpes', async () => {
         user: admin,
       });
 
-      const adminScopes = ['target:read', 'target:delete', 'target:settings', 'taret:write'];
-      const contributorScopes = ['target:read', 'taret:write'];
-      const noRoleUserScopes = ['target:read', 'target:settings'];
+      const adminScopes = [
+        'organization:read',
+        'organization:delete',
+        'organization:settings',
+        'organization:integrations',
+        'organization:members',
+        'project:read',
+        'project:delete',
+        'project:settings',
+        'project:alerts',
+        'project:operations-store:read',
+        'project:operations-store:write',
+        'target:read',
+        'target:delete',
+        'target:settings',
+        'target:registry:read',
+        'target:registry:write',
+        'target:tokens:read',
+        'target:tokens:write',
+      ];
+      const contributorScopes = [
+        'organization:read',
+        'project:read',
+        'project:settings',
+        'project:alerts',
+        'project:operations-store:read',
+        'project:operations-store:write',
+        'target:read',
+        'target:settings',
+        'target:registry:read',
+        'target:registry:write',
+        'target:tokens:read',
+        'target:tokens:write',
+      ];
+      const noRoleUserScopes = [
+        'organization:read',
+        'project:alerts',
+        'project:read',
+        'target:read',
+      ];
 
       // Create an invitation to simulate a pending invitation
       await db.query(sql`
@@ -108,7 +145,7 @@ await describe('migration: legacy-member-socpes', async () => {
         SELECT omr.scopes, omr.id
         FROM organization_member as om
         LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
-        WHERE om.user_id = ${admin.id} AND omr.organization_id = ${organization.id}
+        WHERE om.user_id = ${admin.id} AND om.organization_id = ${organization.id}
       `);
       assert.deepStrictEqual(adminRole.scopes, adminScopes);
 
@@ -119,9 +156,9 @@ await describe('migration: legacy-member-socpes', async () => {
         SELECT omr.scopes, omr.id
         FROM organization_member as om
         LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
-        WHERE om.user_id = ${contributor.id} AND omr.organization_id = ${organization.id}
+        WHERE om.user_id = ${contributor.id} AND om.organization_id = ${organization.id}
         `);
-      assert.deepStrictEqual(contributorRole, contributorScopes);
+      assert.deepStrictEqual(contributorRole.scopes, contributorScopes);
 
       // assert no role user has no role
       assert.strictEqual(
@@ -142,7 +179,7 @@ await describe('migration: legacy-member-socpes', async () => {
         SELECT omr.scopes, omr.name
         FROM organization_member as om
         LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
-        WHERE om.user_id = ${noRoleUser.id} AND omr.organization_id = ${organization.id}
+        WHERE om.user_id = ${noRoleUser.id} AND om.organization_id = ${organization.id}
       `);
 
       assert.deepStrictEqual(previouslyNoRoleUser.scopes, noRoleUserScopes);
@@ -157,7 +194,7 @@ await describe('migration: legacy-member-socpes', async () => {
           SELECT omr.id
           FROM organization_member as om
           LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
-          WHERE om.user_id = ${admin.id} AND omr.organization_id = ${organization.id}
+          WHERE om.user_id = ${admin.id} AND om.organization_id = ${organization.id}
         `),
         adminRole.id,
       );
@@ -167,7 +204,7 @@ await describe('migration: legacy-member-socpes', async () => {
           SELECT omr.id
           FROM organization_member as om
           LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
-          WHERE om.user_id = ${contributor.id} AND omr.organization_id = ${organization.id}
+          WHERE om.user_id = ${contributor.id} AND om.organization_id = ${organization.id}
         `),
         contributorRole.id,
       );

--- a/packages/migrations/test/2025.01.09T00-00-00.legacy-member-scopes.test.ts
+++ b/packages/migrations/test/2025.01.09T00-00-00.legacy-member-scopes.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { describe, test } from 'node:test';
-import { ForeignKeyIntegrityConstraintViolationError, sql } from 'slonik';
+import { sql } from 'slonik';
 import { createStorage } from '../../services/storage/src/index';
 import { initMigrationTestingEnvironment } from './utils/testkit';
 
@@ -38,59 +38,10 @@ await describe('migration: legacy-member-socpes', async () => {
         },
         user: admin,
       });
-      const secondaryAdmin = await seed.user({
-        user: {
-          name: 'test3',
-          email: 'test3@test.com',
-        },
-      });
-      const secondaryOrganization = await seed.organization({
-        organization: {
-          name: 'org-2',
-        },
-        user: secondaryAdmin,
-      });
 
-      const adminScopes = [
-        'organization:read',
-        'organization:delete',
-        'organization:settings',
-        'organization:integrations',
-        'organization:members',
-        'project:read',
-        'project:delete',
-        'project:settings',
-        'project:alerts',
-        'project:operations-store:read',
-        'project:operations-store:write',
-        'target:read',
-        'target:delete',
-        'target:settings',
-        'target:registry:read',
-        'target:registry:write',
-        'target:tokens:read',
-        'target:tokens:write',
-      ];
-      const contributorScopes = [
-        'organization:read',
-        'project:read',
-        'project:settings',
-        'project:alerts',
-        'project:operations-store:read',
-        'project:operations-store:write',
-        'target:read',
-        'target:settings',
-        'target:registry:read',
-        'target:registry:write',
-        'target:tokens:read',
-        'target:tokens:write',
-      ];
-      const noRoleUserScopes = [
-        'organization:read',
-        'project:read',
-        'target:read',
-        'project:alerts',
-      ];
+      const adminScopes = ['target:read', 'target:delete', 'target:settings', 'taret:write'];
+      const contributorScopes = ['target:read', 'taret:write'];
+      const noRoleUserScopes = ['target:read', 'target:settings'];
 
       // Create an invitation to simulate a pending invitation
       await db.query(sql`
@@ -102,8 +53,7 @@ await describe('migration: legacy-member-socpes', async () => {
         VALUES
           (${organization.id}, ${admin.id}, ${sql.array(adminScopes, 'text')}),
           (${organization.id}, ${contributor.id}, ${sql.array(contributorScopes, 'text')}),
-          (${organization.id}, ${noRoleUser.id}, ${sql.array(noRoleUserScopes, 'text')}),
-          (${secondaryOrganization.id}, ${secondaryAdmin.id}, ${sql.array(adminScopes, 'text')})
+          (${organization.id}, ${noRoleUser.id}, ${sql.array(noRoleUserScopes, 'text')})
       `);
 
       // assert correct scopes
@@ -124,12 +74,6 @@ await describe('migration: legacy-member-socpes', async () => {
         SELECT scopes FROM organization_member WHERE user_id = ${noRoleUser.id}
         `),
         noRoleUserScopes,
-      );
-      assert.deepStrictEqual(
-        await db.oneFirst(sql`
-        SELECT scopes FROM organization_member WHERE user_id = ${secondaryAdmin.id}
-        `),
-        adminScopes,
       );
 
       // run the next migrations
@@ -153,12 +97,6 @@ await describe('migration: legacy-member-socpes', async () => {
         SELECT scopes FROM organization_member WHERE user_id = ${noRoleUser.id}
         `),
         noRoleUserScopes,
-      );
-      assert.deepStrictEqual(
-        await db.oneFirst(sql`
-        SELECT scopes FROM organization_member WHERE user_id = ${secondaryAdmin.id}
-        `),
-        adminScopes,
       );
 
       // assert assigned roles have identical scopes
@@ -191,91 +129,6 @@ await describe('migration: legacy-member-socpes', async () => {
         SELECT role_id FROM organization_member WHERE user_id = ${noRoleUser.id}
         `),
         null,
-      );
-
-      assert.deepStrictEqual(
-        await db.oneFirst(sql`
-        SELECT omr.scopes
-        FROM organization_member as om
-        LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
-        WHERE om.user_id = ${secondaryAdmin.id} AND omr.organization_id = ${secondaryOrganization.id}
-        `),
-        adminScopes,
-      );
-
-      // deleting a role with assigned members should not be possible
-      const deletionError = await db
-        .query(
-          sql`
-          DELETE FROM organization_member_roles WHERE organization_id = ${organization.id} AND id IN (
-            SELECT role_id FROM organization_member WHERE organization_id = ${organization.id} AND user_id = ${contributor.id}
-          )
-      `,
-        )
-        .catch(error => Promise.resolve(error));
-      assert.strictEqual(
-        deletionError instanceof ForeignKeyIntegrityConstraintViolationError,
-        true,
-      );
-
-      // locked roles should be Viewer and Admin
-      assert.deepStrictEqual(
-        await db.manyFirst(sql`
-          SELECT name FROM organization_member_roles WHERE organization_id = ${organization.id} AND locked = true ORDER BY name ASC
-        `),
-        ['Admin', 'Viewer'],
-      );
-
-      // deleting a member should not delete the role
-      const contributorRoleId = await db.oneFirst<string>(sql`
-        SELECT role_id FROM organization_member WHERE organization_id = ${organization.id} AND user_id = ${contributor.id}
-      `);
-      assert.strictEqual(
-        await db.oneFirst(sql`
-          DELETE FROM organization_member WHERE user_id = ${contributor.id} AND organization_id = ${organization.id} RETURNING user_id
-        `),
-        contributor.id,
-      );
-      assert.strictEqual(
-        await db.oneFirst(sql`
-          SELECT id FROM organization_member_roles WHERE organization_id = ${organization.id} AND id = ${contributorRoleId}
-        `),
-        contributorRoleId,
-      );
-
-      // deleting a user should not delete the role
-      const customRoleId = await db.oneFirst<string>(sql`
-        INSERT INTO organization_member_roles
-        (organization_id, name, description, scopes)
-        VALUES
-        (${organization.id}, 'Custom', 'Custom role', ${sql.array(noRoleUserScopes, 'text')})
-        RETURNING id
-      `);
-      await db.query(sql`
-        UPDATE organization_member SET role_id = ${customRoleId} WHERE user_id = ${noRoleUser.id} AND organization_id = ${organization.id}
-      `);
-      assert.strictEqual(
-        await db.oneFirst(sql`
-          DELETE FROM users WHERE id = ${noRoleUser.id} RETURNING id
-        `),
-        noRoleUser.id,
-      );
-      assert.strictEqual(
-        await db.oneFirst(sql`
-          SELECT id FROM organization_member_roles WHERE organization_id = ${organization.id} AND id = ${customRoleId}
-        `),
-        customRoleId,
-      );
-
-      // pending invitations should have Viewer role
-      assert.deepStrictEqual(
-        await db.manyFirst(sql`
-          SELECT omr.name
-          FROM organization_invitations as oi
-          LEFT JOIN organization_member_roles as omr ON (omr.id = oi.role_id AND omr.organization_id = oi.organization_id)
-          WHERE oi.organization_id = ${organization.id}
-        `),
-        ['Viewer'],
       );
 
       await complete();

--- a/packages/migrations/test/2025.01.09T00-00-00.legacy-member-scopes.test.ts
+++ b/packages/migrations/test/2025.01.09T00-00-00.legacy-member-scopes.test.ts
@@ -1,0 +1,335 @@
+import assert from 'node:assert';
+import { describe, test } from 'node:test';
+import { ForeignKeyIntegrityConstraintViolationError, sql } from 'slonik';
+import { createStorage } from '../../services/storage/src/index';
+import { initMigrationTestingEnvironment } from './utils/testkit';
+
+await describe('migration: legacy-member-socpes', async () => {
+  await test('should assign newly created roles to users without a role, without modifying existing roles', async () => {
+    const { db, runTo, complete, done, seed, connectionString } =
+      await initMigrationTestingEnvironment();
+    const storage = await createStorage(connectionString, 1);
+    try {
+      // Run migrations all the way to the point before the one we are testing
+      await runTo('2023.10.25T14.41.41.schema-checks-dedup.ts');
+
+      // Seed the database with some data (schema_sdl, supergraph_sdl, composite_schema_sdl)
+      const admin = await seed.user({
+        user: {
+          name: 'test1',
+          email: 'test1@test.com',
+        },
+      });
+      const contributor = await seed.user({
+        user: {
+          name: 'test2',
+          email: 'test2@test.com',
+        },
+      });
+      const noRoleUser = await seed.user({
+        user: {
+          name: 'test3',
+          email: 'test3@test.com',
+        },
+      });
+      const organization = await seed.organization({
+        organization: {
+          name: 'org-1',
+        },
+        user: admin,
+      });
+      const secondaryAdmin = await seed.user({
+        user: {
+          name: 'test3',
+          email: 'test3@test.com',
+        },
+      });
+      const secondaryOrganization = await seed.organization({
+        organization: {
+          name: 'org-2',
+        },
+        user: secondaryAdmin,
+      });
+
+      const adminScopes = [
+        'organization:read',
+        'organization:delete',
+        'organization:settings',
+        'organization:integrations',
+        'organization:members',
+        'project:read',
+        'project:delete',
+        'project:settings',
+        'project:alerts',
+        'project:operations-store:read',
+        'project:operations-store:write',
+        'target:read',
+        'target:delete',
+        'target:settings',
+        'target:registry:read',
+        'target:registry:write',
+        'target:tokens:read',
+        'target:tokens:write',
+      ];
+      const contributorScopes = [
+        'organization:read',
+        'project:read',
+        'project:settings',
+        'project:alerts',
+        'project:operations-store:read',
+        'project:operations-store:write',
+        'target:read',
+        'target:settings',
+        'target:registry:read',
+        'target:registry:write',
+        'target:tokens:read',
+        'target:tokens:write',
+      ];
+      const noRoleUserScopes = [
+        'organization:read',
+        'project:read',
+        'target:read',
+        'project:alerts',
+      ];
+
+      // Create an invitation to simulate a pending invitation
+      await db.query(sql`
+        INSERT INTO organization_invitations (organization_id, email) VALUES (${organization.id}, 'invited@test.com')
+      `);
+
+      await db.query(sql`
+        INSERT INTO organization_member (organization_id, user_id, scopes)
+        VALUES
+          (${organization.id}, ${admin.id}, ${sql.array(adminScopes, 'text')}),
+          (${organization.id}, ${contributor.id}, ${sql.array(contributorScopes, 'text')}),
+          (${organization.id}, ${noRoleUser.id}, ${sql.array(noRoleUserScopes, 'text')}),
+          (${secondaryOrganization.id}, ${secondaryAdmin.id}, ${sql.array(adminScopes, 'text')})
+      `);
+
+      // assert correct scopes
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${admin.id}
+        `),
+        adminScopes,
+      );
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${contributor.id}
+        `),
+        contributorScopes,
+      );
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${noRoleUser.id}
+        `),
+        noRoleUserScopes,
+      );
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${secondaryAdmin.id}
+        `),
+        adminScopes,
+      );
+
+      // run the next migrations
+      await runTo('2025.01.02T00-00-00.legacy-user-org-cleanup.ts')
+
+      // assert scopes are still in place and identical
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${admin.id}
+        `),
+        adminScopes,
+      );
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${contributor.id}
+        `),
+        contributorScopes,
+      );
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${noRoleUser.id}
+        `),
+        noRoleUserScopes,
+      );
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT scopes FROM organization_member WHERE user_id = ${secondaryAdmin.id}
+        `),
+        adminScopes,
+      );
+
+      // assert assigned roles have identical scopes
+      
+      const adminRole = await db.one<{
+        scopes: string[];
+        id: string;
+      }>(sql`
+        SELECT omr.scopes, omr.id
+        FROM organization_member as om
+        LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
+        WHERE om.user_id = ${admin.id} AND omr.organization_id = ${organization.id}
+      `);
+      assert.deepStrictEqual(
+        adminRole.scopes,
+        adminScopes,
+      );
+
+      const contributorRole = await db.one<{
+        scopes: string[];
+        id: string;
+      }>(sql`
+        SELECT omr.scopes, omr.id
+        FROM organization_member as om
+        LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
+        WHERE om.user_id = ${contributor.id} AND omr.organization_id = ${organization.id}
+        `);
+      assert.deepStrictEqual(
+        contributorRole,
+        contributorScopes,
+      );
+      
+      // assert no role user has no role
+      assert.strictEqual(
+        await db.oneFirst(sql`
+        SELECT role_id FROM organization_member WHERE user_id = ${noRoleUser.id}
+        `),
+        null,
+      );
+
+      assert.deepStrictEqual(
+        await db.oneFirst(sql`
+        SELECT omr.scopes
+        FROM organization_member as om
+        LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
+        WHERE om.user_id = ${secondaryAdmin.id} AND omr.organization_id = ${secondaryOrganization.id}
+        `),
+        adminScopes,
+      );
+
+      // deleting a role with assigned members should not be possible
+      const deletionError = await db
+        .query(
+          sql`
+          DELETE FROM organization_member_roles WHERE organization_id = ${organization.id} AND id IN (
+            SELECT role_id FROM organization_member WHERE organization_id = ${organization.id} AND user_id = ${contributor.id}
+          )
+      `,
+        )
+        .catch(error => Promise.resolve(error));
+      assert.strictEqual(
+        deletionError instanceof ForeignKeyIntegrityConstraintViolationError,
+        true,
+      );
+
+      // locked roles should be Viewer and Admin
+      assert.deepStrictEqual(
+        await db.manyFirst(sql`
+          SELECT name FROM organization_member_roles WHERE organization_id = ${organization.id} AND locked = true ORDER BY name ASC
+        `),
+        ['Admin', 'Viewer'],
+      );
+
+      // deleting a member should not delete the role
+      const contributorRoleId = await db.oneFirst<string>(sql`
+        SELECT role_id FROM organization_member WHERE organization_id = ${organization.id} AND user_id = ${contributor.id}
+      `);
+      assert.strictEqual(
+        await db.oneFirst(sql`
+          DELETE FROM organization_member WHERE user_id = ${contributor.id} AND organization_id = ${organization.id} RETURNING user_id
+        `),
+        contributor.id,
+      );
+      assert.strictEqual(
+        await db.oneFirst(sql`
+          SELECT id FROM organization_member_roles WHERE organization_id = ${organization.id} AND id = ${contributorRoleId}
+        `),
+        contributorRoleId,
+      );
+
+      // deleting a user should not delete the role
+      const customRoleId = await db.oneFirst<string>(sql`
+        INSERT INTO organization_member_roles
+        (organization_id, name, description, scopes)
+        VALUES
+        (${organization.id}, 'Custom', 'Custom role', ${sql.array(noRoleUserScopes, 'text')})
+        RETURNING id
+      `);
+      await db.query(sql`
+        UPDATE organization_member SET role_id = ${customRoleId} WHERE user_id = ${noRoleUser.id} AND organization_id = ${organization.id}
+      `);
+      assert.strictEqual(
+        await db.oneFirst(sql`
+          DELETE FROM users WHERE id = ${noRoleUser.id} RETURNING id
+        `),
+        noRoleUser.id,
+      );
+      assert.strictEqual(
+        await db.oneFirst(sql`
+          SELECT id FROM organization_member_roles WHERE organization_id = ${organization.id} AND id = ${customRoleId}
+        `),
+        customRoleId,
+      );
+
+      // pending invitations should have Viewer role
+      assert.deepStrictEqual(
+        await db.manyFirst(sql`
+          SELECT omr.name
+          FROM organization_invitations as oi
+          LEFT JOIN organization_member_roles as omr ON (omr.id = oi.role_id AND omr.organization_id = oi.organization_id)
+          WHERE oi.organization_id = ${organization.id}
+        `),
+        ['Viewer'],
+      );
+
+      await complete();
+
+      // assert that the migration created a new role for the non-role user
+      // and the role has exact same scopes as the user
+      const previouslyNoRoleUser = await db.one<{
+        scopes: string[];
+        name: string;
+      }>(sql`
+        SELECT omr.scopes, omr.name
+        FROM organization_member as om
+        LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
+        WHERE om.user_id = ${noRoleUser.id} AND omr.organization_id = ${organization.id}
+      `)
+      
+      assert.deepStrictEqual(
+        previouslyNoRoleUser.scopes,
+        noRoleUserScopes,
+      );
+
+      // assert that the role has the correct name
+      assert.match(previouslyNoRoleUser.name, /^Auto Role /);
+
+      // asser that users with roles were not affected,
+      // meaning the role was exactly the same as before
+      assert.deepStrictEqual(
+        await db.oneFirst<string>(sql`
+          SELECT omr.id
+          FROM organization_member as om
+          LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
+          WHERE om.user_id = ${admin.id} AND omr.organization_id = ${organization.id}
+        `),
+        adminRole.id,
+      );
+
+      assert.deepStrictEqual(
+        await db.oneFirst<string>(sql`
+          SELECT omr.id
+          FROM organization_member as om
+          LEFT JOIN organization_member_roles as omr ON omr.id = om.role_id
+          WHERE om.user_id = ${contributor.id} AND omr.organization_id = ${organization.id}
+        `),
+        contributorRole.id,
+      );
+    } finally {
+      await done();
+      await storage.destroy();
+    }
+  });
+});

--- a/packages/migrations/test/root.ts
+++ b/packages/migrations/test/root.ts
@@ -3,3 +3,4 @@ import './2023.09.25T15.23.00.github-check-with-project-name.test';
 import './2023.11.20T10-00-00.organization-member-roles.test';
 import './2024.01.26T00.00.01.schema-check-purging.test';
 import './2024.07.23T09.36.00.schema-cleanup-tracker.test';
+import './2025.01.09T00-00-00.legacy-member-scopes.test';


### PR DESCRIPTION
This migration is going to create a new role for each group of members that have the same scopes but no role assigned.

Users won't be affected by this change, as they will still have the same scopes.

The role will be named `Auto Role {counter}`.
The counter will be reset for each organization.

The script will create 1 or 2 roles for 97% of organizations that haven't complete the migration.

Completes https://the-guild.dev/graphql/hive/product-updates/2023-12-05-member-roles