### PR TITLE
Allow to close the last tab in Laboratory

### DIFF
--- a/.changeset/serious-poets-shake.md
+++ b/.changeset/serious-poets-shake.md
@@ -1,0 +1,5 @@
+---
+'hive': minor
+---
+
+Allow to close the last tab in Laboratory

--- a/cypress/e2e/laboratory-collections.cy.ts
+++ b/cypress/e2e/laboratory-collections.cy.ts
@@ -16,6 +16,7 @@ beforeEach(() => {
         .first()
         .click();
       cy.get('[aria-label="Show Operation Collections"]').click();
+      laboratory.closeTabsUntilOneLeft();
     });
   });
 });

--- a/cypress/e2e/laboratory-tabs.cy.ts
+++ b/cypress/e2e/laboratory-tabs.cy.ts
@@ -1,0 +1,36 @@
+import { laboratory } from '../support/testkit';
+
+beforeEach(() => {
+  cy.clearAllLocalStorage().then(() => {
+    return cy.task('seedTarget').then(({ slug, refreshToken }: any) => {
+      cy.setCookie('sRefreshToken', refreshToken);
+
+      cy.visit(`/${slug}/laboratory`);
+    });
+  });
+});
+
+describe('Laboratory > Tabs', () => {
+  it('deleting the last tab should reset its state to defaults', () => {
+    const op1 = 'query { tab1 }';
+    const op2 = 'query { tab2 }';
+
+    // make sure there's only one tab
+    laboratory.closeTabsUntilOneLeft();
+    laboratory.updateEditorValue(op1);
+    laboratory.getEditorValue().should('eq', op1);
+
+    // open a new tab and update its value
+    laboratory.openNewTab();
+    laboratory.updateEditorValue(op2);
+    laboratory.getEditorValue().should('eq', op2);
+
+    // close the second tab
+    laboratory.closeActiveTab();
+    laboratory.getEditorValue().should('eq', op1);
+    // close the first tab
+    laboratory.closeActiveTab();
+    // it should reset the editor to its default state
+    laboratory.getEditorValue().should('not.eq', op1);
+  });
+});

--- a/cypress/support/testkit.ts
+++ b/cypress/support/testkit.ts
@@ -70,6 +70,18 @@ export const laboratory = {
       'exist',
     );
   },
+  closeActiveTab() {
+    cy.get('li.graphiql-tab-active > button.graphiql-tab-close').click();
+  },
+  closeTabsUntilOneLeft() {
+    cy.get('li.graphiql-tab').then($tabs => {
+      if ($tabs.length > 1) {
+        laboratory.closeActiveTab();
+        // Recurse until there's only one tab left
+        return laboratory.closeTabsUntilOneLeft();
+      }
+    });
+  },
 };
 
 export function dedent(strings: TemplateStringsArray, ...values: unknown[]): string {

--- a/patches/@graphiql__react.patch
+++ b/patches/@graphiql__react.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 8ca339a2ba2031f0c1e22f1d099fa9a571492107..1cf3e8c620dc2c3ad4cfc42e2feeb4ca4682163c 100644
+index 8ca339a2ba2031f0c1e22f1d099fa9a571492107..8639aaf06c35c5bea8e5384c7492641f9c6faf66 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
 @@ -1,6 +1,6 @@
@@ -248,7 +248,29 @@ index 8ca339a2ba2031f0c1e22f1d099fa9a571492107..1cf3e8c620dc2c3ad4cfc42e2feeb4ca
    const changeTab = useCallback(
      (index) => {
        setTabState((current) => {
-@@ -3432,6 +3415,7 @@ function EditorContextProvider(props) {
+@@ -3371,10 +3354,20 @@ function EditorContextProvider(props) {
+   const closeTab = useCallback(
+     (index) => {
+       setTabState((current) => {
+-        const updated = {
++        const updated = current.tabs.length === 1 ?  {
++          // If there is only one tab, "reset" it to the default state
++          tabs: [
++            createTab({
++              headers: defaultHeaders,
++              query: defaultQuery ?? DEFAULT_QUERY,
++            }),
++          ],
++          activeTabIndex: 0,
++        } : {
+           tabs: current.tabs.filter((_tab, i) => index !== i),
+           activeTabIndex: Math.max(current.activeTabIndex - 1, 0)
+         };
++        
+         storeTabs(updated);
+         setEditorValues(updated.tabs[updated.activeTabIndex]);
+         onTabChange == null ? void 0 : onTabChange(updated);
+@@ -3432,6 +3425,7 @@ function EditorContextProvider(props) {
    const value = useMemo(
      () => ({
        ...tabState,
@@ -256,7 +278,7 @@ index 8ca339a2ba2031f0c1e22f1d099fa9a571492107..1cf3e8c620dc2c3ad4cfc42e2feeb4ca
        addTab,
        changeTab,
        moveTab,
-@@ -3743,9 +3727,10 @@ function GraphiQLProvider({
+@@ -3743,9 +3737,10 @@ function GraphiQLProvider({
    storage,
    validationRules,
    variables,
@@ -269,7 +291,7 @@ index 8ca339a2ba2031f0c1e22f1d099fa9a571492107..1cf3e8c620dc2c3ad4cfc42e2feeb4ca
      EditorContextProvider,
      {
        defaultQuery,
-@@ -3776,6 +3761,7 @@ function GraphiQLProvider({
+@@ -3776,6 +3771,7 @@ function GraphiQLProvider({
                getDefaultFieldNames,
                fetcher,
                operationName,
@@ -277,7 +299,7 @@ index 8ca339a2ba2031f0c1e22f1d099fa9a571492107..1cf3e8c620dc2c3ad4cfc42e2feeb4ca
                children: /* @__PURE__ */ jsx(ExplorerContextProvider, { children: /* @__PURE__ */ jsx(
                  PluginContextProvider,
                  {
-@@ -3790,7 +3776,7 @@ function GraphiQLProvider({
+@@ -3790,7 +3786,7 @@ function GraphiQLProvider({
          }
        )
      }
@@ -286,7 +308,7 @@ index 8ca339a2ba2031f0c1e22f1d099fa9a571492107..1cf3e8c620dc2c3ad4cfc42e2feeb4ca
  }
  function useTheme(defaultTheme = null) {
    const storageContext = useStorageContext();
-@@ -4200,6 +4186,7 @@ export {
+@@ -4200,6 +4196,7 @@ export {
    TypeLink,
    UnStyledButton,
    VariableEditor,

--- a/patches/graphiql.patch
+++ b/patches/graphiql.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index d0d893ea0caffb6c1c70c5f95aed8ca49bc74701..ba3c02801e958c66fde9b813821e5a608f49b1cf 100644
+index d0d893ea0caffb6c1c70c5f95aed8ca49bc74701..738c53fe71b5cde39d288b11481da83eef380f04 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
 @@ -14,7 +14,7 @@ declare type AddSuffix<Obj extends Record<string, any>, Suffix extends string> =
@@ -11,8 +11,21 @@ index d0d893ea0caffb6c1c70c5f95aed8ca49bc74701..ba3c02801e958c66fde9b813821e5a60
  
  export declare namespace GraphiQL {
      var Logo: typeof GraphiQLLogo;
+diff --git a/dist/index.js b/dist/index.js
+index 8658855e3697ce1f5e8bd83afc2beecade922288..d94624983c04ef8efccf5b7fe0dd436ad5762136 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -392,7 +392,7 @@ function GraphiQLInterface(props) {
+         },
+         tab.title
+       ),
+-      tabs.length > 1 && /* @__PURE__ */ React.createElement(react.Tab.Close, { onClick: handleTabClose })
++      /* @__PURE__ */ React.createElement(react.Tab.Close, { onClick: handleTabClose })
+     ))
+   ), /* @__PURE__ */ React.createElement(react.Tooltip, { label: "New tab" }, /* @__PURE__ */ React.createElement(
+     react.UnStyledButton,
 diff --git a/dist/index.mjs b/dist/index.mjs
-index cf1a9036b4b35b7918da09ead6977e1e77724b8a..896dadb9c22b36ceee99776b87684f9e3899023d 100644
+index cf1a9036b4b35b7918da09ead6977e1e77724b8a..970cc4cda25ff74c49e542db51af558d7e0d277a 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
 @@ -1,4 +1,4 @@
@@ -39,7 +52,15 @@ index cf1a9036b4b35b7918da09ead6977e1e77724b8a..896dadb9c22b36ceee99776b87684f9e
      },
      /* @__PURE__ */ React.createElement(
        GraphiQLInterface,
-@@ -398,7 +400,7 @@ function GraphiQLInterface(props) {
+@@ -391,14 +393,14 @@ function GraphiQLInterface(props) {
+         },
+         tab.title
+       ),
+-      tabs.length > 1 && /* @__PURE__ */ React.createElement(Tab.Close, { onClick: handleTabClose })
++      /* @__PURE__ */ React.createElement(Tab.Close, { onClick: handleTabClose })
+     ))
+   ), /* @__PURE__ */ React.createElement(Tooltip, { label: "New tab" }, /* @__PURE__ */ React.createElement(
+     UnStyledButton,
      {
        type: "button",
        className: "graphiql-tab-add",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ patchedDependencies:
     hash: wz23vdqq6qtsz64wb433afnvou
     path: patches/@fastify__vite.patch
   '@graphiql/react':
-    hash: cxjlr4qnvqgvcsnnl2map34diy
+    hash: scbly4qchgvjjjrsxpgbcil634
     path: patches/@graphiql__react.patch
   '@graphql-eslint/eslint-plugin@3.20.1':
     hash: n437g5o7zq7pnxdxldn52uql2q
@@ -45,7 +45,7 @@ patchedDependencies:
     hash: b6pwqmrs3qqykctltsasvrfwti
     path: patches/got@14.4.5.patch
   graphiql:
-    hash: yjzkcog7ut7wshk4npre67txki
+    hash: slfrsoypyaawb5yvbcg5g5f3u4
     path: patches/graphiql.patch
   mjml-core@4.14.0:
     hash: zxxsxbqejjmcwuzpigutzzq6wa
@@ -1681,10 +1681,10 @@ importers:
         version: 6.0.7(patch_hash=wz23vdqq6qtsz64wb433afnvou)(@types/node@22.10.5)(less@4.2.0)(lightningcss@1.28.2)(terser@5.37.0)
       '@graphiql/plugin-explorer':
         specifier: 4.0.0-alpha.2
-        version: 4.0.0-alpha.2(@graphiql/react@1.0.0-alpha.4(patch_hash=cxjlr4qnvqgvcsnnl2map34diy)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.0.0-alpha.2(@graphiql/react@1.0.0-alpha.4(patch_hash=scbly4qchgvjjjrsxpgbcil634)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@graphiql/react':
         specifier: 1.0.0-alpha.4
-        version: 1.0.0-alpha.4(patch_hash=cxjlr4qnvqgvcsnnl2map34diy)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.0.0-alpha.4(patch_hash=scbly4qchgvjjjrsxpgbcil634)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@graphiql/toolkit':
         specifier: 0.9.1
         version: 0.9.1(@types/node@22.10.5)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)
@@ -1906,7 +1906,7 @@ importers:
         version: 11.16.1(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphiql:
         specifier: 4.0.0-alpha.5
-        version: 4.0.0-alpha.5(patch_hash=yjzkcog7ut7wshk4npre67txki)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.0.0-alpha.5(patch_hash=slfrsoypyaawb5yvbcg5g5f3u4)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -3901,6 +3901,7 @@ packages:
 
   '@fastify/vite@6.0.7':
     resolution: {integrity: sha512-+dRo9KUkvmbqdmBskG02SwigWl06Mwkw8SBDK1zTNH6vd4DyXbRvI7RmJEmBkLouSU81KTzy1+OzwHSffqSD6w==}
+    bundledDependencies: []
 
   '@floating-ui/core@1.2.6':
     resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}
@@ -16499,8 +16500,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
-      '@aws-sdk/client-sts': 3.596.0
+      '@aws-sdk/client-sso-oidc': 3.596.0
+      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -16607,11 +16608,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.596.0(@aws-sdk/client-sts@3.596.0)':
+  '@aws-sdk/client-sso-oidc@3.596.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.596.0
+      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -16650,7 +16651,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0)':
@@ -16784,11 +16784,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.596.0':
+  '@aws-sdk/client-sts@3.596.0(@aws-sdk/client-sso-oidc@3.596.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
+      '@aws-sdk/client-sso-oidc': 3.596.0
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -16827,6 +16827,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.723.0':
@@ -16940,7 +16941,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.596.0
+      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
       '@aws-sdk/credential-provider-env': 3.587.0
       '@aws-sdk/credential-provider-http': 3.596.0
       '@aws-sdk/credential-provider-process': 3.587.0
@@ -17059,7 +17060,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.587.0(@aws-sdk/client-sts@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.596.0
+      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.11
       '@smithy/types': 3.7.2
@@ -17234,7 +17235,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.587.0(@aws-sdk/client-sso-oidc@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
+      '@aws-sdk/client-sso-oidc': 3.596.0
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.11
       '@smithy/shared-ini-file-loader': 3.1.12
@@ -18641,15 +18642,15 @@ snapshots:
       graphql: 16.9.0
       typescript: 5.7.3
 
-  '@graphiql/plugin-explorer@4.0.0-alpha.2(@graphiql/react@1.0.0-alpha.4(patch_hash=cxjlr4qnvqgvcsnnl2map34diy)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@graphiql/plugin-explorer@4.0.0-alpha.2(@graphiql/react@1.0.0-alpha.4(patch_hash=scbly4qchgvjjjrsxpgbcil634)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@graphiql/react': 1.0.0-alpha.4(patch_hash=cxjlr4qnvqgvcsnnl2map34diy)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@graphiql/react': 1.0.0-alpha.4(patch_hash=scbly4qchgvjjjrsxpgbcil634)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphiql-explorer: 0.9.0(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphql: 16.9.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@graphiql/react@1.0.0-alpha.4(patch_hash=cxjlr4qnvqgvcsnnl2map34diy)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@graphiql/react@1.0.0-alpha.4(patch_hash=scbly4qchgvjjjrsxpgbcil634)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@graphiql/toolkit': 0.10.0(@types/node@22.10.5)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)
       '@headlessui/react': 1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -27622,9 +27623,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  graphiql@4.0.0-alpha.5(patch_hash=yjzkcog7ut7wshk4npre67txki)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  graphiql@4.0.0-alpha.5(patch_hash=slfrsoypyaawb5yvbcg5g5f3u4)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@graphiql/react': 1.0.0-alpha.4(patch_hash=cxjlr4qnvqgvcsnnl2map34diy)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@graphiql/react': 1.0.0-alpha.4(patch_hash=scbly4qchgvjjjrsxpgbcil634)(@codemirror/language@6.10.2)(@types/node@22.10.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql-ws@5.16.1(graphql@16.9.0))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphql: 16.9.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
Closing the last tab ends up replacing it with a new content (default query, default headers etc).
We can't simply close the last tab and show no tabs at all, it requires a lot of changes in GraphiQL.