### PR TITLE
Use `hive` pkg version for published Docker images

### DIFF
--- a/.changeset/popular-pumpkins-grab.md
+++ b/.changeset/popular-pumpkins-grab.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Fix release and package flow for Docker images of `hive`

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,18 +5,38 @@ on:
       - main
 
 jobs:
+  # Release NPM packages and tarballs
+  package:
+    uses: ./.github/workflows/release-stable.yaml
+    secrets: inherit
+
   # Build all packages and applications, and creates Docker images.
   build:
+    needs:
+      - package
     uses: ./.github/workflows/build-and-dockerize.yaml
     with:
-      imageTag: ${{ github.sha }}
+      imageTag:
+        # prettier-ignore
+        ${{ needs.package.outputs.hivePublish == 'true' && needs.package.outputs.hiveVersion || github.sha }}
       publishSourceMaps: true
-      publishLatest: false
+      publishLatest: ${{ needs.package.outputs.hivePublish == 'true' }}
       targets: build
       uploadJavaScriptArtifacts: true
     secrets: inherit
 
-  # Trigger deployment
+  # Dockerize the CLI in case a CLI version was released
+  publish_docker_cli:
+    needs:
+      - package
+    uses: ./.github/workflows/dockerize-cli.yaml
+    if: ${{ needs.package.outputs.cliPublish == 'true' }}
+    with:
+      cliVersion: ${{ needs.package.outputs.cliVersion }}
+      publishLatest: true
+    secrets: inherit
+
+  # Trigger deployment for staging
   deploy:
     name: trigger staging deployment
     needs:
@@ -61,11 +81,6 @@ jobs:
   # Deploy Storybook to CloudFlare Pages
   storybook:
     uses: ./.github/workflows/storybook.yaml
-    secrets: inherit
-
-  # Release NPM packages and tarballs
-  package:
-    uses: ./.github/workflows/release-stable.yaml
     secrets: inherit
 
   # GraphQL Schema Publish

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -1,5 +1,18 @@
 on:
   workflow_call:
+    outputs:
+      hivePublish:
+        description: 'A boolean indicating whether hive pkg was published'
+        value: ${{ jobs.publish.outputs.hivePublish }}
+      hiveVersion:
+        description: 'A semver version of the hive pkg, in case it was published'
+        value: ${{ jobs.publish.outputs.hiveVersion }}
+      cliPublish:
+        description: 'A boolean indicating whether cli pkg was published'
+        value: ${{ jobs.publish.outputs.cliPublish }}
+      cliVersion:
+        description: 'A semver version of the cli pkg, in case it was published'
+        value: ${{ jobs.publish.outputs.cliVersion }}
 
 jobs:
   publish:
@@ -13,8 +26,10 @@ jobs:
       AWS_S3_ENDPOINT: https://6d5bc18cd8d13babe7ed321adba3d8ae.r2.cloudflarestorage.com
 
     outputs:
-      publish: ${{ steps.cli.outputs.publish }}
-      version: ${{ steps.cli.outputs.version }}
+      cliPublish: ${{ steps.cli.outputs.publish }}
+      cliVersion: ${{ steps.cli.outputs.version }}
+      hivePublish: ${{ steps.hive.outputs.publish }}
+      hiveVersion: ${{ steps.hive.outputs.version }}
 
     steps:
       - name: checkout
@@ -62,6 +77,17 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "publish=true" >> $GITHUB_OUTPUT
 
+      - name: extract published hive version
+        if:
+          steps.changesets.outputs.published && contains(steps.changesets.outputs.publishedPackages,
+          '"hive"')
+        id: hive
+        run: |
+          echo '${{steps.changesets.outputs.publishedPackages}}' > hive-ver.json
+          VERSION=`echo $(jq -r '.[] | select(.name | endswith("hive")).version' hive-ver.json)`
+          echo "hiveVersion=$VERSION" >> $GITHUB_OUTPUT
+          echo "hivePublish=true" >> $GITHUB_OUTPUT
+
       # Needed for `oclif pack win`
       - name: Install NSIS
         run: |
@@ -101,12 +127,3 @@ jobs:
           cd packages/libraries/router
           cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish --allow-dirty --no-verify
-
-  publish_docker_cli:
-    needs: [publish]
-    uses: ./.github/workflows/dockerize-cli.yaml
-    if: ${{ needs.publish.outputs.publish == 'true' }}
-    with:
-      cliVersion: ${{ needs.publish.outputs.version }}
-      publishLatest: true
-    secrets: inherit


### PR DESCRIPTION
- [x] Use `package` pipeline to extract the version of `hive` image 
- [x] Make things more parallelized (CLI Docker image can happen in parallel now, no need to block the Docker images release) 
