### PR TITLE
Start typechecking docs/tailwind.config.ts, add `flattenColorPalette` types

### DIFF
--- a/packages/web/docs/src/deps.d.ts
+++ b/packages/web/docs/src/deps.d.ts
@@ -1,0 +1,5 @@
+declare module 'tailwindcss/lib/util/flattenColorPalette' {
+  export default function flattenColorPalette(
+    pallette: Record<string, string>,
+  ): Record<string, string>;
+}

--- a/packages/web/docs/tailwind.config.ts
+++ b/packages/web/docs/tailwind.config.ts
@@ -6,6 +6,7 @@ import { fontFamily } from 'tailwindcss/defaultTheme';
 import { default as flattenColorPalette } from 'tailwindcss/lib/util/flattenColorPalette';
 import plugin from 'tailwindcss/plugin';
 import tailwindTypography from '@tailwindcss/typography';
+// @ts-expect-error @theguild/tailwind-config types require moduleResolution: bundler
 import baseConfig from '@theguild/tailwind-config';
 
 const config: Config = {

--- a/packages/web/docs/tsconfig.json
+++ b/packages/web/docs/tsconfig.json
@@ -21,6 +21,6 @@
     ],
     "strictNullChecks": true
   },
-  "include": ["next-env.d.ts", "src", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "src", "*.ts", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### Background

I'm extracting this out from #6089 to make it smaller and easier to review.

### Description

I don't see a reason for not checking for errors in config files. Gives us better autocomplete and in the case of Tailwind, it ensures we don't mess up styles by accident.
