### PR TITLE
fix: load environment variables

### DIFF
--- a/packages/migrations/tools/db-connection-string.cjs
+++ b/packages/migrations/tools/db-connection-string.cjs
@@ -1,3 +1,8 @@
+require('dotenv').config({
+  debug: true,
+  encoding: 'utf8',
+});
+
 const {
   POSTGRES_USER = 'postgres',
   POSTGRES_PASSWORD = null,
@@ -10,6 +15,7 @@ const {
 
 function cn(dbName = POSTGRES_DB) {
   const user = encodeURIComponent(POSTGRES_USER);
+  console.log('WTF', POSTGRES_PASSWORD);
   const password =
     typeof POSTGRES_PASSWORD === 'string' ? `:${encodeURIComponent(POSTGRES_PASSWORD)}` : '';
   const host = encodeURIComponent(POSTGRES_HOST);

--- a/packages/migrations/tools/db-connection-string.cjs
+++ b/packages/migrations/tools/db-connection-string.cjs
@@ -15,7 +15,6 @@ const {
 
 function cn(dbName = POSTGRES_DB) {
   const user = encodeURIComponent(POSTGRES_USER);
-  console.log('WTF', POSTGRES_PASSWORD);
   const password =
     typeof POSTGRES_PASSWORD === 'string' ? `:${encodeURIComponent(POSTGRES_PASSWORD)}` : '';
   const host = encodeURIComponent(POSTGRES_HOST);


### PR DESCRIPTION
### Background

https://github.com/graphql-hive/console/pull/6123 broke the `pnpm start` script locally.

### Description

Attempt loading environment variables using dotenv.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
