### PR TITLE
Customizable default member role for OIDC users

### DIFF
--- a/.changeset/few-mice-buy.md
+++ b/.changeset/few-mice-buy.md
@@ -1,0 +1,5 @@
+---
+'hive': minor
+---
+
+Adds ability to select a default role for new OIDC users

--- a/cypress/e2e/app.cy.ts
+++ b/cypress/e2e/app.cy.ts
@@ -119,6 +119,36 @@ describe('oidc', () => {
     });
   });
 
+  it('default member role for first time oidc login', () => {
+    const organizationAdminUser = getUserData();
+    cy.visit('/');
+    cy.signup(organizationAdminUser);
+
+    const slug = generateRandomSlug();
+    cy.createOIDCIntegration(slug);
+
+    // Pick Admin role as the default role
+    cy.get('[data-cy="role-selector-trigger"]').click();
+    cy.contains('[data-cy="role-selector-item"]', 'Admin').click();
+    cy.visit('/logout');
+
+    // First time login
+    cy.clearAllCookies();
+    cy.clearAllLocalStorage();
+    cy.clearAllSessionStorage();
+    cy.get('a[href^="/auth/sso"]').click();
+    cy.get('input[name="slug"]').type(slug);
+    cy.get('button[type="submit"]').click();
+    // OIDC login
+    cy.get('input[id="Input_Username"]').type('test-user-2');
+    cy.get('input[id="Input_Password"]').type('password');
+    cy.get('button[value="login"]').click();
+
+    cy.get('[data-cy="organization-picker-current"]').contains(slug);
+    // Check if the user has the Admin role by checking if the Members tab is visible
+    cy.get(`a[href="/${slug}/view/members"]`).should('exist');
+  });
+
   it('oidc login for invalid url shows correct error message', () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();

--- a/cypress/e2e/app.cy.ts
+++ b/cypress/e2e/app.cy.ts
@@ -146,7 +146,7 @@ describe('oidc', () => {
 
     cy.get('[data-cy="organization-picker-current"]').contains(slug);
     // Check if the user has the Admin role by checking if the Members tab is visible
-    cy.get(`a[href="/${slug}/view/members"]`).should('exist');
+    cy.get(`a[href^="/${slug}/view/members"]`).should('exist');
   });
 
   it('oidc login for invalid url shows correct error message', () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -36,10 +36,6 @@ Cypress.Commands.add('createOIDCIntegration', (organizationSlug: string) => {
 
   cy.get('div[role="dialog"]').find('button[type="submit"]').last().click();
 
-  cy.url().then(url => {
-    return new URL(url).pathname.split('/')[0];
-  });
-
   return cy
     .get('div[role="dialog"]')
     .find('input[id="sign-in-uri"]')

--- a/packages/migrations/src/actions/2025.01.13T10-08-00.default-role.ts
+++ b/packages/migrations/src/actions/2025.01.13T10-08-00.default-role.ts
@@ -1,0 +1,11 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+export default {
+  name: '2025.01.13T10-08-00.default-role.ts',
+  // Adds a default role to OIDC integration
+  run: ({ sql }) => sql`
+    ALTER TABLE "oidc_integrations"
+    ADD COLUMN "default_role_id" UUID REFERENCES organization_member_roles(id)
+    ON DELETE SET NULL;
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2025.01.13T10-08-00.default-role.ts
+++ b/packages/migrations/src/actions/2025.01.13T10-08-00.default-role.ts
@@ -2,10 +2,23 @@ import { type MigrationExecutor } from '../pg-migrator';
 
 export default {
   name: '2025.01.13T10-08-00.default-role.ts',
-  // Adds a default role to OIDC integration
-  run: ({ sql }) => sql`
-    ALTER TABLE "oidc_integrations"
-    ADD COLUMN "default_role_id" UUID REFERENCES organization_member_roles(id)
-    ON DELETE SET NULL;
-  `,
+  // Adds a default role to OIDC integration and set index on "oidc_integrations"."default_role_id"
+  run: ({ sql }) => [
+    {
+      name: 'Add a column',
+      query: sql`
+      ALTER TABLE "oidc_integrations"
+      ADD COLUMN IF NOT EXISTS "default_role_id" UUID REFERENCES organization_member_roles(id)
+      ON DELETE SET NULL;
+    `,
+    },
+    {
+      name: 'Create an index',
+      query: sql`
+        CREATE INDEX IF NOT EXISTS "oidc_integrations_default_role_id_idx"
+        ON "oidc_integrations"("default_role_id")
+        WHERE "default_role_id" is not null;
+      `,
+    },
+  ],
 } satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2025.01.13T10-08-00.default-role.ts
+++ b/packages/migrations/src/actions/2025.01.13T10-08-00.default-role.ts
@@ -2,6 +2,7 @@ import { type MigrationExecutor } from '../pg-migrator';
 
 export default {
   name: '2025.01.13T10-08-00.default-role.ts',
+  noTransaction: true,
   // Adds a default role to OIDC integration and set index on "oidc_integrations"."default_role_id"
   run: ({ sql }) => [
     {

--- a/packages/migrations/src/actions/2025.01.13T10-08-00.default-role.ts
+++ b/packages/migrations/src/actions/2025.01.13T10-08-00.default-role.ts
@@ -15,7 +15,7 @@ export default {
     {
       name: 'Create an index',
       query: sql`
-        CREATE INDEX IF NOT EXISTS "oidc_integrations_default_role_id_idx"
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "oidc_integrations_default_role_id_idx"
         ON "oidc_integrations"("default_role_id")
         WHERE "default_role_id" is not null;
       `,

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -154,5 +154,6 @@ export const runPGMigrations = async (args: { slonik: DatabasePool; runTo?: stri
       await import('./actions/2025.01.02T00-00-00.legacy-user-org-cleanup'),
       await import('./actions/2025.01.09T00-00-00.legacy-member-scopes'),
       await import('./actions/2025.01.10T00.00.00.breaking-changes-request-count'),
+      await import('./actions/2025.01.13T10-08-00.default-role'),
     ],
   });

--- a/packages/services/api/src/modules/oidc-integrations/module.graphql.ts
+++ b/packages/services/api/src/modules/oidc-integrations/module.graphql.ts
@@ -19,6 +19,7 @@ export default gql`
     authorizationEndpoint: String!
     organization: Organization!
     oidcUserAccessOnly: Boolean!
+    defaultMemberRole: MemberRole!
   }
 
   extend type Mutation {
@@ -26,6 +27,9 @@ export default gql`
     updateOIDCIntegration(input: UpdateOIDCIntegrationInput!): UpdateOIDCIntegrationResult!
     deleteOIDCIntegration(input: DeleteOIDCIntegrationInput!): DeleteOIDCIntegrationResult!
     updateOIDCRestrictions(input: UpdateOIDCRestrictionsInput!): UpdateOIDCRestrictionsResult!
+    updateOIDCDefaultMemberRole(
+      input: UpdateOIDCDefaultMemberRoleInput!
+    ): UpdateOIDCDefaultMemberRoleResult!
   }
 
   type Subscription {
@@ -147,6 +151,27 @@ export default gql`
   }
 
   type UpdateOIDCRestrictionsError implements Error {
+    message: String!
+  }
+
+  input UpdateOIDCDefaultMemberRoleInput {
+    oidcIntegrationId: ID!
+    defaultMemberRoleId: ID!
+  }
+
+  """
+  @oneOf
+  """
+  type UpdateOIDCDefaultMemberRoleResult {
+    ok: UpdateOIDCDefaultMemberRoleOk
+    error: UpdateOIDCDefaultMemberRoleError
+  }
+
+  type UpdateOIDCDefaultMemberRoleOk {
+    updatedOIDCIntegration: OIDCIntegration!
+  }
+
+  type UpdateOIDCDefaultMemberRoleError implements Error {
     message: String!
   }
 `;

--- a/packages/services/api/src/modules/oidc-integrations/providers/oidc-integrations.provider.ts
+++ b/packages/services/api/src/modules/oidc-integrations/providers/oidc-integrations.provider.ts
@@ -363,6 +363,57 @@ export class OIDCIntegrationsProvider {
     } as const;
   }
 
+  async updateOIDCDefaultMemberRole(args: { oidcIntegrationId: string; roleId: string }) {
+    if (this.isEnabled() === false) {
+      return {
+        type: 'error',
+        message: 'OIDC integrations are disabled.',
+      } as const;
+    }
+
+    const oidcIntegration = await this.storage.getOIDCIntegrationById({
+      oidcIntegrationId: args.oidcIntegrationId,
+    });
+
+    if (oidcIntegration === null) {
+      return {
+        type: 'error',
+        message: 'Integration not found.',
+      } as const;
+    }
+
+    const viewer = await this.session.getViewer();
+    const [member, adminRole] = await Promise.all([
+      this.storage.getOrganizationMember({
+        organizationId: oidcIntegration.linkedOrganizationId,
+        userId: viewer.id,
+      }),
+      this.storage.getAdminOrganizationMemberRole({
+        organizationId: oidcIntegration.linkedOrganizationId,
+      }),
+    ]);
+
+    if (member?.role.id !== adminRole.id) {
+      return {
+        type: 'error',
+        message: 'You do not have permission to update the default member role.',
+      } as const;
+    }
+
+    await this.session.assertPerformAction({
+      organizationId: oidcIntegration.linkedOrganizationId,
+      action: 'oidc:modify',
+      params: {
+        organizationId: oidcIntegration.linkedOrganizationId,
+      },
+    });
+
+    return {
+      type: 'ok',
+      oidcIntegration: await this.storage.updateOIDCDefaultMemberRole(args),
+    } as const;
+  }
+
   async getOIDCIntegrationById(args: { oidcIntegrationId: string }) {
     if (this.isEnabled() === false) {
       return {

--- a/packages/services/api/src/modules/oidc-integrations/resolvers/Mutation/updateOIDCDefaultMemberRole.ts
+++ b/packages/services/api/src/modules/oidc-integrations/resolvers/Mutation/updateOIDCDefaultMemberRole.ts
@@ -1,0 +1,25 @@
+import { OIDCIntegrationsProvider } from '../../providers/oidc-integrations.provider';
+import type { MutationResolvers } from './../../../../__generated__/types';
+
+export const updateOIDCDefaultMemberRole: NonNullable<
+  MutationResolvers['updateOIDCDefaultMemberRole']
+> = async (_, { input }, { injector }) => {
+  const result = await injector.get(OIDCIntegrationsProvider).updateOIDCDefaultMemberRole({
+    roleId: input.defaultMemberRoleId,
+    oidcIntegrationId: input.oidcIntegrationId,
+  });
+
+  if (result.type === 'error') {
+    return {
+      error: {
+        message: result.message,
+      },
+    };
+  }
+
+  return {
+    ok: {
+      updatedOIDCIntegration: result.oidcIntegration,
+    },
+  };
+};

--- a/packages/services/api/src/modules/oidc-integrations/resolvers/OIDCIntegration.ts
+++ b/packages/services/api/src/modules/oidc-integrations/resolvers/OIDCIntegration.ts
@@ -1,3 +1,4 @@
+import { OrganizationManager } from '../../organization/providers/organization-manager';
 import { OIDCIntegrationsProvider } from '../providers/oidc-integrations.provider';
 import type { OidcIntegrationResolvers } from './../../../__generated__/types';
 
@@ -9,4 +10,27 @@ export const OIDCIntegration: OidcIntegrationResolvers = {
   clientId: oidcIntegration => oidcIntegration.clientId,
   clientSecretPreview: (oidcIntegration, _, { injector }) =>
     injector.get(OIDCIntegrationsProvider).getClientSecretPreview(oidcIntegration),
+  /**
+   * Fallbacks to Viewer if default member role is not set
+   */
+  defaultMemberRole: async (oidcIntegration, _, { injector }) => {
+    if (!oidcIntegration.defaultMemberRoleId) {
+      return injector.get(OrganizationManager).getViewerMemberRole({
+        organizationId: oidcIntegration.linkedOrganizationId,
+      });
+    }
+
+    const role = await injector.get(OrganizationManager).getMemberRole({
+      organizationId: oidcIntegration.linkedOrganizationId,
+      roleId: oidcIntegration.defaultMemberRoleId,
+    });
+
+    if (!role) {
+      throw new Error(
+        `Default role not found (role_id=${oidcIntegration.defaultMemberRoleId}, organization=${oidcIntegration.linkedOrganizationId})`,
+      );
+    }
+
+    return role;
+  },
 };

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -1419,6 +1419,20 @@ export class OrganizationManager {
     });
   }
 
+  async getViewerMemberRole(selector: { organizationId: string }) {
+    await this.session.assertPerformAction({
+      action: 'member:describe',
+      organizationId: selector.organizationId,
+      params: {
+        organizationId: selector.organizationId,
+      },
+    });
+
+    return this.storage.getViewerOrganizationMemberRole({
+      organizationId: selector.organizationId,
+    });
+  }
+
   async canDeleteRole(
     role: OrganizationMemberRole,
     currentUserScopes: readonly (

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -638,6 +638,11 @@ export interface Storage {
     oidcUserAccessOnly: boolean;
   }): Promise<OIDCIntegration>;
 
+  updateOIDCDefaultMemberRole(_: {
+    oidcIntegrationId: string;
+    roleId: string;
+  }): Promise<OIDCIntegration>;
+
   createCDNAccessToken(_: {
     id: string;
     targetId: string;

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -219,6 +219,7 @@ export interface OIDCIntegration {
   userinfoEndpoint: string;
   authorizationEndpoint: string;
   oidcUserAccessOnly: boolean;
+  defaultMemberRoleId: string | null;
 }
 
 export interface CDNAccessToken {

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -157,6 +157,7 @@ export interface oidc_integrations {
   client_id: string;
   client_secret: string;
   created_at: Date;
+  default_role_id: string | null;
   id: string;
   linked_organization_id: string;
   oauth_api_url: string | null;

--- a/packages/web/app/src/components/organization/members/common.tsx
+++ b/packages/web/app/src/components/organization/members/common.tsx
@@ -29,6 +29,7 @@ export function RoleSelector<T>(props: {
         reason?: string;
       };
   disabled?: boolean;
+  searchPlaceholder?: string;
   onSelect(role: Role<T>): void | Promise<void>;
   /**
    * It's only needed for the migration flow, where we need to be able to select no role.
@@ -46,7 +47,8 @@ export function RoleSelector<T>(props: {
       <PopoverTrigger asChild>
         <Button
           variant="outline"
-          className="ml-auto"
+          className="ml-auto flex items-center gap-x-4"
+          data-cy="role-selector-trigger"
           disabled={props.disabled === true || isBusy}
           onClick={() => {
             props.onBlur?.();
@@ -58,7 +60,7 @@ export function RoleSelector<T>(props: {
       </PopoverTrigger>
       <PopoverContent className="w-[400px] p-0" align="end">
         <Command>
-          <CommandInput placeholder="Select new role..." />
+          <CommandInput placeholder={props.searchPlaceholder ?? 'Search roles...'} />
           <CommandList>
             <CommandEmpty>No roles found.</CommandEmpty>
             <CommandGroup>
@@ -95,6 +97,7 @@ export function RoleSelector<T>(props: {
                             /[^a-z0-9\-\:\ ]+/gi,
                             '',
                           )}
+                          data-cy="role-selector-item"
                           onSelect={() => {
                             setPhase('busy');
                             setOpen(false);

--- a/packages/web/app/src/components/organization/members/list.tsx
+++ b/packages/web/app/src/components/organization/members/list.tsx
@@ -128,6 +128,7 @@ function OrganizationMemberRoleSwitcher(props: {
   return (
     <>
       <RoleSelector
+        searchPlaceholder="Select new role..."
         roles={roles}
         onSelect={async role => {
           try {

--- a/packages/web/app/src/components/organization/members/roles.tsx
+++ b/packages/web/app/src/components/organization/members/roles.tsx
@@ -14,6 +14,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -48,6 +49,7 @@ import { FragmentType, graphql, useFragment } from '@/gql';
 import { OrganizationAccessScope, ProjectAccessScope, TargetAccessScope } from '@/gql/graphql';
 import { scopes } from '@/lib/access/common';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Link } from '@tanstack/react-router';
 
 export const roleFormSchema = z.object({
   name: z
@@ -638,6 +640,9 @@ const OrganizationMemberRoleRow_MemberRoleFragment = graphql(`
 `);
 
 function OrganizationMemberRoleRow(props: {
+  organizationSlug: string;
+  canChangeOIDCDefaultRole: boolean;
+  isOIDCDefaultRole: boolean;
   role: FragmentType<typeof OrganizationMemberRoleRow_MemberRoleFragment>;
   onEdit(role: FragmentType<typeof OrganizationMemberRoleRow_MemberRoleFragment>): void;
   onDelete(role: FragmentType<typeof OrganizationMemberRoleRow_MemberRoleFragment>): void;
@@ -661,6 +666,39 @@ function OrganizationMemberRoleRow(props: {
                       <div className="font-medium">This role is locked</div>
                       <div className="text-sm text-gray-400">
                         Locked roles are created by the system and cannot be modified or deleted.
+                      </div>
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+          ) : null}
+          {props.isOIDCDefaultRole ? (
+            <div className="ml-2">
+              <TooltipProvider>
+                <Tooltip delayDuration={100}>
+                  <TooltipTrigger>
+                    <Badge variant="outline">default</Badge>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    <div className="flex flex-col items-start gap-y-2 p-2">
+                      <div className="font-medium">Default role for new members</div>
+                      <div className="text-sm text-gray-400">
+                        <p>New members will be assigned to this role by default.</p>
+                        <p>
+                          You can change it in the{' '}
+                          <Link
+                            to="/$organizationSlug/view/settings"
+                            hash="manage-oidc-integration"
+                            params={{
+                              organizationSlug: props.organizationSlug,
+                            }}
+                            className="underline"
+                          >
+                            OIDC settings
+                          </Link>
+                          .
+                        </p>
                       </div>
                     </div>
                   </TooltipContent>
@@ -770,8 +808,18 @@ const OrganizationMemberRoles_OrganizationFragment = graphql(`
     }
     me {
       id
+      role {
+        id
+        name
+      }
       ...OrganizationMemberRoleCreator_MeFragment
       ...OrganizationMemberRoleEditor_MeFragment
+    }
+    oidcIntegration {
+      id
+      defaultMemberRole {
+        id
+      }
     }
   }
 `);
@@ -912,6 +960,9 @@ export function OrganizationMemberRoles(props: {
           <tbody className="divide-y-[1px] divide-gray-500/20">
             {organization.memberRoles?.map(role => (
               <OrganizationMemberRoleRow
+                organizationSlug={organization.slug}
+                isOIDCDefaultRole={organization.oidcIntegration?.defaultMemberRole?.id === role.id}
+                canChangeOIDCDefaultRole={organization.me.role?.name === 'Admin'}
                 key={role.id}
                 role={role}
                 onEdit={() => setRoleToEdit(role)}

--- a/packages/web/app/src/components/organization/members/roles.tsx
+++ b/packages/web/app/src/components/organization/members/roles.tsx
@@ -685,20 +685,24 @@ function OrganizationMemberRoleRow(props: {
                       <div className="font-medium">Default role for new members</div>
                       <div className="text-sm text-gray-400">
                         <p>New members will be assigned to this role by default.</p>
-                        <p>
-                          You can change it in the{' '}
-                          <Link
-                            to="/$organizationSlug/view/settings"
-                            hash="manage-oidc-integration"
-                            params={{
-                              organizationSlug: props.organizationSlug,
-                            }}
-                            className="underline"
-                          >
-                            OIDC settings
-                          </Link>
-                          .
-                        </p>
+                        {props.canChangeOIDCDefaultRole ? (
+                          <p>
+                            You can change it in the{' '}
+                            <Link
+                              to="/$organizationSlug/view/settings"
+                              hash="manage-oidc-integration"
+                              params={{
+                                organizationSlug: props.organizationSlug,
+                              }}
+                              className="underline"
+                            >
+                              OIDC settings
+                            </Link>
+                            .
+                          </p>
+                        ) : (
+                          <p>Only admins can change it in the OIDC settings.</p>
+                        )}
                       </div>
                     </div>
                   </TooltipContent>

--- a/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
+++ b/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
@@ -658,7 +658,6 @@ function OIDCDefaultRoleSelector(props: {
       disabled={props.disabled}
       onSelect={async role => {
         if (role.id === defaultRole.id) {
-          // No need to update
           return;
         }
 

--- a/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
+++ b/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
@@ -37,6 +37,7 @@ import { cn } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation as useRQMutation } from '@tanstack/react-query';
 import { Link, useRouter } from '@tanstack/react-router';
+import { RoleSelector } from '../members/common';
 
 function CopyInput(props: { value: string; id?: string }) {
   const copy = useClipboard();
@@ -75,6 +76,16 @@ const OIDCIntegrationSection_OrganizationFragment = graphql(`
       ...UpdateOIDCIntegration_OIDCIntegrationFragment
       authorizationEndpoint
     }
+    memberRoles {
+      ...OIDCDefaultRoleSelector_MemberRoleFragment
+    }
+    me {
+      id
+      role {
+        id
+        name
+      }
+    }
   }
 `);
 
@@ -88,6 +99,7 @@ export function OIDCIntegrationSection(props: {
 }): ReactElement {
   const router = useRouter();
   const organization = useFragment(OIDCIntegrationSection_OrganizationFragment, props.organization);
+  const isAdmin = organization.me.role.name === 'Admin';
 
   const hash = router.latestLocation.hash;
   const openCreateModalHash = 'create-oidc-integration';
@@ -152,7 +164,10 @@ export function OIDCIntegrationSection(props: {
       />
       <ManageOIDCIntegrationModal
         key={organization.oidcIntegration?.id ?? 'noop'}
+        isAdmin={isAdmin}
+        organizationId={organization.id}
         oidcIntegration={organization.oidcIntegration ?? null}
+        memberRoles={organization.memberRoles ?? null}
         isOpen={isUpdateOIDCIntegrationModalOpen}
         close={closeModal}
         openCreateModalHash={openCreateModalHash}
@@ -547,40 +562,139 @@ function CreateOIDCIntegrationForm(props: {
 function ManageOIDCIntegrationModal(props: {
   isOpen: boolean;
   close: () => void;
-  oidcIntegration: FragmentType<typeof UpdateOIDCIntegration_OIDCIntegrationFragment> | null;
+  organizationId: string;
+  isAdmin: boolean;
   openCreateModalHash: string;
-}): ReactElement {
+  oidcIntegration: FragmentType<typeof UpdateOIDCIntegration_OIDCIntegrationFragment> | null;
+  memberRoles: Array<FragmentType<typeof OIDCDefaultRoleSelector_MemberRoleFragment>> | null;
+}) {
   const oidcIntegration = useFragment(
     UpdateOIDCIntegration_OIDCIntegrationFragment,
     props.oidcIntegration,
   );
 
-  return oidcIntegration == null ? (
-    <Dialog open={props.isOpen} onOpenChange={props.close}>
-      <DialogContent className={classes.modal}>
-        <DialogHeader>
-          <DialogTitle>Manage OpenID Connect Integration</DialogTitle>
-          <DialogDescription>
-            You are trying to update an OpenID Connect integration for an organization that has no
-            integration.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter className="space-x-2 text-right">
-          <Button variant="outline" onClick={props.close}>
-            Close
-          </Button>
-          <Button asChild>
-            <Link hash={props.openCreateModalHash}>Connect OIDC Provider</Link>
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  ) : (
+  if (oidcIntegration == null) {
+    return (
+      <Dialog open={props.isOpen} onOpenChange={props.close}>
+        <DialogContent className={classes.modal}>
+          <DialogHeader>
+            <DialogTitle>Manage OpenID Connect Integration</DialogTitle>
+            <DialogDescription>
+              You are trying to update an OpenID Connect integration for an organization that has no
+              integration.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="space-x-2 text-right">
+            <Button variant="outline" onClick={props.close}>
+              Close
+            </Button>
+            <Button asChild>
+              <Link hash={props.openCreateModalHash}>Connect OIDC Provider</Link>
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  if (!props.memberRoles) {
+    console.error('ManageOIDCIntegrationModal is missing member roles');
+    return null;
+  }
+
+  return (
     <UpdateOIDCIntegrationForm
       close={props.close}
       isOpen={props.isOpen}
+      isAdmin={props.isAdmin}
       key={oidcIntegration.id}
       oidcIntegration={oidcIntegration}
+      memberRoles={props.memberRoles}
+    />
+  );
+}
+
+const OIDCDefaultRoleSelector_MemberRoleFragment = graphql(`
+  fragment OIDCDefaultRoleSelector_MemberRoleFragment on MemberRole {
+    id
+    name
+    description
+  }
+`);
+
+const OIDCDefaultRoleSelector_UpdateMutation = graphql(`
+  mutation OIDCDefaultRoleSelector_UpdateMutation($input: UpdateOIDCDefaultMemberRoleInput!) {
+    updateOIDCDefaultMemberRole(input: $input) {
+      ok {
+        updatedOIDCIntegration {
+          id
+          defaultMemberRole {
+            ...OIDCDefaultRoleSelector_MemberRoleFragment
+          }
+        }
+      }
+      error {
+        message
+      }
+    }
+  }
+`);
+
+function OIDCDefaultRoleSelector(props: {
+  oidcIntegrationId: string;
+  disabled: boolean;
+  defaultRole: FragmentType<typeof OIDCDefaultRoleSelector_MemberRoleFragment>;
+  memberRoles: Array<FragmentType<typeof OIDCDefaultRoleSelector_MemberRoleFragment>>;
+}) {
+  const defaultRole = useFragment(OIDCDefaultRoleSelector_MemberRoleFragment, props.defaultRole);
+  const memberRoles = useFragment(OIDCDefaultRoleSelector_MemberRoleFragment, props.memberRoles);
+  const [_, mutate] = useMutation(OIDCDefaultRoleSelector_UpdateMutation);
+  const { toast } = useToast();
+
+  return (
+    <RoleSelector
+      roles={memberRoles}
+      defaultRole={defaultRole}
+      disabled={props.disabled}
+      onSelect={async role => {
+        if (role.id === defaultRole.id) {
+          // No need to update
+          return;
+        }
+
+        try {
+          const result = await mutate({
+            input: {
+              oidcIntegrationId: props.oidcIntegrationId,
+              defaultMemberRoleId: role.id,
+            },
+          });
+
+          if (result.data?.updateOIDCDefaultMemberRole.ok) {
+            toast({
+              title: 'Default member role updated',
+              description: `${role.name} is now the default role for new OIDC members`,
+            });
+            return;
+          }
+
+          toast({
+            title: 'Failed to update default member role',
+            description:
+              result.data?.updateOIDCDefaultMemberRole.error?.message ??
+              result.error?.message ??
+              'Please try again later',
+          });
+        } catch (error) {
+          toast({
+            title: 'Failed to update default member role',
+            description: 'Please try again later',
+            variant: 'destructive',
+          });
+          console.error(error);
+        }
+      }}
+      isRoleActive={_ => true}
     />
   );
 }
@@ -594,6 +708,10 @@ const UpdateOIDCIntegration_OIDCIntegrationFragment = graphql(`
     clientId
     clientSecretPreview
     oidcUserAccessOnly
+    defaultMemberRole {
+      id
+      ...OIDCDefaultRoleSelector_MemberRoleFragment
+    }
   }
 `);
 
@@ -648,6 +766,8 @@ function UpdateOIDCIntegrationForm(props: {
   close: () => void;
   isOpen: boolean;
   oidcIntegration: DocumentType<typeof UpdateOIDCIntegration_OIDCIntegrationFragment>;
+  isAdmin: boolean;
+  memberRoles: Array<FragmentType<typeof OIDCDefaultRoleSelector_MemberRoleFragment>>;
 }): ReactElement {
   const [oidcUpdateMutation, oidcUpdateMutate] = useMutation(
     UpdateOIDCIntegrationForm_UpdateOIDCIntegrationMutation,
@@ -771,8 +891,8 @@ function UpdateOIDCIntegrationForm(props: {
                 <Separator orientation="horizontal" />
 
                 <div className="space-y-5">
-                  <div className="text-lg font-medium">Restrictions</div>
-                  <div>
+                  <div className="text-lg font-medium">Other Options</div>
+                  <div className="space-y-5">
                     <div className="flex items-center justify-between space-x-4">
                       <div className="flex flex-col space-y-1 text-sm font-medium leading-none">
                         <p>OIDC-Only Access</p>
@@ -788,6 +908,28 @@ function UpdateOIDCIntegrationForm(props: {
                         checked={props.oidcIntegration.oidcUserAccessOnly}
                         onCheckedChange={onOidcUserAccessOnlyChange}
                         disabled={oidcRestrictionsMutation.fetching}
+                      />
+                    </div>
+                    <div
+                      className={cn(
+                        'flex items-center justify-between space-x-4',
+                        props.isAdmin ? null : 'cursor-not-allowed',
+                      )}
+                    >
+                      <div className="flex flex-col space-y-1 text-sm font-medium leading-none">
+                        <p>Default Member Role</p>
+                        <p className="text-muted-foreground text-xs font-normal leading-snug">
+                          This role is assigned to new members who sign in via OIDC.{' '}
+                          <span className="font-medium">
+                            Only members with the Admin role can modify it.
+                          </span>
+                        </p>
+                      </div>
+                      <OIDCDefaultRoleSelector
+                        disabled={!props.isAdmin}
+                        oidcIntegrationId={props.oidcIntegration.id}
+                        defaultRole={props.oidcIntegration.defaultMemberRole}
+                        memberRoles={props.memberRoles}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
Closes #6346

- [ ] follow-up PR with the product update

This feature is only relevant to organizations with OIDC enabled.
Every new OIDC users is added to the organization with the default role.
If a default role has not been yet configured, the `Viewer` system role is used instead.

Default role has `default` badge and instructions how to change it
![Default role tooltip](https://github.com/user-attachments/assets/ad4e0f49-b3cd-45a0-b9e0-45b46f284ac2)

Actual setting
![OIDC Settings](https://github.com/user-attachments/assets/75e8093d-682f-445c-aba4-fd7294dc9e78)
