### PR TITLE
Measure latency of RPC to rate-limit service and duration of report parsing

### DIFF
--- a/integration-tests/docker-compose.integration.yaml
+++ b/integration-tests/docker-compose.integration.yaml
@@ -240,6 +240,7 @@ services:
   usage:
     environment:
       RATE_LIMIT_ENDPOINT: '${RATE_LIMIT_ENDPOINT}'
+      RATE_LIMIT_TTL: 1000
       LOG_LEVEL: debug
     depends_on:
       broker:

--- a/integration-tests/tests/api/rate-limit/emails.spec.ts
+++ b/integration-tests/tests/api/rate-limit/emails.spec.ts
@@ -71,7 +71,7 @@ test('rate limit approaching and reached for organization', async () => {
 
   // Make sure we don't send the same email again
   const collectEvenMoreResult = await collectOperations([op, op]);
-  expect(collectEvenMoreResult.status).toEqual(200);
+  expect(collectEvenMoreResult.status).toEqual(429);
 
   await waitFor(5000);
 

--- a/packages/services/usage/package.json
+++ b/packages/services/usage/package.json
@@ -21,6 +21,7 @@
     "got": "14.4.5",
     "graphql": "16.9.0",
     "kafkajs": "2.2.4",
+    "lru-cache": "11.0.2",
     "pino-pretty": "11.3.0",
     "tiny-lru": "8.0.2",
     "zod": "3.24.1"

--- a/packages/services/usage/package.json
+++ b/packages/services/usage/package.json
@@ -22,7 +22,6 @@
     "graphql": "16.9.0",
     "kafkajs": "2.2.4",
     "lru-cache": "11.0.2",
-    "ms": "2.1.3",
     "pino-pretty": "11.3.0",
     "tiny-lru": "8.0.2",
     "zod": "3.24.1"

--- a/packages/services/usage/package.json
+++ b/packages/services/usage/package.json
@@ -22,6 +22,7 @@
     "graphql": "16.9.0",
     "kafkajs": "2.2.4",
     "lru-cache": "11.0.2",
+    "ms": "2.1.3",
     "pino-pretty": "11.3.0",
     "tiny-lru": "8.0.2",
     "zod": "3.24.1"

--- a/packages/services/usage/src/environment.ts
+++ b/packages/services/usage/src/environment.ts
@@ -22,6 +22,7 @@ const EnvironmentModel = zod.object({
   PORT: emptyString(NumberFromString.optional()),
   TOKENS_ENDPOINT: zod.string().url(),
   RATE_LIMIT_ENDPOINT: emptyString(zod.string().url().optional()),
+  RATE_LIMIT_TTL: emptyString(NumberFromString.optional()).default(30_000),
   ENVIRONMENT: emptyString(zod.string().optional()),
   RELEASE: emptyString(zod.string().optional()),
 });
@@ -141,6 +142,7 @@ export const env = {
     rateLimit: base.RATE_LIMIT_ENDPOINT
       ? {
           endpoint: base.RATE_LIMIT_ENDPOINT,
+          ttl: base.RATE_LIMIT_TTL,
         }
       : null,
   },

--- a/packages/services/usage/src/index.ts
+++ b/packages/services/usage/src/index.ts
@@ -72,10 +72,17 @@ async function main() {
       logger: server.log,
     });
 
-    const rateLimit = createUsageRateLimit({
-      endpoint: env.hive.rateLimit?.endpoint ?? null,
-      logger: server.log,
-    });
+    const rateLimit = createUsageRateLimit(
+      env.hive.rateLimit
+        ? {
+            endpoint: env.hive.rateLimit.endpoint,
+            ttlMs: env.hive.rateLimit.ttl,
+            logger: server.log,
+          }
+        : {
+            logger: server.log,
+          },
+    );
 
     server.route<{
       Body: unknown;

--- a/packages/services/usage/src/index.ts
+++ b/packages/services/usage/src/index.ts
@@ -16,6 +16,7 @@ import {
   httpRequestsWithNoAccess,
   httpRequestsWithNonExistingToken,
   httpRequestsWithoutToken,
+  parseReportDuration,
   tokensDuration,
   usedAPIVersion,
 } from './metrics';
@@ -71,12 +72,10 @@ async function main() {
       logger: server.log,
     });
 
-    const rateLimit = env.hive.rateLimit
-      ? createUsageRateLimit({
-          endpoint: env.hive.rateLimit.endpoint,
-          logger: server.log,
-        })
-      : null;
+    const rateLimit = createUsageRateLimit({
+      endpoint: env.hive.rateLimit?.endpoint ?? null,
+      logger: server.log,
+    });
 
     server.route<{
       Body: unknown;
@@ -160,25 +159,23 @@ async function main() {
           status: 'success',
         });
 
-        if (
-          await rateLimit
-            ?.isRateLimited({
-              id: tokenInfo.target,
-              type: 'operations-reporting',
-              token,
-              entityType: 'target',
-            })
-            .catch(error => {
-              authenticatedRequestLogger.error('Failed to check rate limit');
-              authenticatedRequestLogger.error(error);
-              Sentry.captureException(error, {
-                level: 'error',
-              });
+        const isRateLimited = await rateLimit
+          .isRateLimited({
+            targetId: tokenInfo.target,
+            token,
+          })
+          .catch(error => {
+            authenticatedRequestLogger.error('Failed to check rate limit');
+            authenticatedRequestLogger.error(error);
+            Sentry.captureException(error, {
+              level: 'error',
+            });
 
-              // If we can't check rate limit, we should not drop the report
-              return false;
-            })
-        ) {
+            // If we can't check rate limit, we should not drop the report
+            return false;
+          });
+
+        if (isRateLimited) {
           droppedReports
             .labels({ targetId: tokenInfo.target, orgId: tokenInfo.organization })
             .inc();
@@ -193,14 +190,15 @@ async function main() {
           return;
         }
 
-        const retentionInfo =
-          (await rateLimit?.getRetentionForTargetId?.(tokenInfo.target).catch(error => {
+        const retentionInfo = await rateLimit
+          .getRetentionForTargetId(tokenInfo.target)
+          .catch(error => {
             authenticatedRequestLogger.error(error);
             Sentry.captureException(error, {
               level: 'error',
             });
             return null;
-          })) || null;
+          });
 
         if (typeof retentionInfo !== 'number') {
           authenticatedRequestLogger.error('Failed to get retention info');
@@ -221,7 +219,10 @@ async function main() {
           }
 
           if (apiVersion === undefined || apiVersion === '1') {
-            const result = usageProcessorV1(server.log, req.body as any, tokenInfo, retentionInfo);
+            const result = measureParsing(
+              () => usageProcessorV1(server.log, req.body as any, tokenInfo, retentionInfo),
+              'v1',
+            );
             collect(result.report);
             stopTimer({
               status: 'success',
@@ -231,7 +232,10 @@ async function main() {
               operations: result.operations,
             });
           } else if (apiVersion === '2') {
-            const result = usageProcessorV2(server.log, req.body, tokenInfo, retentionInfo);
+            const result = measureParsing(
+              () => usageProcessorV2(server.log, req.body, tokenInfo, retentionInfo),
+              'v2',
+            );
 
             if (result.success === false) {
               stopTimer({
@@ -318,3 +322,17 @@ main().catch(err => {
   console.error(err);
   process.exit(1);
 });
+
+function measureParsing<T>(fn: () => T, version: 'v1' | 'v2'): T {
+  const stop = parseReportDuration.startTimer({ version });
+  try {
+    const result = fn();
+
+    return result;
+  } catch (error) {
+    Sentry.captureException(error);
+    throw error;
+  } finally {
+    stop();
+  }
+}

--- a/packages/services/usage/src/metrics.ts
+++ b/packages/services/usage/src/metrics.ts
@@ -16,6 +16,12 @@ export const tokensDuration = new metrics.Histogram({
   labelNames: ['status'],
 });
 
+export const rateLimitDuration = new metrics.Histogram({
+  name: 'usage_rate_limit_duration_seconds',
+  help: 'Duration of an HTTP Request to Rate Limit service in seconds',
+  labelNames: ['type'],
+});
+
 export const httpRequests = new metrics.Counter({
   name: 'usage_http_requests',
   help: 'Number of http requests',
@@ -107,5 +113,11 @@ export const estimationError = new metrics.Summary({
 export const usedAPIVersion = new metrics.Counter({
   name: 'used_api_version',
   help: 'The used API version (x-api-version header)',
+  labelNames: ['version'],
+});
+
+export const parseReportDuration = new metrics.Histogram({
+  name: 'usage_parse_duration_seconds',
+  help: 'Duration of parsing a report in seconds',
   labelNames: ['version'],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1532,6 +1532,9 @@ importers:
       kafkajs:
         specifier: 2.2.4
         version: 2.2.4
+      lru-cache:
+        specifier: 11.0.2
+        version: 11.0.2
       pino-pretty:
         specifier: 11.3.0
         version: 11.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1535,6 +1535,9 @@ importers:
       lru-cache:
         specifier: 11.0.2
         version: 11.0.2
+      ms:
+        specifier: 2.1.3
+        version: 2.1.3
       pino-pretty:
         specifier: 11.3.0
         version: 11.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1535,9 +1535,6 @@ importers:
       lru-cache:
         specifier: 11.0.2
         version: 11.0.2
-      ms:
-        specifier: 2.1.3
-        version: 2.1.3
       pino-pretty:
         specifier: 11.3.0
         version: 11.3.0


### PR DESCRIPTION
Replace the caching + deduplication of rate-limit RPC with lru-cache.fetch that has deduplication built-in (like we have in the tokens services).

I also added a timeout of 5s to rate-limit RPCs, to avoid waiting for it infinitely. The fallback values are: do not rate limit, data retention of 1 year anyway.

Latency of requests to the tokens service is measured already.