### PR TITLE
Validate MDX links

### DIFF
--- a/.github/workflows/on-mdx-change.yaml
+++ b/.github/workflows/on-mdx-change.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   validate-mdx-links:
-    uses: the-guild-org/shared-config/.github/workflows/validate-mdx-links.yaml@validate-mdx-links
+    uses: the-guild-org/shared-config/.github/workflows/validate-mdx-links.yaml@main
     with:
       packageManager: pnpm
       cwd: packages/web/docs

--- a/.github/workflows/on-mdx-change.yaml
+++ b/.github/workflows/on-mdx-change.yaml
@@ -1,0 +1,20 @@
+name: on-mdx-change
+on:
+  pull_request:
+    # paths:
+    #   # we run to check if the links are wrong
+    #   - 'packages/web/docs/src/**/*.mdx'
+    #   # or if a page disappeared
+    #   - 'packages/web/docs/src/app/**'
+
+jobs:
+  validate-mdx-links:
+    uses: the-guild-org/shared-config/.github/workflows/validate-mdx-links.yaml@validate-mdx-links
+    with:
+      packageManager: pnpm
+      cwd: packages/web/docs
+      files: src/**/*.mdx
+      version: '1.0.6'
+    concurrency:
+      group: mdx-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/.github/workflows/on-mdx-change.yaml
+++ b/.github/workflows/on-mdx-change.yaml
@@ -1,11 +1,12 @@
 name: on-mdx-change
 on:
   pull_request:
-    # paths:
-    #   # we run to check if the links are wrong
-    #   - 'packages/web/docs/src/**/*.mdx'
-    #   # or if a page disappeared
-    #   - 'packages/web/docs/src/app/**'
+    paths:
+      # we run to check if the links are wrong
+      - 'packages/web/docs/src/**/*.mdx'
+      # or if a page disappeared
+      - 'packages/web/docs/src/pages/**'
+      - 'packages/web/docs/src/app/**'
 
 jobs:
   validate-mdx-links:

--- a/packages/web/docs/package.json
+++ b/packages/web/docs/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "next build && next-sitemap",
-    "dev": "next"
+    "dev": "next",
+    "validate-mdx-links": "pnpx validate-mdx-links@1.0.6 --files 'src/**/*.mdx'"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "1.2.2",

--- a/packages/web/docs/src/pages/docs/api-reference/client.mdx
+++ b/packages/web/docs/src/pages/docs/api-reference/client.mdx
@@ -4,8 +4,8 @@ import { Tabs } from '@theguild/components'
 # Hive Client
 
 **Hive Client** is a set of libraries and utilities for interacting with Hive, for both
-[Schema Registry](../features/schema-registry.mdx) and
-[Usage Reporting](../features/usage-reporting.mdx).
+[Schema Registry](/docs/schema-registry) and
+[Usage Reporting](../schema-registry/usage-reporting.mdx).
 
 ## Available Clients
 

--- a/packages/web/docs/src/pages/docs/gateway/other-features/custom-plugins.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/other-features/custom-plugins.mdx
@@ -335,13 +335,13 @@ Possible usage examples of this hook are:
 - Manipulate the request
 - Short circuit before Yoga handles the request
 
-| Payload field   | Description                                                                                                                                     |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `request`       | The incoming HTTP request as WHATWG `Request` object. [Learn more about the request](https://developer.mozilla.org/en-US/docs/Web/API/Request). |
-| `serverContext` | The early context object that is shared between all hooks and the GraphQL execution. [Learn more about the context](/docs/features/context).    |
-| `fetchAPI`      | WHATWG Fetch API implementation. [Learn more about the fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).                  |
-| `url`           | WHATWG URL object of the incoming request. [Learn more about the URL object](https://developer.mozilla.org/en-US/docs/Web/API/URL).             |
-| `endResponse`   | A function that allows you to end the request early and send a response to the client.                                                          |
+| Payload field   | Description                                                                                                                                                                                          |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `request`       | The incoming HTTP request as WHATWG `Request` object. [Learn more about the request](https://developer.mozilla.org/en-US/docs/Web/API/Request).                                                      |
+| `serverContext` | The early context object that is shared between all hooks and the GraphQL execution. [Learn more about the context](https://the-guild.dev/graphql/yoga-server/docs/features/context#server-context). |
+| `fetchAPI`      | WHATWG Fetch API implementation. [Learn more about the fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).                                                                       |
+| `url`           | WHATWG URL object of the incoming request. [Learn more about the URL object](https://developer.mozilla.org/en-US/docs/Web/API/URL).                                                                  |
+| `endResponse`   | A function that allows you to end the request early and send a response to the client.                                                                                                               |
 
 #### `onRequestParse`
 
@@ -375,12 +375,12 @@ to serve a result from the cache instead.
 
 Possible usage examples of this hook are:
 
-- **[Response Cache](/docs/features/response-caching)**: Short-circuit GraphQL execution if response
-  can be served from the cache.
-- **[Persisted Operations](/docs/features/persisted-operations):** Load the `query` document string
-  from the persisted operations store before running the execution.
-- **[APQ](/docs/features/automatic-persisted-queries):** Load/persist the `query` document string on
-  the persisted operations store.
+- **[Response Cache](https://the-guild.dev/graphql/yoga-server/docs/features/response-caching)**:
+  Short-circuit GraphQL execution if response can be served from the cache.
+- **[Persisted Operations](https://the-guild.dev/graphql/yoga-server/docs/features/persisted-operations):**
+  Load the `query` document string from the persisted operations store before running the execution.
+- **[APQ](https://the-guild.dev/graphql/yoga-server/docs/features/automatic-persisted-queries):**
+  Load/persist the `query` document string on the persisted operations store.
 
 | Payload field | Description                                                                                                                                                                                                      |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -444,7 +444,8 @@ into the after phase by returning a function (see [`onValidateDone`](#onvalidate
 
 **Example actions in this hook:**
 
-- Register additional validation rules (e.g. [Disable Introspection](/docs/features/introspection))
+- Register additional validation rules (e.g.
+  [Disable Introspection](https://the-guild.dev/graphql/yoga-server/docs/features/introspection))
 - Collect metrics about validation success/failures
 
 | Payload field       | Description                                                               |
@@ -819,11 +820,11 @@ Prefer `onRequestParse` when possible, or wrap the hook code in a `try` block.
 - Specify custom response format
 - Logging/Metrics
 
-| Field Name      | Description                                                                                                                                                   |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `request`       | The incoming HTTP request as WHATWG `Request` object. [Learn more about the request](https://developer.mozilla.org/en-US/docs/Web/API/Request).               |
-| `serverContext` | The final context object that is shared between all hooks and the GraphQL execution. [Learn more about the context](/docs/features/context).                  |
-| `response`      | The outgoing HTTP response as WHATWG `Response` object. [Learn more about the response interface](https://developer.mozilla.org/en-US/docs/Web/API/Response). |
+| Field Name      | Description                                                                                                                                                                                          |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `request`       | The incoming HTTP request as WHATWG `Request` object. [Learn more about the request](https://developer.mozilla.org/en-US/docs/Web/API/Request).                                                      |
+| `serverContext` | The final context object that is shared between all hooks and the GraphQL execution. [Learn more about the context](https://the-guild.dev/graphql/yoga-server/docs/features/context#server-context). |
+| `response`      | The outgoing HTTP response as WHATWG `Response` object. [Learn more about the response interface](https://developer.mozilla.org/en-US/docs/Web/API/Response).                                        |
 
 ### Plugin Context
 

--- a/packages/web/docs/src/pages/product-updates/2024-02-06-schema-contracts-for-federation.mdx
+++ b/packages/web/docs/src/pages/product-updates/2024-02-06-schema-contracts-for-federation.mdx
@@ -36,4 +36,4 @@ For each contract definition, Hive runs:
   publishing process. Each valid contract version is **published to the high-availability CDN** (SDL
   and Supergraph), allowing you to start an Apollo Router instance with the contract supergraph.
 
-[Head over to our documentation to learn more](/docs/management/contracts).
+[Head over to our documentation to learn more](/docs/schema-registry/contracts).


### PR DESCRIPTION
### Background

Uri gave me a pass to go on a refactor spree :) so I've split out `validate-mdx-links.yaml` from that big Nextra 4 PR to a new shared workflow.

### Description

This PR adds it here on a trigger _in PRs where MDX or pages change_ and fixes the broken and the outdated links.

- Broken: We had broken links in [gateway/other-features/custom-plugins](https://the-guild.dev/graphql/hive/docs/gateway/other-features/custom-plugins).
- Outdated: Some of the links were valid, but linking to an old route that was moved and had a rewrite still supporting it. I don't think it's worth to add rewrite handling to that validation script, because it makes sense to keep the links tidy and up to date anyway.

#### Screenshots

This is how it looks when it finds something:

<img width="1139" alt="image" src="https://github.com/user-attachments/assets/aef7d18e-2f9e-4073-ae96-80a5181ace8e" />

