### PR TITLE
chore(services/emails): fix development watch mode

### DIFF
--- a/packages/services/emails/package.json
+++ b/packages/services/emails/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "tsx ../../../scripts/runify.ts",
-    "dev": "tsup-node --config ../../../configs/tsup/dev.config.node.ts src/dev.ts",
+    "dev": "pnpm tsx watch src/dev.ts | pino-pretty --ignore time,pid,hostname",
     "postbuild": "copyfiles -f \"node_modules/bullmq/dist/esm/commands/*.lua\" dist && copyfiles -f \"node_modules/bullmq/dist/esm/commands/includes/*.lua\" dist/includes",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
When working locally on Emails service I reliably experience tsup being unable to wait for or force exit the previously running process for whatever reason.

![CleanShot 2025-01-24 at 10 47 46@2x](https://github.com/user-attachments/assets/2db40ee6-39b3-4efe-9d7a-fb30c9a9ea68)

When I switch to `tsx watch` I no longer experience this issue.

- This changes dev script for one service, but it would be confusing to only change one of our services. I have not investigated if other services have this issue. Maybe its not needed, if we are already aligned on just switching all to `tsx watch`.

- There is significantly more configuration for our `tsup` development setup which has not been ported over to `tsx` usage. Is it needed? I see some include paths that could be ported to `tsx`. Maybe even those are not needed though.
