### PR TITLE
Use structured logs instead of strings in Preflight Script

### DIFF
--- a/cypress/e2e/laboratory-preflight-script.cy.ts
+++ b/cypress/e2e/laboratory-preflight-script.cy.ts
@@ -76,7 +76,7 @@ describe('Preflight Script Modal', () => {
   it('logs show console/error information', () => {
     setEditorScript(script);
     cy.dataCy('run-preflight-script').click();
-    cy.dataCy('console-output').should('contain', 'Log: Hello_world (Line: 1, Column: 1)');
+    cy.dataCy('console-output').should('contain', 'log: Hello_world (1:1)');
 
     setEditorScript(
       `console.info(1)
@@ -87,16 +87,11 @@ throw new TypeError('Test')`,
 
     cy.dataCy('run-preflight-script').click();
     // First log previous log message
-    cy.dataCy('console-output').should('contain', 'Log: Hello_world (Line: 1, Column: 1)');
+    cy.dataCy('console-output').should('contain', 'log: Hello_world (1:1)');
     // After the new logs
     cy.dataCy('console-output').should(
       'contain',
-      [
-        'Info: 1 (Line: 1, Column: 1)',
-        'Warn: true (Line: 2, Column: 1)',
-        'Error: Fatal (Line: 3, Column: 1)',
-        'TypeError: Test (Line: 4, Column: 7)',
-      ].join(''),
+      ['info: 1 (1:1)', 'warn: true (2:1)', 'error: Fatal (3:1)', 'error: Test (4:7)'].join(''),
     );
   });
 
@@ -104,7 +99,7 @@ throw new TypeError('Test')`,
     setEditorScript(script);
 
     cy.dataCy('run-preflight-script').click();
-    cy.dataCy('console-output').should('contain', 'Log: Hello_world (Line: 1, Column: 1)');
+    cy.dataCy('console-output').should('contain', 'log: Hello_world (1:1)');
 
     setEditorScript(
       dedent`
@@ -118,12 +113,12 @@ throw new TypeError('Test')`,
     cy.dataCy('prompt').get('form').submit();
 
     // First log previous log message
-    cy.dataCy('console-output').should('contain', 'Log: Hello_world (Line: 1, Column: 1)');
+    cy.dataCy('console-output').should('contain', 'log: Hello_world (1:1)');
     // After the new logs
     cy.dataCy('console-output').should(
       'contain',
       dedent`
-        Info: test-username (Line: 2, Column: 1)
+        info: test-username (2:1)
       `,
     );
   });
@@ -132,7 +127,7 @@ throw new TypeError('Test')`,
     setEditorScript(script);
 
     cy.dataCy('run-preflight-script').click();
-    cy.dataCy('console-output').should('contain', 'Log: Hello_world (Line: 1, Column: 1)');
+    cy.dataCy('console-output').should('contain', 'log: Hello_world (1:1)');
 
     setEditorScript(
       dedent`
@@ -146,12 +141,12 @@ throw new TypeError('Test')`,
     cy.dataCy('prompt').get('[data-cy="prompt-cancel"]').click();
 
     // First log previous log message
-    cy.dataCy('console-output').should('contain', 'Log: Hello_world (Line: 1, Column: 1)');
+    cy.dataCy('console-output').should('contain', 'log: Hello_world (1:1)');
     // After the new logs
     cy.dataCy('console-output').should(
       'contain',
       dedent`
-        Info: null (Line: 2, Column: 1)
+        info: null (2:1)
       `,
     );
   });
@@ -170,10 +165,10 @@ throw new TypeError('Test')`,
   it('`crypto-js` can be used for generating hashes', () => {
     setEditorScript('console.log(lab.CryptoJS.SHA256("🐝"))');
     cy.dataCy('run-preflight-script').click();
-    cy.dataCy('console-output').should('contain', 'Info: Using crypto-js version:');
+    cy.dataCy('console-output').should('contain', 'info: Using crypto-js version:');
     cy.dataCy('console-output').should(
       'contain',
-      'Log: d5b51e79e4be0c4f4d6b9a14e16ca864de96afe68459e60a794e80393a4809e8',
+      'log: d5b51e79e4be0c4f4d6b9a14e16ca864de96afe68459e60a794e80393a4809e8',
     );
   });
 
@@ -339,12 +334,12 @@ describe('Execution', () => {
     cy.get('#preflight-script-logs [data-cy="logs"]').should(
       'contain',
       [
-        '> start running script: > Start running script',
-        'info: 1 (Line: 1, Column: 1)',
-        'warn: true (Line: 2, Column: 1)',
-        'error: Fatal (Line: 3, Column: 1)',
-        'error: TypeError: Test (Line: 4, Column: 7)',
-        '> preflight script failed: > Preflight script failed',
+        'log: Running script...',
+        'info: 1 (1:1)',
+        'warn: true (2:1)',
+        'error: Fatal (3:1)',
+        'error: Test (4:7)',
+        'log: Script failed',
       ].join(''),
     );
   });
@@ -375,15 +370,16 @@ describe('Execution', () => {
       // it's because the button is not fully visible on the screen
       force: true,
     });
+
     cy.get('#preflight-script-logs [data-cy="logs"]').should(
       'contain',
       [
-        '> start running script: > Start running script',
-        'info: 1 (Line: 1, Column: 1)',
-        'warn: true (Line: 2, Column: 1)',
-        'error: Fatal (Line: 3, Column: 1)',
-        'error: TypeError: Test (Line: 4, Column: 7)',
-        '> preflight script failed: > Preflight script failed',
+        'log: Running script...',
+        'info: 1 (1:1)',
+        'warn: true (2:1)',
+        'error: Fatal (3:1)',
+        'error: Test (4:7)',
+        'log: Script failed',
       ].join(''),
     );
 

--- a/packages/web/app/src/lib/preflight-sandbox/preflight-worker-embed.ts
+++ b/packages/web/app/src/lib/preflight-sandbox/preflight-worker-embed.ts
@@ -71,9 +71,9 @@ function handleEvent(data: IFrameEvents.Incoming.EventData) {
       postMessage({
         type: IFrameEvents.Outgoing.Event.error,
         runId,
-        error: new Error(
-          `Preflight script execution timed out after ${PREFLIGHT_TIMEOUT / 1000} seconds`,
-        ),
+        error: {
+          message: `Preflight script execution timed out after ${PREFLIGHT_TIMEOUT / 1000} seconds`,
+        },
       });
       terminate();
     }, PREFLIGHT_TIMEOUT);
@@ -141,7 +141,9 @@ function handleEvent(data: IFrameEvents.Incoming.EventData) {
     postMessage({
       type: IFrameEvents.Outgoing.Event.error,
       runId,
-      error: error as Error,
+      error: {
+        message: String(error),
+      },
     });
     terminate();
   }

--- a/packages/web/app/src/lib/preflight-sandbox/shared-types.ts
+++ b/packages/web/app/src/lib/preflight-sandbox/shared-types.ts
@@ -2,6 +2,19 @@
 
 type _MessageEvent<T> = MessageEvent<T>;
 
+export type LogMessage = {
+  level: 'log' | 'warn' | 'error' | 'info';
+  message: string;
+  line?: number;
+  column?: number;
+};
+
+export type ErrorMessage = {
+  message: string;
+  line?: number;
+  column?: number;
+};
+
 export namespace IFrameEvents {
   export namespace Outgoing {
     export const enum Event {
@@ -25,7 +38,7 @@ export namespace IFrameEvents {
     type LogEventData = {
       type: Event.log;
       runId: string;
-      log: string | Error;
+      log: LogMessage;
     };
 
     type ResultEventData = {
@@ -37,7 +50,7 @@ export namespace IFrameEvents {
     type ErrorEventData = {
       type: Event.error;
       runId: string;
-      error: Error;
+      error: ErrorMessage;
     };
 
     type PromptEventData = {
@@ -100,8 +113,8 @@ export namespace WorkerEvents {
       prompt = 'prompt',
     }
 
-    type LogEventData = { type: Event.log; message: string };
-    type ErrorEventData = { type: Event.error; error: Error };
+    type LogEventData = { type: Event.log; message: LogMessage };
+    type ErrorEventData = { type: Event.error; error: ErrorMessage };
     type PromptEventData = {
       type: Event.prompt;
       promptId: number;

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -36,6 +36,7 @@ import { useSyncOperationState } from '@/lib/hooks/laboratory/use-sync-operation
 import { useOperationFromQueryString } from '@/lib/hooks/laboratory/useOperationFromQueryString';
 import { useResetState } from '@/lib/hooks/use-reset-state';
 import {
+  LogLine,
   LogRecord,
   preflightScriptPlugin,
   PreflightScriptProvider,
@@ -702,13 +703,6 @@ function PreflightScriptLogs(props: { logs: LogRecord[]; onClear: () => void }) 
     consoleEl?.scroll({ top: consoleEl.scrollHeight, behavior: 'smooth' });
   }, [props.logs, isOpen]);
 
-  const logColor = {
-    error: 'text-red-400',
-    info: 'text-emerald-400',
-    warn: 'text-yellow-400',
-    log: '', // default
-  };
-
   return (
     <Collapsible
       open={isOpen}
@@ -768,25 +762,9 @@ function PreflightScriptLogs(props: { logs: LogRecord[]; onClear: () => void }) 
           </div>
         ) : (
           <>
-            {props.logs.map((log, index) => {
-              if ('type' in log && log.type === 'separator') {
-                return <hr key={index} className="my-2 border-dashed border-current" />;
-              }
-
-              if (!('level' in log)) {
-                captureException(new Error('Unexpected log type in Preflight Script Logs'), {
-                  extra: { log },
-                });
-                return null;
-              }
-
-              return (
-                <div key={index} className={logColor[log.level] ?? ''}>
-                  {log.level}: {log.message} $
-                  {log.line && log.column ? `(${log.line}:${log.column})` : ''}
-                </div>
-              );
-            })}
+            {props.logs.map((log, index) => (
+              <LogLine key={index} log={log} />
+            ))}
           </>
         )}
       </CollapsibleContent>

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -769,20 +769,11 @@ function PreflightScriptLogs(props: { logs: LogRecord[]; onClear: () => void }) 
         ) : (
           <>
             {props.logs.map((log, index) => {
-              if (typeof log !== 'string' && 'type' in log && log.type === 'separator') {
+              if ('type' in log && log.type === 'separator') {
                 return <hr key={index} className="my-2 border-dashed border-current" />;
               }
 
-              let logType: 'error' | 'warn' | 'info' | 'log' = 'log';
-              let logMessage = '';
-
-              if (log instanceof Error) {
-                logType = 'error';
-                logMessage = `${log.name}: ${log.message}`;
-              } else if (typeof log === 'string') {
-                logType = log.split(':')[0].toLowerCase() as 'error' | 'warn' | 'info' | 'log';
-                logMessage = log.substring(log.indexOf(':') + 1).trim();
-              } else {
+              if (!('level' in log)) {
                 captureException(new Error('Unexpected log type in Preflight Script Logs'), {
                   extra: { log },
                 });
@@ -790,8 +781,9 @@ function PreflightScriptLogs(props: { logs: LogRecord[]; onClear: () => void }) 
               }
 
               return (
-                <div key={index} className={logColor[logType] ?? ''}>
-                  {logType}: {logMessage}
+                <div key={index} className={logColor[log.level] ?? ''}>
+                  {log.level}: {log.message} $
+                  {log.line && log.column ? `(${log.line}:${log.column})` : ''}
                 </div>
               );
             })}


### PR DESCRIPTION
Replaces
```
log: message (Line: 1, Column 2)
```
passed as a string, with
```
{
  level: ...,
  message: string
  line?: number
  column?: number
}
```

Same with the error event.