### PR TITLE
tests: match longer duration in log line replace to make unit tests mo…

### DIFF
--- a/packages/libraries/core/tests/test-utils.ts
+++ b/packages/libraries/core/tests/test-utils.ts
@@ -11,7 +11,7 @@ function getLogLines(calls: Array<Array<unknown>>) {
     if (typeof log[1] === 'string') {
       msg = log[1]
         // Replace milliseconds with static value
-        .replace(/\(\d{1,3}ms\)/, '(666ms)')
+        .replace(/\(\d{1,4}ms\)/, '(666ms)')
         // Replace stack trace line numbers with static value
         .replace(/\(node:net:\d+:\d+\)/, '(node:net:666:666)')
         .replace(/\(node:dns:\d+:\d+\)/, '(node:dns:666:666)');


### PR DESCRIPTION
…re consistent

### Background

Unit tests can take > 1s. If using the `createHiveTestingLogger` from `test-utils.ts`, then this can cause the log line to not replace the duration which breaks any snapshots.
<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

This change matches durations up to 9999ms which should help make our unit tests less flaky.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
