### PR TITLE
Show Impact metric in the Operations list on the Insights page.

### DIFF
--- a/.changeset/short-donkeys-live.md
+++ b/.changeset/short-donkeys-live.md
@@ -1,0 +1,12 @@
+---
+'hive': minor
+---
+
+Show Impact metric in the Operations list on the Insights page.
+Impact equals to the total time spent (p95) on this operation in the selected period in seconds.
+It helps assess which operations contribute the most to overall latency.
+
+
+```
+Impact = Requests * p95/1000
+```

--- a/.changeset/short-donkeys-live.md
+++ b/.changeset/short-donkeys-live.md
@@ -3,10 +3,10 @@
 ---
 
 Show Impact metric in the Operations list on the Insights page.
-Impact equals to the total time spent (p95) on this operation in the selected period in seconds.
+Impact equals to the total time spent on this operation in the selected period in seconds.
 It helps assess which operations contribute the most to overall latency.
 
 
 ```
-Impact = Requests * p95/1000
+Impact = Requests * avg/1000
 ```

--- a/packages/services/api/src/modules/operations/module.graphql.mappers.ts
+++ b/packages/services/api/src/modules/operations/module.graphql.mappers.ts
@@ -28,6 +28,7 @@ export interface OperationsStatsMapper {
   clients: readonly string[];
 }
 export interface DurationValuesMapper {
+  avg: number | null;
   p75: number | null;
   p90: number | null;
   p95: number | null;

--- a/packages/services/api/src/modules/operations/module.graphql.ts
+++ b/packages/services/api/src/modules/operations/module.graphql.ts
@@ -136,6 +136,7 @@ export default gql`
   }
 
   type DurationValues {
+    avg: Int!
     p75: Int!
     p90: Int!
     p95: Int!

--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -715,7 +715,7 @@ export class OperationsManager {
   }
 
   @cache<{ period: DateRange } & TargetSelector>(selector => JSON.stringify(selector))
-  async readDetailedDurationPercentiles({
+  async readDetailedDurationMetrics({
     period,
     organizationId: organization,
     projectId: project,
@@ -744,7 +744,7 @@ export class OperationsManager {
       },
     });
 
-    return this.reader.durationPercentiles({
+    return this.reader.durationMetrics({
       target,
       period,
       operations,

--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -32,7 +32,7 @@ function toUnixTimestamp(utcDate: string): any {
   return new UTCDate(iso).getTime();
 }
 
-export interface Percentiles {
+export interface DurationMetrics {
   avg: number;
   p75: number;
   p90: number;
@@ -40,23 +40,13 @@ export interface Percentiles {
   p99: number;
 }
 
-function toPercentiles(item: Percentiles | number[], avg: number) {
-  if (Array.isArray(item)) {
-    return {
-      avg,
-      p75: item[0],
-      p90: item[1],
-      p95: item[2],
-      p99: item[3],
-    };
-  }
-
+function toDurationMetrics(percentiles: [number, number, number, number], avg: number) {
   return {
     avg,
-    p75: item.p75,
-    p90: item.p90,
-    p95: item.p95,
-    p99: item.p99,
+    p75: percentiles[0],
+    p90: percentiles[1],
+    p95: percentiles[2],
+    p99: percentiles[3],
   };
 }
 
@@ -1726,7 +1716,7 @@ export class OperationsReader {
   }): Promise<
     Array<{
       date: any;
-      duration: Percentiles;
+      duration: DurationMetrics;
     }>
   > {
     return this.getDurationAndCountOverTime({
@@ -1748,9 +1738,10 @@ export class OperationsReader {
     period: DateRange;
     operations?: readonly string[];
     clients?: readonly string[];
-  }): Promise<Percentiles> {
+  }): Promise<DurationMetrics> {
     const result = await this.clickHouse.query<{
       percentiles: [number, number, number, number];
+      average: number;
     }>(
       this.pickAggregationByPeriod({
         query: aggregationTableName => sql`
@@ -1766,10 +1757,10 @@ export class OperationsReader {
       }),
     );
 
-    return toPercentiles(result.data[0].percentiles, result.data[0].average);
+    return toDurationMetrics(result.data[0].percentiles, result.data[0].average);
   }
 
-  async durationPercentiles({
+  async durationMetrics({
     target,
     period,
     operations,
@@ -1819,10 +1810,10 @@ export class OperationsReader {
       }),
     );
 
-    const collection = new Map<string, Percentiles>();
+    const collection = new Map<string, DurationMetrics>();
 
     result.data.forEach(row => {
-      collection.set(row.hash, toPercentiles(row.percentiles, row.average));
+      collection.set(row.hash, toDurationMetrics(row.percentiles, row.average));
     });
 
     return collection;
@@ -1946,7 +1937,7 @@ export class OperationsReader {
         date: toUnixTimestamp(row.date),
         total: ensureNumber(row.total),
         totalOk: ensureNumber(row.totalOk),
-        duration: toPercentiles(row.percentiles, row.average),
+        duration: toDurationMetrics(row.percentiles, row.average),
       };
     });
   }

--- a/packages/services/api/src/modules/operations/resolvers/ClientStats.ts
+++ b/packages/services/api/src/modules/operations/resolvers/ClientStats.ts
@@ -45,7 +45,7 @@ export const ClientStats: ClientStatsResolvers = {
         period,
         clients: clientName === 'unknown' ? ['unknown', ''] : [clientName],
       }),
-      operationsManager.readDetailedDurationPercentiles({
+      operationsManager.readDetailedDurationMetrics({
         organizationId: organization,
         projectId: project,
         targetId: target,

--- a/packages/services/api/src/modules/operations/resolvers/DurationValues.ts
+++ b/packages/services/api/src/modules/operations/resolvers/DurationValues.ts
@@ -2,6 +2,9 @@ import { nsToMs } from '../../../shared/helpers';
 import type { DurationValuesResolvers } from './../../../__generated__/types';
 
 export const DurationValues: DurationValuesResolvers = {
+  avg: value => {
+    return transformPercentile(value.avg);
+  },
   p75: value => {
     return transformPercentile(value.p75);
   },

--- a/packages/services/api/src/modules/operations/resolvers/OperationsStats.ts
+++ b/packages/services/api/src/modules/operations/resolvers/OperationsStats.ts
@@ -18,7 +18,7 @@ export const OperationsStats: OperationsStatsResolvers = {
         operations: operationsFilter,
         clients,
       }),
-      operationsManager.readDetailedDurationPercentiles({
+      operationsManager.readDetailedDurationMetrics({
         organizationId: organization,
         projectId: project,
         targetId: target,

--- a/packages/services/api/src/modules/operations/resolvers/SchemaCoordinateStats.ts
+++ b/packages/services/api/src/modules/operations/resolvers/SchemaCoordinateStats.ts
@@ -40,7 +40,7 @@ export const SchemaCoordinateStats: SchemaCoordinateStatsResolvers = {
         period,
         schemaCoordinate,
       }),
-      operationsManager.readDetailedDurationPercentiles({
+      operationsManager.readDetailedDurationMetrics({
         organizationId: organization,
         projectId: project,
         targetId: target,

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -59,7 +59,9 @@ function OperationRow({
   const p90 = useFormattedDuration(operation.p90);
   const p95 = useFormattedDuration(operation.p95);
   const p99 = useFormattedDuration(operation.p99);
-  const impact = useFormattedNumber(operation.impact);
+  const impact = useFormattedNumber(
+    operation.impact < 1000 ? Math.round(operation.impact * 100) / 100 : operation.impact,
+  );
 
   return (
     <>

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -40,11 +40,6 @@ interface Operation {
   hash: string;
 }
 
-const humanNumberFormatter = new Intl.NumberFormat('en-US', {
-  style: 'decimal',
-  notation: 'compact',
-});
-
 function OperationRow({
   operation,
   organizationSlug,
@@ -64,7 +59,7 @@ function OperationRow({
   const p90 = useFormattedDuration(operation.p90);
   const p95 = useFormattedDuration(operation.p95);
   const p99 = useFormattedDuration(operation.p99);
-  const impact = humanNumberFormatter.format(operation.impact);
+  const impact = useFormattedNumber(operation.impact);
 
   return (
     <>

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -362,6 +362,7 @@ const OperationsTableContainer_OperationsStatsFragment = graphql(`
           p90
           p95
           p99
+          avg
         }
         countOk
         count
@@ -417,7 +418,7 @@ function OperationsTableContainer({
           failureRate: (1 - op.countOk / op.count) * 100,
           requests: op.count,
           percentage: op.percentage,
-          impact: op.duration.p95 > 0 ? op.count * (op.duration.p95 / 1000) : 0,
+          impact: op.duration.avg > 0 ? op.count * (op.duration.avg / 1000) : 0,
           hash: op.operationHash!,
         });
       }

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -268,10 +268,10 @@ function OperationsTable({
                           </TooltipTrigger>
                           <TooltipContent className="max-w-[300px] text-left text-sm">
                             <p className="mb-4">
-                              Equals to the total time spent (p95) on this operation in the selected
+                              Equals to the total time spent on this operation in the selected
                               period in seconds.
                             </p>
-                            <code>Impact = Requests * p95/1000</code>
+                            <code>Impact = Requests * avg/1000</code>
                           </TooltipContent>
                         </Tooltip>
                       </TooltipProvider>

--- a/packages/web/app/src/components/v2/sortable.tsx
+++ b/packages/web/app/src/components/v2/sortable.tsx
@@ -1,14 +1,9 @@
 import { ComponentProps, ReactElement, ReactNode } from 'react';
-import { Tooltip } from '@/components/v2/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { TriangleUpIcon } from '@radix-ui/react-icons';
 import { SortDirection } from '@tanstack/react-table';
 
-export function Sortable({
-  children,
-  sortOrder,
-  otherColumnSorted,
-  onClick,
-}: {
+export function Sortable(props: {
   children: ReactNode;
   sortOrder: SortDirection | false;
   /**
@@ -16,28 +11,39 @@ export function Sortable({
    * It's used to show a different tooltip when sorting by multiple columns.
    */
   otherColumnSorted?: boolean;
-  onClick: ComponentProps<'button'>['onClick'];
+  onClick?: ComponentProps<'button'>['onClick'];
 }): ReactElement {
   const tooltipText =
-    sortOrder === false
-      ? 'Click to sort descending' + otherColumnSorted
+    props.sortOrder === false
+      ? 'Click to sort descending' + props.otherColumnSorted
         ? ' (hold shift to sort by multiple columns)'
         : ''
       : {
           asc: 'Click to cancel sorting',
           desc: 'Click to sort ascending',
-        }[sortOrder];
+        }[props.sortOrder];
 
   return (
-    <Tooltip content={tooltipText}>
-      <button className="flex items-center justify-center" onClick={onClick}>
-        <div>{children}</div>
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className="inline-flex items-center justify-center"
+            onClick={e => {
+              e.stopPropagation();
+              props.onClick?.(e);
+            }}
+          >
+            <div>{props.children}</div>
 
-        {sortOrder === 'asc' ? <TriangleUpIcon className="ml-2 text-orange-500" /> : null}
-        {sortOrder === 'desc' ? (
-          <TriangleUpIcon className="ml-2 rotate-180 text-orange-500" />
-        ) : null}
-      </button>
-    </Tooltip>
+            {props.sortOrder === 'asc' ? <TriangleUpIcon className="ml-2 text-orange-500" /> : null}
+            {props.sortOrder === 'desc' ? (
+              <TriangleUpIcon className="ml-2 rotate-180 text-orange-500" />
+            ) : null}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{tooltipText}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }


### PR DESCRIPTION
Impact equals to the total time spent on this operation in the selected period in seconds.
It helps assess which operations contribute the most to overall latency.

```
Impact = Requests * avg/1000
```

The result of that formula is formatted number:

```
1                = 1
1.5              = 1.5
10               = 10
10.5             = 11
100              = 100
554              = 554
1000             = 1K
1240             = 1.2K
10000            = 10K
10712            = 11K
100000           = 100K
321120.15        = 321K
1000000          = 1M
10000000         = 10M
100000000        = 100M
1000000000       = 1B
3123400000       = 3.1B
10000000000      = 10B
100000000000     = 100B
1000000000000    = 1T
10000000000000   = 10T
100000000000000  = 100T
```

A time unit could be used instead, but comparing seconds, minutes, hours, days, months, years... is awkward and much harder (9 weeks vs 4 months) than 23K vs 1M.


---

I also used a newer Tooltip component, so it looks much better.