### PR TITLE
Move from tiny-lru to lru-cache in the usage service

### DIFF
--- a/packages/services/usage/package.json
+++ b/packages/services/usage/package.json
@@ -23,7 +23,6 @@
     "kafkajs": "2.2.4",
     "lru-cache": "11.0.2",
     "pino-pretty": "11.3.0",
-    "tiny-lru": "8.0.2",
     "zod": "3.24.1"
   }
 }

--- a/packages/services/usage/src/metrics.ts
+++ b/packages/services/usage/src/metrics.ts
@@ -1,10 +1,5 @@
 import { metrics } from '@hive/service-common';
 
-export const tokenCacheHits = new metrics.Counter({
-  name: 'usage_tokens_cache_hits',
-  help: 'Number of cache hits',
-});
-
 export const tokenRequests = new metrics.Counter({
   name: 'usage_tokens_requests',
   help: 'Number of requests to Tokens service',

--- a/packages/services/usage/src/tokens.ts
+++ b/packages/services/usage/src/tokens.ts
@@ -1,8 +1,8 @@
-import LRU from 'tiny-lru';
+import { LRUCache } from 'lru-cache';
 import { ServiceLogger } from '@hive/service-common';
 import type { TokensApi } from '@hive/tokens';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { tokenCacheHits, tokenRequests } from './metrics';
+import { tokenRequests } from './metrics';
 
 export enum TokenStatus {
   NotFound,
@@ -20,7 +20,6 @@ type Token = TokensResponse | TokenStatus;
 
 export function createTokens(config: { endpoint: string; logger: ServiceLogger }) {
   const endpoint = config.endpoint.replace(/\/$/, '');
-  const tokens = LRU<Promise<Token>>(1000, 30_000);
   const tokensApi = createTRPCProxyClient<TokensApi>({
     links: [
       httpLink({
@@ -32,44 +31,43 @@ export function createTokens(config: { endpoint: string; logger: ServiceLogger }
       }),
     ],
   });
-  async function fetchFreshToken(token: string) {
-    try {
-      const info = await tokensApi.getToken.query({
-        token,
-      });
+  const tokens = new LRUCache<string, Token>({
+    max: 1000,
+    ttl: 30_000,
+    allowStale: false,
+    // If a cache entry is stale or missing, this method is called
+    // to fill the cache with fresh data.
+    // This method is called only once per cache key,
+    // even if multiple requests are waiting for it.
+    async fetchMethod(token) {
+      tokenRequests.inc();
+      try {
+        const info = await tokensApi.getToken.query({
+          token,
+        });
 
-      if (info) {
-        const result = info.scopes.includes('target:registry:write')
-          ? {
-              target: info.target,
-              project: info.project,
-              organization: info.organization,
-              scopes: info.scopes,
-            }
-          : TokenStatus.NoAccess;
-        return result;
+        if (info) {
+          const result = info.scopes.includes('target:registry:write')
+            ? {
+                target: info.target,
+                project: info.project,
+                organization: info.organization,
+                scopes: info.scopes,
+              }
+            : TokenStatus.NoAccess;
+          return result;
+        }
+        return TokenStatus.NotFound;
+      } catch (error) {
+        config.logger.error('Failed to fetch fresh token', error);
+        return TokenStatus.NotFound;
       }
-      return TokenStatus.NotFound;
-    } catch (error) {
-      config.logger.error('Failed to fetch fresh token', error);
-      return TokenStatus.NotFound;
-    }
-  }
+    },
+  });
 
   return {
     async fetch(token: string) {
-      tokenRequests.inc();
-      const tokenInfo = await tokens.get(token);
-
-      if (!tokenInfo) {
-        const result = fetchFreshToken(token);
-        tokens.set(token, result);
-        return result;
-      }
-
-      tokenCacheHits.inc();
-
-      return tokenInfo ?? TokenStatus.NotFound;
+      return (await tokens.fetch(token)) ?? TokenStatus.NotFound;
     },
     isNotFound(token: Token): token is TokenStatus.NotFound {
       return token === TokenStatus.NotFound;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1538,9 +1538,6 @@ importers:
       pino-pretty:
         specifier: 11.3.0
         version: 11.3.0
-      tiny-lru:
-        specifier: 8.0.2
-        version: 8.0.2
       zod:
         specifier: 3.24.1
         version: 3.24.1


### PR DESCRIPTION
- Drops TTL for operation body validation cache, increases the capacity (from 5000 to 20_000 as we store now short strings) and uses a new cache key (`sha256(operation)`)
- Replaces current deduplication logic with built-in of LRU-cache