### PR TITLE
Add typings for global.lab to Monaco Editor

### DIFF
--- a/.changeset/stupid-candles-arrive.md
+++ b/.changeset/stupid-candles-arrive.md
@@ -1,0 +1,5 @@
+---
+'hive': minor
+---
+
+Add type definitions of global.lab to Preflight Script editor

--- a/packages/web/app/src/lib/preflight-sandbox/graphiql-plugin.tsx
+++ b/packages/web/app/src/lib/preflight-sandbox/graphiql-plugin.tsx
@@ -28,7 +28,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { FragmentType, graphql, useFragment } from '@/gql';
 import { useLocalStorage, useToggle } from '@/lib/hooks';
 import { GraphiQLPlugin } from '@graphiql/react';
-import { Editor as MonacoEditor, OnMount } from '@monaco-editor/react';
+import { Editor as MonacoEditor, OnMount, type Monaco } from '@monaco-editor/react';
 import {
   Cross2Icon,
   CrossCircledIcon,
@@ -39,6 +39,7 @@ import {
 } from '@radix-ui/react-icons';
 import { useParams } from '@tanstack/react-router';
 import { cn } from '../utils';
+import labApiDefinitionRaw from './lab-api-declaration?raw';
 import type { LogMessage } from './preflight-script-worker';
 import { IFrameEvents } from './shared-types';
 
@@ -568,6 +569,18 @@ function PreflightScriptModal({
   const handleEnvEditorDidMount: OnMount = useCallback(editor => {
     envEditorRef.current = editor;
   }, []);
+
+  const handleMonacoEditorBeforeMount = useCallback((monaco: Monaco) => {
+    // Add custom typings for globalThis
+    monaco.languages.typescript.javascriptDefaults.addExtraLib(
+      `
+        ${labApiDefinitionRaw}
+        declare const lab: LabAPI;
+      `,
+      'global.d.ts',
+    );
+  }, []);
+
   const handleSubmit = useCallback(() => {
     onScriptValueChange(scriptEditorRef.current?.getValue() ?? '');
     onEnvValueChange(envEditorRef.current?.getValue() ?? '');
@@ -646,6 +659,7 @@ function PreflightScriptModal({
             </div>
             <MonacoEditor
               value={scriptValue}
+              beforeMount={handleMonacoEditorBeforeMount}
               onMount={handleScriptEditorDidMount}
               {...monacoProps.script}
               options={{

--- a/packages/web/app/src/lib/preflight-sandbox/lab-api-declaration.ts
+++ b/packages/web/app/src/lib/preflight-sandbox/lab-api-declaration.ts
@@ -1,0 +1,32 @@
+// The content of this file is used as a string
+// and feed into the context of the Monaco Editor and the Preflight Script.
+// The lack of `declare const lab: LabAPI` is intentional, to avoid messing up the global scope
+// of the web app codebase.
+// This could be a string in `graphiql-plugin.tsx`, but it's better to keep it in a separate file,
+// and use Prettier to format it, have syntax highlighting, etc.
+
+interface LabAPI {
+  /**
+   * [CryptoJS](https://cryptojs.gitbook.io/docs) library.
+   */
+  CryptoJS: any;
+  /**
+   * Use lab.environment API to store and retrieve data between requests
+   * or to pass values directly to HTTP headers for executed GraphQL requests.
+   */
+  environment: {
+    /**
+     * Returns the value of the environment variable with the given key.
+     */
+    get(key: string): unknown;
+    /**
+     * Sets the value of the environment variable with the given key.
+     */
+    set(key: string, value: unknown): void;
+  };
+  /**
+   * Mimics the \`prompt\` function in the browser, by sending a message to the main thread
+   * and waiting for a response.
+   */
+  prompt(message: string, defaultValue?: string): Promise<string>;
+}

--- a/packages/web/app/src/lib/preflight-sandbox/lab-api-declaration.ts
+++ b/packages/web/app/src/lib/preflight-sandbox/lab-api-declaration.ts
@@ -1,3 +1,5 @@
+/* eslint-disable  @typescript-eslint/no-unused-vars */
+
 // The content of this file is used as a string
 // and feed into the context of the Monaco Editor and the Preflight Script.
 // The lack of `declare const lab: LabAPI` is intentional, to avoid messing up the global scope


### PR DESCRIPTION
"Teaches" the Script Editor that `lab` exists. Simple and useful for Preflight Script users.

![lab.prompt](https://github.com/user-attachments/assets/8030fc04-46a3-48a5-be13-80e8a9da1860)

![lab.CryptoJS](https://github.com/user-attachments/assets/03626102-cfd1-47e8-8277-b38a5735d810)

![lab.environment](https://github.com/user-attachments/assets/5ef88ade-fd40-4ee7-800b-dca4182a9263)

![lab.environment.get](https://github.com/user-attachments/assets/b4ea9dc5-1725-43f3-9632-32181f8895a4)
