### PR TITLE
Update federation composition to 0.14.3

### DIFF
--- a/.changeset/good-countries-punch.md
+++ b/.changeset/good-countries-punch.md
@@ -1,0 +1,8 @@
+---
+'@graphql-hive/cli': patch
+'hive': patch
+---
+
+Update `@theguild/federation-composition` to [v0.14.3](https://github.com/the-guild-org/federation/releases/tag/v0.14.3)
+
+

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -60,7 +60,7 @@
     "@oclif/plugin-help": "6.0.22",
     "@oclif/plugin-update": "4.2.13",
     "@sinclair/typebox": "0.34.13",
-    "@theguild/federation-composition": "0.14.2",
+    "@theguild/federation-composition": "0.14.3",
     "colors": "1.4.0",
     "env-ci": "7.3.0",
     "graphql": "^16.8.1",

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -34,7 +34,7 @@
     "@sentry/node": "7.120.2",
     "@sentry/types": "7.120.2",
     "@slack/web-api": "7.8.0",
-    "@theguild/federation-composition": "0.14.2",
+    "@theguild/federation-composition": "0.14.3",
     "@trpc/client": "10.45.2",
     "@trpc/server": "10.45.2",
     "@types/bcryptjs": "2.4.6",

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -15,7 +15,7 @@
     "@graphql-tools/stitching-directives": "3.1.24",
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.120.2",
-    "@theguild/federation-composition": "0.14.2",
+    "@theguild/federation-composition": "0.14.3",
     "@trpc/server": "10.45.2",
     "@types/async-retry": "1.4.8",
     "@types/ioredis-mock": "8.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,8 +431,8 @@ importers:
         specifier: 0.34.13
         version: 0.34.13
       '@theguild/federation-composition':
-        specifier: 0.14.2
-        version: 0.14.2(graphql@16.9.0)
+        specifier: 0.14.3
+        version: 0.14.3(graphql@16.9.0)
       colors:
         specifier: 1.4.0
         version: 1.4.0
@@ -727,8 +727,8 @@ importers:
         specifier: 7.8.0
         version: 7.8.0
       '@theguild/federation-composition':
-        specifier: 0.14.2
-        version: 0.14.2(graphql@16.9.0)
+        specifier: 0.14.3
+        version: 0.14.3(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.2
         version: 10.45.2(@trpc/server@10.45.2)
@@ -1115,8 +1115,8 @@ importers:
         specifier: 7.120.2
         version: 7.120.2
       '@theguild/federation-composition':
-        specifier: 0.14.2
-        version: 0.14.2(graphql@16.9.0)
+        specifier: 0.14.3
+        version: 0.14.3(graphql@16.9.0)
       '@trpc/server':
         specifier: 10.45.2
         version: 10.45.2
@@ -7682,8 +7682,8 @@ packages:
       eslint: ^8 || ^9
       typescript: ^5
 
-  '@theguild/federation-composition@0.14.2':
-    resolution: {integrity: sha512-wMw3nPTIeaAEy2Mt+InIm/fWsNoAAUTfWyjg0VfzjNXhGknZZtF+EYzi+onVGQJkwxhuLmzNOtvVCbEIwuOAww==}
+  '@theguild/federation-composition@0.14.3':
+    resolution: {integrity: sha512-tcs6j+4mOyaRP2cbkdRk/3qCyKUM/FGhzXt3hGup/d7us309ts8r9F+f41IKjc0A8tVYR5b+YB9VW8hqy9vygg==}
     engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.0.0
@@ -23815,7 +23815,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  '@theguild/federation-composition@0.14.2(graphql@16.9.0)':
+  '@theguild/federation-composition@0.14.3(graphql@16.9.0)':
     dependencies:
       constant-case: 3.0.4
       debug: 4.3.4


### PR DESCRIPTION
The `transformSupergraphToPublicSchema` removes now `@policy`, `@requiresScopes` and `@authenticated`.

The public schema shouldn't have them.