### PR TITLE
refactor(cli): explicit BaseCommand log method names

### DIFF
--- a/packages/libraries/cli/src/base-command.ts
+++ b/packages/libraries/cli/src/base-command.ts
@@ -52,19 +52,19 @@ export default abstract class BaseCommand<T extends typeof Command> extends Comm
     this.args = args as Args<T>;
   }
 
-  success(...args: any[]) {
+  logSuccess(...args: any[]) {
     this.log(Texture.success(...args));
   }
 
-  fail(...args: any[]) {
+  logFailure(...args: any[]) {
     this.log(Texture.failure(...args));
   }
 
-  info(...args: any[]) {
+  logInfo(...args: any[]) {
     this.log(Texture.info(...args));
   }
 
-  infoWarning(...args: any[]) {
+  logWarning(...args: any[]) {
     this.log(Texture.warning(...args));
   }
 

--- a/packages/libraries/cli/src/commands/app/create.ts
+++ b/packages/libraries/cli/src/commands/app/create.ts
@@ -116,7 +116,7 @@ export default class AppCreate extends Command<typeof AppCreate> {
                   ? affectedOperation.body.substring(0, maxCharacters) + '...'
                   : affectedOperation.body
               ).replace(/\n/g, '\\n');
-              this.infoWarning(
+              this.logWarning(
                 `Failed uploading document: ${result.addDocumentsToAppDeployment.error.details.message}` +
                   `\nOperation hash: ${affectedOperation?.hash}` +
                   `\nOperation body: ${truncatedBody}`,

--- a/packages/libraries/cli/src/commands/config/delete.ts
+++ b/packages/libraries/cli/src/commands/config/delete.ts
@@ -15,6 +15,6 @@ export default class DeleteConfig extends Command<typeof DeleteConfig> {
   async run() {
     const { args } = await this.parse(DeleteConfig);
     this._userConfig!.delete(args.key);
-    this.success(Texture.boldQuotedWords(`Config flag "${args.key}" was deleted`));
+    this.logSuccess(Texture.boldQuotedWords(`Config flag "${args.key}" was deleted`));
   }
 }

--- a/packages/libraries/cli/src/commands/config/reset.ts
+++ b/packages/libraries/cli/src/commands/config/reset.ts
@@ -5,6 +5,6 @@ export default class ResetConfig extends Command<typeof ResetConfig> {
 
   async run() {
     this.userConfig.clear();
-    this.success('Config cleared.');
+    this.logSuccess('Config cleared.');
   }
 }

--- a/packages/libraries/cli/src/commands/config/set.ts
+++ b/packages/libraries/cli/src/commands/config/set.ts
@@ -22,6 +22,8 @@ export default class SetConfig extends Command<typeof SetConfig> {
   async run() {
     const { args } = await this.parse(SetConfig);
     this.userConfig.set(args.key as ValidConfigurationKeys, args.value);
-    this.success(Texture.boldQuotedWords(`Config flag "${args.key}" was set to "${args.value}"`));
+    this.logSuccess(
+      Texture.boldQuotedWords(`Config flag "${args.key}" was set to "${args.value}"`),
+    );
   }
 }

--- a/packages/libraries/cli/src/commands/dev.ts
+++ b/packages/libraries/cli/src/commands/dev.ts
@@ -216,7 +216,7 @@ export default class Dev extends Command<typeof Dev> {
             write: flags.write,
             unstable__forceLatest,
             onError: message => {
-              this.fail(message);
+              this.logFailure(message);
             },
           }),
         );
@@ -229,7 +229,7 @@ export default class Dev extends Command<typeof Dev> {
           services,
           write: flags.write,
           onError: message => {
-            this.fail(message);
+            this.logFailure(message);
           },
         }),
       );
@@ -329,7 +329,7 @@ export default class Dev extends Command<typeof Dev> {
       return;
     }
 
-    this.success('Composition successful');
+    this.logSuccess('Composition successful');
     this.log(`Saving supergraph schema to ${input.write}`);
     await writeFile(resolve(process.cwd(), input.write), compositionResult.supergraphSdl, 'utf-8');
   }
@@ -387,7 +387,7 @@ export default class Dev extends Command<typeof Dev> {
       return;
     }
 
-    this.success('Composition successful');
+    this.logSuccess('Composition successful');
     this.log(`Saving supergraph schema to ${input.write}`);
     await writeFile(resolve(process.cwd(), input.write), compositionResult.supergraphSdl, 'utf-8');
   }
@@ -397,12 +397,12 @@ export default class Dev extends Command<typeof Dev> {
     serviceInputs: ServiceInput[],
     compose: (services: Service[]) => Promise<void>,
   ) {
-    this.info('Watch mode enabled');
+    this.logInfo('Watch mode enabled');
 
     let services = await this.resolveServices(serviceInputs);
     await compose(services);
 
-    this.info('Watching for changes');
+    this.logInfo('Watching for changes');
 
     let resolveWatchMode: () => void;
 
@@ -419,25 +419,25 @@ export default class Dev extends Command<typeof Dev> {
             service => services.find(s => s.name === service.name)!.sdl !== service.sdl,
           )
         ) {
-          this.info('Detected changes, recomposing');
+          this.logInfo('Detected changes, recomposing');
           await compose(newServices);
           services = newServices;
         }
       } catch (error) {
-        this.fail(String(error));
+        this.logFailure(String(error));
       }
 
       timeoutId = setTimeout(watch, watchInterval);
     };
 
     process.once('SIGINT', () => {
-      this.info('Exiting watch mode');
+      this.logInfo('Exiting watch mode');
       clearTimeout(timeoutId);
       resolveWatchMode();
     });
 
     process.once('SIGTERM', () => {
-      this.info('Exiting watch mode');
+      this.logInfo('Exiting watch mode');
       clearTimeout(timeoutId);
       resolveWatchMode();
     });

--- a/packages/libraries/cli/src/commands/introspect.ts
+++ b/packages/libraries/cli/src/commands/introspect.ts
@@ -47,7 +47,7 @@ export default class Introspect extends Command<typeof Introspect> {
       method: 'POST',
     }).catch(err => {
       if (err instanceof GraphQLError) {
-        this.fail(err.message);
+        this.logFailure(err.message);
         this.exit(1);
       }
 
@@ -57,7 +57,7 @@ export default class Introspect extends Command<typeof Introspect> {
     });
 
     if (!schema) {
-      this.fail('Unable to load schema');
+      this.logFailure('Unable to load schema');
       this.exit(1);
     }
 
@@ -89,11 +89,11 @@ export default class Introspect extends Command<typeof Introspect> {
           break;
         }
         default:
-          this.fail(`Unsupported file extension ${extname(flags.write)}`);
+          this.logFailure(`Unsupported file extension ${extname(flags.write)}`);
           this.exit(1);
       }
 
-      this.success(`Saved to ${filepath}`);
+      this.logSuccess(`Saved to ${filepath}`);
     }
   }
 }

--- a/packages/libraries/cli/src/commands/operations/check.ts
+++ b/packages/libraries/cli/src/commands/operations/check.ts
@@ -117,7 +117,7 @@ export default class OperationsCheck extends Command<typeof OperationsCheck> {
       });
 
       if (operations.length === 0) {
-        this.info('No operations found');
+        this.logInfo('No operations found');
         this.exit(0);
         return;
       }
@@ -160,7 +160,7 @@ export default class OperationsCheck extends Command<typeof OperationsCheck> {
       const operationsWithErrors = invalidOperations.filter(o => o.errors.length > 0);
 
       if (operationsWithErrors.length === 0) {
-        this.success(`All operations are valid (${operations.length})`);
+        this.logSuccess(`All operations are valid (${operations.length})`);
         this.exit(0);
         return;
       }
@@ -184,7 +184,7 @@ export default class OperationsCheck extends Command<typeof OperationsCheck> {
       if (error instanceof Errors.ExitError) {
         throw error;
       } else {
-        this.fail('Failed to validate operations');
+        this.logFailure('Failed to validate operations');
         this.handleFetchError(error);
       }
     }
@@ -197,7 +197,7 @@ export default class OperationsCheck extends Command<typeof OperationsCheck> {
   }
 
   private renderErrors(sourceName: string, errors: GraphQLError[]) {
-    this.fail(sourceName);
+    this.logFailure(sourceName);
     errors.forEach(e => {
       this.log(` - ${Texture.boldQuotedWords(e.message)}`);
     });

--- a/packages/libraries/cli/src/commands/schema/check.ts
+++ b/packages/libraries/cli/src/commands/schema/check.ts
@@ -236,9 +236,9 @@ export default class SchemaCheck extends Command<typeof SchemaCheck> {
       if (result.schemaCheck.__typename === 'SchemaCheckSuccess') {
         const changes = result.schemaCheck.changes;
         if (result.schemaCheck.initial) {
-          this.success('Schema registry is empty, nothing to compare your schema with.');
+          this.logSuccess('Schema registry is empty, nothing to compare your schema with.');
         } else if (!changes?.total) {
-          this.success('No changes');
+          this.logSuccess('No changes');
         } else {
           this.log(renderChanges(changes));
         }
@@ -272,12 +272,12 @@ export default class SchemaCheck extends Command<typeof SchemaCheck> {
         this.log('');
 
         if (forceSafe) {
-          this.success('Breaking changes were expected (forced)');
+          this.logSuccess('Breaking changes were expected (forced)');
         } else {
           this.exit(1);
         }
       } else if (result.schemaCheck.__typename === 'GitHubSchemaCheckSuccess') {
-        this.success(result.schemaCheck.message);
+        this.logSuccess(result.schemaCheck.message);
       } else {
         this.error(result.schemaCheck.message);
       }
@@ -285,7 +285,7 @@ export default class SchemaCheck extends Command<typeof SchemaCheck> {
       if (error instanceof Errors.ExitError) {
         throw error;
       } else {
-        this.fail('Failed to check schema');
+        this.logFailure('Failed to check schema');
         this.handleFetchError(error);
       }
     }

--- a/packages/libraries/cli/src/commands/schema/delete.ts
+++ b/packages/libraries/cli/src/commands/schema/delete.ts
@@ -94,7 +94,7 @@ export default class SchemaDelete extends Command<typeof SchemaDelete> {
         );
 
         if (!confirmed) {
-          this.info('Aborting');
+          this.logInfo('Aborting');
           this.exit(0);
         }
       }
@@ -125,12 +125,12 @@ export default class SchemaDelete extends Command<typeof SchemaDelete> {
       });
 
       if (result.schemaDelete.__typename === 'SchemaDeleteSuccess') {
-        this.success(`${service} deleted`);
+        this.logSuccess(`${service} deleted`);
         this.exit(0);
         return;
       }
 
-      this.fail(`Failed to delete ${service}`);
+      this.logFailure(`Failed to delete ${service}`);
       const errors = result.schemaDelete.errors;
 
       if (errors) {
@@ -141,7 +141,7 @@ export default class SchemaDelete extends Command<typeof SchemaDelete> {
       if (error instanceof Errors.ExitError) {
         throw error;
       } else {
-        this.fail(`Failed to complete`);
+        this.logFailure(`Failed to complete`);
         this.handleFetchError(error);
       }
     }

--- a/packages/libraries/cli/src/commands/schema/fetch.ts
+++ b/packages/libraries/cli/src/commands/schema/fetch.ts
@@ -172,7 +172,7 @@ export default class SchemaFetch extends Command<typeof SchemaFetch> {
             await writeFile(filepath, schema, 'utf8');
             break;
           default:
-            this.fail(`Unsupported file extension ${extname(flags.write)}`);
+            this.logFailure(`Unsupported file extension ${extname(flags.write)}`);
             this.exit(1);
         }
         return;

--- a/packages/libraries/cli/src/commands/schema/publish.ts
+++ b/packages/libraries/cli/src/commands/schema/publish.ts
@@ -299,32 +299,32 @@ export default class SchemaPublish extends Command<typeof SchemaPublish> {
           const changes = result.schemaPublish.changes;
 
           if (result.schemaPublish.initial) {
-            this.success('Published initial schema.');
+            this.logSuccess('Published initial schema.');
           } else if (result.schemaPublish.successMessage) {
-            this.success(result.schemaPublish.successMessage);
+            this.logSuccess(result.schemaPublish.successMessage);
           } else if (changes && changes.total === 0) {
-            this.success('No changes. Skipping.');
+            this.logSuccess('No changes. Skipping.');
           } else {
             if (changes) {
               this.log(renderChanges(changes));
             }
-            this.success('Schema published');
+            this.logSuccess('Schema published');
           }
 
           if (result.schemaPublish.linkToWebsite) {
-            this.info(`Available at ${result.schemaPublish.linkToWebsite}`);
+            this.logInfo(`Available at ${result.schemaPublish.linkToWebsite}`);
           }
         } else if (result.schemaPublish.__typename === 'SchemaPublishRetry') {
           this.log(result.schemaPublish.reason);
           this.log('Waiting for other schema publishes to complete...');
           result = null;
         } else if (result.schemaPublish.__typename === 'SchemaPublishMissingServiceError') {
-          this.fail(
+          this.logFailure(
             `${result.schemaPublish.missingServiceError} Please use the '--service <name>' parameter.`,
           );
           this.exit(1);
         } else if (result.schemaPublish.__typename === 'SchemaPublishMissingUrlError') {
-          this.fail(
+          this.logFailure(
             `${result.schemaPublish.missingUrlError} Please use the '--url <url>' parameter.`,
           );
           this.exit(1);
@@ -340,17 +340,17 @@ export default class SchemaPublish extends Command<typeof SchemaPublish> {
           this.log('');
 
           if (!force) {
-            this.fail('Failed to publish schema');
+            this.logFailure('Failed to publish schema');
             this.exit(1);
           } else {
-            this.success('Schema published (forced)');
+            this.logSuccess('Schema published (forced)');
           }
 
           if (result.schemaPublish.linkToWebsite) {
-            this.info(`Available at ${result.schemaPublish.linkToWebsite}`);
+            this.logInfo(`Available at ${result.schemaPublish.linkToWebsite}`);
           }
         } else if (result.schemaPublish.__typename === 'GitHubSchemaPublishSuccess') {
-          this.success(result.schemaPublish.message);
+          this.logSuccess(result.schemaPublish.message);
         } else {
           this.error(
             'message' in result.schemaPublish ? result.schemaPublish.message : 'Unknown error',
@@ -361,7 +361,7 @@ export default class SchemaPublish extends Command<typeof SchemaPublish> {
       if (error instanceof Errors.ExitError) {
         throw error;
       } else {
-        this.fail('Failed to publish schema');
+        this.logFailure('Failed to publish schema');
         this.handleFetchError(error);
       }
     }


### PR DESCRIPTION
Progresses #6122

New methods are coming for constructing output types. This refactor
clarifies the difference between loggeres and data constructors.
