### PR TITLE
Make the ecosystem link relative by passing `isHive`

### DIFF
--- a/packages/web/docs/src/components/landing-page.tsx
+++ b/packages/web/docs/src/components/landing-page.tsx
@@ -91,7 +91,7 @@ export function IndexPage(): ReactElement {
       <EnterpriseFocusedCards className="mx-4 my-6 md:mx-6" />
       <TeamSection className="mx-4 md:mx-6" />
       <CommunitySection className="mx-4 mt-6 md:mx-6" />
-      <ToolsAndLibrariesCards className="mx-4 mt-6 md:mx-6" />
+      <ToolsAndLibrariesCards isHive className="mx-4 mt-6 md:mx-6" />
       <FrequentlyAskedQuestions className="mx-4 md:mx-6" />
       <GetYourAPIGameRightSection className="mx-4 sm:mb-6 md:mx-6" />
     </Page>


### PR DESCRIPTION
### Background

<img width="700" alt="image" src="https://github.com/user-attachments/assets/4de61d6a-41fe-43ee-afea-9bafa34f21aa" />

### Description

Instead of a plain anchor to an "external" URL, we'll now render a Next.js Link.


