### PR TITLE
Add defaults for new columns to ConditionalBreakingChangeMetadataModel

### DIFF
--- a/packages/services/storage/src/schema-change-model.ts
+++ b/packages/services/storage/src/schema-change-model.ts
@@ -1007,8 +1007,8 @@ export const ConditionalBreakingChangeMetadataModel = z.object({
   settings: z.object({
     retentionInDays: z.number(),
     percentage: z.number(),
-    requestCount: z.number(),
-    breakingChangeFormula: z.enum(['PERCENTAGE', 'REQUEST_COUNT']),
+    requestCount: z.number().default(1),
+    breakingChangeFormula: z.enum(['PERCENTAGE', 'REQUEST_COUNT']).default('PERCENTAGE'),
     excludedClientNames: z.array(z.string()).nullable(),
     /** we keep both reference to id and name so in case target gets deleted we can still display the name */
     targets: z.array(


### PR DESCRIPTION
### Background

Fixed a bug introduced in https://github.com/graphql-hive/console/pull/6254
<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description
`ConditionalBreakingChangeMetadata` is stored in the `SchemaCheckModel` as a JSON column. Without defaulting this, saved check records fail the zod validation. Rather than migrate all past checks, set a default.

Another option is to make this nullable, but for simplicity when dealing with any breaking change data in our codebase, I prefer defaulting. That limits the amount of null checking or extra cases we have to handle elsewhere.
<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
