### PR TITLE
improve(services/emails): debug log email

### DIFF
--- a/.changeset/proud-toys-shout.md
+++ b/.changeset/proud-toys-shout.md
@@ -1,0 +1,11 @@
+---
+'hive': minor
+---
+
+Emails Service: Debug log emails
+
+When developing Hive, working on Emails service, it is useful to see the output of emails since they will not actually be sent in development.
+
+Now when log level is set to debug, sent emails will be logged.
+
+Reminder: We strongly recommend to disable debug logs in production for performance and security reasons.

--- a/.changeset/proud-toys-shout.md
+++ b/.changeset/proud-toys-shout.md
@@ -8,4 +8,29 @@ When developing Hive, working on Emails service, it is useful to see the output 
 
 Now when log level is set to debug, sent emails will be logged.
 
-Reminder: We strongly recommend to disable debug logs in production for performance and security reasons.
+> [!CAUTION]
+> Remember that we strongly recommend to disable debug logs in production for performance and security reasons.
+
+### Example
+
+#### Before
+
+```
+[15:19:52] INFO: Sending email to jason3kuhrt@me.com
+[15:19:52] INFO: Email sent
+```
+
+#### After
+
+```
+[15:19:52] INFO: Sending email to jason3kuhrt@me.com
+[15:19:52] DEBUG:
+    event: "send_email"
+    email: {
+      "id": "{\"id\":\"org-invitation\",\"organization\":\"daedd972-df38-48c4-85c0-9ee566de9312\",\"code\":\"811fc5c94e2ebe608956079e75475ad0ec72fb3d9f2589aa1100fdbc57ec0d60\",\"email\":\"1d98be49fd18d4fa141b074bb085373e54817e39101319f81005b0e5cda73cb1\"}",
+      "email": "jason3kuhrt@me.com",
+      "subject": "You have been invited to join kuhrt",
+      "body": "\n          <mjml>\n            <mj-body>\n              <mj-section>\n                <mj-column>\n                  <mj-image width=\"150px\" src=\"https://graphql-hive.com/logo.png\"></mj-image>\n                  <mj-divider border-color=\"#ca8a04\"></mj-divider>\n                  <mj-text>\n                    Someone from <strong>kuhrt</strong> invited you to join GraphQL Hive.\n                  </mj-text>.\n                  <mj-button href=\"http://localhost:3000/join/c1edaa5e8\">\n                    Accept the invitation\n                  </mj-button>\n                </mj-column>\n              </mj-section>\n            </mj-body>\n          </mjml>\n        "
+    }
+[15:19:52] INFO: Email sent
+```

--- a/packages/services/emails/package.json
+++ b/packages/services/emails/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "tsx ../../../scripts/runify.ts",
-    "dev": "tsup-node --config ../../../configs/tsup/dev.config.node.ts src/dev.ts",
+    "dev": "LOG_LEVEL=debug tsup-node --config ../../../configs/tsup/dev.config.node.ts src/dev.ts",
     "postbuild": "copyfiles -f \"node_modules/bullmq/dist/esm/commands/*.lua\" dist && copyfiles -f \"node_modules/bullmq/dist/esm/commands/includes/*.lua\" dist/includes",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/services/emails/src/scheduler.ts
+++ b/packages/services/emails/src/scheduler.ts
@@ -71,6 +71,7 @@ export function createScheduler(config: {
       config.queueName,
       async job => {
         logger.info('Sending email to %s', job.data.email);
+        logger.debug({ event: 'send_email', email: job.data });
         let body = job.data.body;
         // Poor mans MJML check :)
         if (job.data.body.includes('<mjml>')) {


### PR DESCRIPTION
I wrote a changeset for this PR. It duplicates the description of this PR basically. You can refer to that for details about the PR. It doubles as the description that our users will experience too.

<details>

### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

When developing Hive, working on Emails service, it is useful to see the output of emails since they will not actually be sent in development.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

This PR adds a debug log for each email sent by Email service. It also changes our dev script to use debug log level.

I assume we recommend to our self-host users to not use debug log level in production for performance and security reasons. I also assume we apply that advice to ourselves. If so, this change should be safe.

Before:

```
[15:19:52] INFO: Sending email to jason3kuhrt@me.com
[15:19:52] INFO: Email sent
```

After:

```
[15:19:52] INFO: Sending email to jason3kuhrt@me.com
[15:19:52] DEBUG:
    event: "send_email"
    email: {
      "id": "{\"id\":\"org-invitation\",\"organization\":\"daedd972-df38-48c4-85c0-9ee566de9312\",\"code\":\"811fc5c94e2ebe608956079e75475ad0ec72fb3d9f2589aa1100fdbc57ec0d60\",\"email\":\"1d98be49fd18d4fa141b074bb085373e54817e39101319f81005b0e5cda73cb1\"}",
      "email": "jason3kuhrt@me.com",
      "subject": "You have been invited to join kuhrt",
      "body": "\n          <mjml>\n            <mj-body>\n              <mj-section>\n                <mj-column>\n                  <mj-image width=\"150px\" src=\"https://graphql-hive.com/logo.png\"></mj-image>\n                  <mj-divider border-color=\"#ca8a04\"></mj-divider>\n                  <mj-text>\n                    Someone from <strong>kuhrt</strong> invited you to join GraphQL Hive.\n                  </mj-text>.\n                  <mj-button href=\"http://localhost:3000/join/c1edaa5e8\">\n                    Accept the invitation\n                  </mj-button>\n                </mj-column>\n              </mj-section>\n            </mj-body>\n          </mjml>\n        "
    }
[15:19:52] INFO: Email sent
```



</details>

