### PR TITLE
Fix the audit log export

### DIFF
--- a/.changeset/dirty-stingrays-press.md
+++ b/.changeset/dirty-stingrays-press.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Fix the audit log export

--- a/packages/services/api/src/modules/audit-logs/providers/audit-logs-manager.ts
+++ b/packages/services/api/src/modules/audit-logs/providers/audit-logs-manager.ts
@@ -7,7 +7,6 @@ import { Session } from '../../auth/lib/authz';
 import { type AwsClient } from '../../cdn/providers/aws';
 import { ClickHouse, sql } from '../../operations/providers/clickhouse-client';
 import { Emails, mjml } from '../../shared/providers/emails';
-import { IdTranslator } from '../../shared/providers/id-translator';
 import { Logger } from '../../shared/providers/logger';
 import { Storage } from '../../shared/providers/storage';
 import { formatToClickhouseDateTime } from './audit-log-recorder';
@@ -37,7 +36,6 @@ export class AuditLogManager {
     private emailProvider: Emails,
     private session: Session,
     private storage: Storage,
-    private idTranslator: IdTranslator,
   ) {
     this.logger = logger.child({ source: 'AuditLogManager' });
   }
@@ -45,7 +43,7 @@ export class AuditLogManager {
   async getAuditLogsByDateRange(
     organizationId: string,
     filter: { startDate: Date; endDate: Date },
-  ): Promise<{ data: AuditLogType[] }> {
+  ) {
     await this.session.assertPerformAction({
       action: 'auditLog:export',
       organizationId,
@@ -82,11 +80,7 @@ export class AuditLogManager {
       timeout: 10000,
     });
 
-    const data = AuditLogClickhouseArrayModel.parse(result.data);
-
-    return {
-      data,
-    };
+    return AuditLogClickhouseArrayModel.parse(result.data);
   }
 
   @traceFn('AuditLogsManager.exportAndSendEmail', {
@@ -103,7 +97,7 @@ export class AuditLogManager {
     }),
   })
   async exportAndSendEmail(
-    organizationSlug: string,
+    organizationId: string,
     filter: { startDate: Date; endDate: Date },
   ): Promise<
     | {
@@ -119,9 +113,6 @@ export class AuditLogManager {
         };
       }
   > {
-    const organizationId = await this.idTranslator.translateOrganizationId({
-      organizationSlug,
-    });
     await this.session.assertPerformAction({
       action: 'auditLog:export',
       organizationId,
@@ -132,7 +123,7 @@ export class AuditLogManager {
 
     const getAllAuditLogs = await this.getAuditLogsByDateRange(organizationId, filter);
 
-    if (!getAllAuditLogs || !getAllAuditLogs.data || getAllAuditLogs.data.length === 0) {
+    if (!getAllAuditLogs || !getAllAuditLogs || getAllAuditLogs.length === 0) {
       return {
         error: {
           message: 'No audit logs found for the given date range',
@@ -144,7 +135,7 @@ export class AuditLogManager {
       const { email } = await this.session.getViewer();
       const csvData = await new Promise<string>((resolve, reject) => {
         stringify(
-          getAllAuditLogs.data,
+          getAllAuditLogs,
           {
             header: true,
             columns: {

--- a/packages/services/api/src/modules/audit-logs/providers/audit-logs-types.ts
+++ b/packages/services/api/src/modules/audit-logs/providers/audit-logs-types.ts
@@ -340,7 +340,7 @@ const AuditLogClickhouseObjectModel = z.object({
   eventAction: z.enum(auditLogEventTypes as [string, ...string[]]),
   userId: z.string(),
   userEmail: z.string(),
-  metadata: z.string().transform(x => JSON.parse(x)),
+  metadata: z.string(),
 });
 
 export type AuditLogType = z.infer<typeof AuditLogClickhouseObjectModel>;

--- a/packages/services/api/src/modules/audit-logs/resolvers/Mutation/exportOrganizationAuditLog.ts
+++ b/packages/services/api/src/modules/audit-logs/resolvers/Mutation/exportOrganizationAuditLog.ts
@@ -1,12 +1,15 @@
 import { AuditLogManager } from '../../../audit-logs/providers/audit-logs-manager';
+import { IdTranslator } from '../../../shared/providers/id-translator';
 import type { MutationResolvers } from './../../../../__generated__/types';
 
 export const exportOrganizationAuditLog: NonNullable<
   MutationResolvers['exportOrganizationAuditLog']
-> = async (_parent, arg, ctx) => {
-  const auditLogManager = ctx.injector.get(AuditLogManager);
+> = async (_parent, arg, { injector }) => {
+  const organizationId = await injector
+    .get(IdTranslator)
+    .translateOrganizationId(arg.input.selector);
 
-  const result = await auditLogManager.exportAndSendEmail(arg.input.selector.organizationSlug, {
+  const result = await injector.get(AuditLogManager).exportAndSendEmail(organizationId, {
     endDate: arg.input.filter.endDate,
     startDate: arg.input.filter.startDate,
   });

--- a/packages/web/app/src/pages/organization-settings.tsx
+++ b/packages/web/app/src/pages/organization-settings.tsx
@@ -714,9 +714,8 @@ function AuditLogsOrganizationModal(props: {
     props.toggleModalOpen();
     form.reset();
     toast({
-      variant: 'warning',
-      title: 'Audit logs report started',
-      description: 'Your audit logs report is being generated. You will receive an email shortly.',
+      title: 'Audit logs report generated',
+      description: 'The audit logs report has been generated and will be sent to your email.',
     });
   }
 


### PR DESCRIPTION
`JSON.parse(metadata)` failed because some logs were not properly stringified.

There's no need to parse the JSON when reading, because in the csv report, it's stringified anyway.