### PR TITLE
dev: fix local federated schema seeds

### DIFF
--- a/scripts/seed-local-env.ts
+++ b/scripts/seed-local-env.ts
@@ -175,6 +175,9 @@ const publishMutationDocument =
 async function federation() {
   const instance = createInstance(null);
   const schemaInventory = /* GraphQL */ `
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.3",
+            import: ["@key", "@shareable", "@external", "@requires"])
     type Product implements ProductItf @key(fields: "id") {
       id: ID!
       dimensions: ProductDimension @external
@@ -205,6 +208,9 @@ async function federation() {
   `;
 
   const schemaPandas = /* GraphQL */ `
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.3",
+            import: ["@tag"])
     directive @tag(name: String!) repeatable on FIELD_DEFINITION
 
     type Query {
@@ -219,6 +225,9 @@ async function federation() {
   `;
 
   const schemaProducts = /* GraphQL */ `
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.3",
+            import: ["@key", "@shareable", "@inaccessible", "@tag"])
     directive @myDirective(a: String!) on FIELD_DEFINITION
     directive @hello on FIELD_DEFINITION
 
@@ -277,6 +286,10 @@ async function federation() {
   `;
 
   const schemaReviews = /* GraphQL */ `
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.3",
+            import: ["@key", "@shareable", "@override"])
+
     type Product implements ProductItf @key(fields: "id") {
       id: ID!
       reviewsCount: Int!
@@ -302,12 +315,15 @@ async function federation() {
   `;
 
   const schemaUsers = /* GraphQL */ `
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.3",
+            import: ["@key", "@tag", "@shareable"])
     directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT
 
     type User @key(fields: "email") {
       email: ID! @tag(name: "test-from-users")
       name: String
-      totalProductsCreated: Int
+      totalProductsCreated: Int @shareable
       createdAt: DateTime
     }
 

--- a/scripts/seed-local-env.ts
+++ b/scripts/seed-local-env.ts
@@ -176,8 +176,10 @@ async function federation() {
   const instance = createInstance(null);
   const schemaInventory = /* GraphQL */ `
     extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.3",
-            import: ["@key", "@shareable", "@external", "@requires"])
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.3"
+        import: ["@key", "@shareable", "@external", "@requires"]
+      )
     type Product implements ProductItf @key(fields: "id") {
       id: ID!
       dimensions: ProductDimension @external
@@ -208,9 +210,7 @@ async function federation() {
   `;
 
   const schemaPandas = /* GraphQL */ `
-    extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.3",
-            import: ["@tag"])
+    extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@tag"])
     directive @tag(name: String!) repeatable on FIELD_DEFINITION
 
     type Query {
@@ -226,8 +226,10 @@ async function federation() {
 
   const schemaProducts = /* GraphQL */ `
     extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.3",
-            import: ["@key", "@shareable", "@inaccessible", "@tag"])
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.3"
+        import: ["@key", "@shareable", "@inaccessible", "@tag"]
+      )
     directive @myDirective(a: String!) on FIELD_DEFINITION
     directive @hello on FIELD_DEFINITION
 
@@ -287,8 +289,10 @@ async function federation() {
 
   const schemaReviews = /* GraphQL */ `
     extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.3",
-            import: ["@key", "@shareable", "@override"])
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.3"
+        import: ["@key", "@shareable", "@override"]
+      )
 
     type Product implements ProductItf @key(fields: "id") {
       id: ID!
@@ -316,8 +320,7 @@ async function federation() {
 
   const schemaUsers = /* GraphQL */ `
     extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.3",
-            import: ["@key", "@tag", "@shareable"])
+      @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@tag", "@shareable"])
     directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT
 
     type User @key(fields: "email") {


### PR DESCRIPTION
### Background

Local development federated schema seed currently produces an invalid supergraph

```
FEDERATION=1 TOKEN="***" pnpm seed

```
<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

This adds the necessary imports so that the federated directives are understood by the native schema composer and a valid federated supergraph is produced.
<img width="1263" alt="Screenshot 2025-01-24 at 12 41 54 PM" src="https://github.com/user-attachments/assets/948484c5-7101-4734-bd8d-4cdf23f6fe51" />


<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
