### PR TITLE
Add `step=1` to Pricing slider

### DIFF
--- a/packages/web/docs/src/components/pricing.tsx
+++ b/packages/web/docs/src/components/pricing.tsx
@@ -216,6 +216,7 @@ function PricingSlider({ className, ...rest }: { className?: string }) {
           min={min}
           max={max}
           defaultValue={min}
+          step={1}
           // 10$ base price + 10$ per 1M
           style={{ '--ops': min, '--price': 'calc(10 + var(--ops) * 10)' }}
           counter="after:content-[''_counter(ops)_'M_operations,_$'_counter(price)_'_/_month'] after:[counter-set:ops_calc(var(--ops))_price_calc(var(--price))]"


### PR DESCRIPTION
### Background

This was incorrect:

<img width="270" alt="image" src="https://github.com/user-attachments/assets/bc7f1021-b461-40bc-9c6b-658aa061c6ca" />

### Description

We're using `step` instead of `Math.round` because it's not pay-for-usage rounded up to a million, you select a tier.


