### PR TITLE
Fix 'MacOS' casing to 'macOS' in Apollo Router Hive Versioning

### DIFF
--- a/packages/web/docs/src/pages/product-updates/2024-11-19-apollo-router-hive-versioning.mdx
+++ b/packages/web/docs/src/pages/product-updates/2024-11-19-apollo-router-hive-versioning.mdx
@@ -43,7 +43,7 @@ For running instructions, see our [Docker usage guide](/docs/other-integrations/
 
 ### Binary Installation
 
-Download Apollo Router with Hive plugin for Linux (`x86_64`), MacOS (`x86_64`), or Windows
+Download Apollo Router with Hive plugin for Linux (`x86_64`), macOS (`x86_64`), or Windows
 (`x86_64`):
 
 ```bash


### PR DESCRIPTION
### Background

Extracted out from #6089. (It looks like I'm farming PRs for a Hacktoberfest T-Shirt :D)

### Description

<img width="717" alt="image" src="https://github.com/user-attachments/assets/7eca6447-c28d-4805-ac77-373a30291627" />
****