### PR TITLE
Reject usage reports with incorrect duration and errorsTotal values

### DIFF
--- a/.changeset/healthy-flies-wink.md
+++ b/.changeset/healthy-flies-wink.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Improves validation for operation durations and error totals. Prevents processing of invalid usage report data.

--- a/cypress/e2e/usage.cy.ts
+++ b/cypress/e2e/usage.cy.ts
@@ -331,6 +331,7 @@ describe('usage reporting', () => {
   });
 
   it.only('partially corrupted usage report should be visible in Insights', () => {
+  it('partially corrupted usage report should be visible in Insights', () => {
     const organizationSlug = generateRandomSlug();
     const projectSlug = generateRandomSlug();
     const targetSlug = 'development';

--- a/cypress/e2e/usage.cy.ts
+++ b/cypress/e2e/usage.cy.ts
@@ -458,6 +458,38 @@ describe('usage reporting', () => {
           },
           {
             operationMapKey: 'op1',
+            // ERROR: negative timestamp
+            timestamp: -Date.now(),
+            execution: {
+              ok: true,
+              duration: 20_000_000,
+              errorsTotal: 0,
+            },
+            metadata: {
+              client: {
+                name: 'web',
+                version: 'v1.2.3',
+              },
+            },
+          },
+          {
+            operationMapKey: 'op1',
+            // ERROR: incorrect timestamp
+            timestamp: 1234,
+            execution: {
+              ok: true,
+              duration: 20_000_000,
+              errorsTotal: 0,
+            },
+            metadata: {
+              client: {
+                name: 'web',
+                version: 'v1.2.3',
+              },
+            },
+          },
+          {
+            operationMapKey: 'op1',
             timestamp: Date.now(),
             execution: {
               ok: true,

--- a/cypress/e2e/usage.cy.ts
+++ b/cypress/e2e/usage.cy.ts
@@ -62,6 +62,8 @@ function sendUsageReport(params: { report: Report }) {
         },
       });
 
+      cy.log('Response: ' + JSON.stringify(await res.clone().json()));
+
       expect(res.status).to.equal(200);
     })
     .wait(2000);
@@ -330,7 +332,6 @@ describe('usage reporting', () => {
     cy.get('h3').contains('Versions').parent().get('p').contains('vUnknown');
   });
 
-  it.only('partially corrupted usage report should be visible in Insights', () => {
   it('partially corrupted usage report should be visible in Insights', () => {
     const organizationSlug = generateRandomSlug();
     const projectSlug = generateRandomSlug();

--- a/cypress/e2e/usage.cy.ts
+++ b/cypress/e2e/usage.cy.ts
@@ -62,8 +62,6 @@ function sendUsageReport(params: { report: Report }) {
         },
       });
 
-      cy.log('Response: ' + JSON.stringify(await res.clone().json()));
-
       expect(res.status).to.equal(200);
     })
     .wait(2000);
@@ -103,27 +101,12 @@ describe('usage reporting', () => {
             timestamp: Date.now(),
             execution: {
               ok: true,
-              duration: 30_000_000,
+              duration: 200_000_000,
               errorsTotal: 0,
             },
             metadata: {
               client: {
                 name: 'ios',
-                version: 'v1.2.3',
-              },
-            },
-          },
-          {
-            operationMapKey: 'op1',
-            timestamp: Date.now(),
-            execution: {
-              ok: true,
-              duration: 50_000_000,
-              errorsTotal: 0,
-            },
-            metadata: {
-              client: {
-                name: 'android',
                 version: 'v1.2.3',
               },
             },
@@ -330,198 +313,5 @@ describe('usage reporting', () => {
     cy.get('h3').contains('Operations').parent().get('a').contains('_pong');
     cy.get('h3').contains('Versions').parent().get('p').contains('vUndefined');
     cy.get('h3').contains('Versions').parent().get('p').contains('vUnknown');
-  });
-
-  it('partially corrupted usage report should be visible in Insights', () => {
-    const organizationSlug = generateRandomSlug();
-    const projectSlug = generateRandomSlug();
-    const targetSlug = 'development';
-
-    createUserAndOrganization(organizationSlug);
-    waitForOrganizationPage(organizationSlug);
-
-    createProject(projectSlug);
-    waitForProjectPage(projectSlug);
-
-    // go to the development target
-    cy.get(`a[href="/${organizationSlug}/${projectSlug}/${targetSlug}"]`).click();
-    waitForTargetPage(targetSlug);
-
-    createRegistryAccessToken({ organizationSlug, projectSlug, targetSlug });
-
-    sendUsageReport({
-      report: {
-        size: 1,
-        map: {
-          op1: {
-            operation: 'query ping { ping }',
-            operationName: 'ping',
-            fields: ['Query', 'Query.ping'],
-          },
-        },
-        operations: [
-          {
-            operationMapKey: 'op1',
-            timestamp: Date.now(),
-            execution: {
-              ok: true,
-              // ERROR: negative value
-              duration: -300_000_000_000,
-              errorsTotal: 0,
-            },
-            metadata: {
-              client: {
-                name: 'ios',
-                version: 'v1.2.3',
-              },
-            },
-          },
-          {
-            operationMapKey: 'op1',
-            timestamp: Date.now(),
-            execution: {
-              ok: true,
-              duration: 10_000_000_000,
-              // ERROR: negative value
-              errorsTotal: -2,
-            },
-            metadata: {
-              client: {
-                name: 'web',
-                version: 'v1.2.3',
-              },
-            },
-          },
-          {
-            operationMapKey: 'op1',
-            timestamp: Date.now(),
-            execution: {
-              ok: true,
-              // ERROR: decimal
-              duration: 10_000_000_000.123,
-              errorsTotal: 0,
-            },
-            metadata: {
-              client: {
-                name: 'web',
-                version: 'v1.2.3',
-              },
-            },
-          },
-          {
-            operationMapKey: 'op1',
-            timestamp: Date.now(),
-            execution: {
-              ok: true,
-              duration: 10_000_000_000,
-              // ERROR: decimal
-              errorsTotal: 2.5,
-            },
-            metadata: {
-              client: {
-                name: 'web',
-                version: 'v1.2.3',
-              },
-            },
-          },
-          {
-            operationMapKey: 'op1',
-            timestamp: Date.now(),
-            execution: {
-              ok: true,
-              duration: 10_000_000_000,
-              // ERROR: too big value
-              errorsTotal: Math.pow(2, 30),
-            },
-            metadata: {
-              client: {
-                name: 'web',
-                version: 'v1.2.3',
-              },
-            },
-          },
-          {
-            operationMapKey: 'op1',
-            timestamp: Date.now(),
-            execution: {
-              ok: true,
-              // ERROR: too big value
-              duration: Math.pow(2, 64),
-              errorsTotal: 0,
-            },
-            metadata: {
-              client: {
-                name: 'web',
-                version: 'v1.2.3',
-              },
-            },
-          },
-          {
-            operationMapKey: 'op1',
-            // ERROR: negative timestamp
-            timestamp: -Date.now(),
-            execution: {
-              ok: true,
-              duration: 20_000_000,
-              errorsTotal: 0,
-            },
-            metadata: {
-              client: {
-                name: 'web',
-                version: 'v1.2.3',
-              },
-            },
-          },
-          {
-            operationMapKey: 'op1',
-            // ERROR: incorrect timestamp
-            timestamp: 1234,
-            execution: {
-              ok: true,
-              duration: 20_000_000,
-              errorsTotal: 0,
-            },
-            metadata: {
-              client: {
-                name: 'web',
-                version: 'v1.2.3',
-              },
-            },
-          },
-          {
-            operationMapKey: 'op1',
-            timestamp: Date.now(),
-            execution: {
-              ok: true,
-              duration: 50_000_000,
-              errorsTotal: 0,
-            },
-            metadata: {
-              client: {
-                name: 'android',
-                version: 'v1.2.3',
-              },
-            },
-          },
-        ],
-      },
-    });
-
-    // visit Insights
-    cy.visit(`/${organizationSlug}/${projectSlug}/${targetSlug}/insights`);
-    cy.get('h3').contains('Operations').parent().get('a').contains('_ping');
-    cy.get('h3').contains('Requests').parent().parent().get('div > div').contains('1');
-    // android should be reported
-    cy.visit(`/${organizationSlug}/${projectSlug}/${targetSlug}/insights/client/android`);
-    cy.get('h3').contains('Operations').parent().get('a').contains('_ping');
-    cy.get('h3').contains('Versions').parent().get('p').contains('v1.2.3');
-    // ios should not be reported (negative duration)
-    cy.visit(`/${organizationSlug}/${projectSlug}/${targetSlug}/insights/client/ios`);
-    cy.get('h3').contains('Operations').parent().get('a').should('not.contain', '_ping');
-    cy.get('h3').contains('Versions').parent().get('p').should('not.contain', 'v1.2.3');
-    // web should not be reported (negative values, decimals, too big values)
-    cy.visit(`/${organizationSlug}/${projectSlug}/${targetSlug}/insights/client/web`);
-    cy.get('h3').contains('Operations').parent().get('a').should('not.contain', '_ping');
-    cy.get('h3').contains('Versions').parent().get('p').should('not.contain', 'v1.2.3');
   });
 });

--- a/integration-tests/tests/usage-reporting/usage-reporting-format-1.spec.ts
+++ b/integration-tests/tests/usage-reporting/usage-reporting-format-1.spec.ts
@@ -12,12 +12,11 @@ test('valid operation is accepted', async () => {
   const response = await fetch(`http://${usageAddress}`, {
     method: 'POST',
     headers: {
-      'X-Usage-API-Version': '2',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({
-      size: 3,
+      size: 1,
       map: {
         c3b6d9b0: {
           operationName: 'me',
@@ -67,7 +66,6 @@ test('invalid operation is rejected', async () => {
   const response = await fetch(`http://${usageAddress}`, {
     method: 'POST',
     headers: {
-      'X-Usage-API-Version': '2',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
@@ -120,7 +118,6 @@ test('reject a report with a negative timestamp', async () => {
   const response = await fetch(`http://${usageAddress}`, {
     method: 'POST',
     headers: {
-      'X-Usage-API-Version': '2',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
@@ -146,7 +143,14 @@ test('reject a report with a negative timestamp', async () => {
       ],
     }),
   });
-  expect(response.status).toBe(400);
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({
+    id: expect.any(String),
+    operations: {
+      accepted: 0,
+      rejected: 1,
+    },
+  });
 });
 
 test('reject a report with an too short timestamp', async () => {
@@ -160,7 +164,6 @@ test('reject a report with an too short timestamp', async () => {
   const response = await fetch(`http://${usageAddress}`, {
     method: 'POST',
     headers: {
-      'X-Usage-API-Version': '2',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
@@ -186,7 +189,14 @@ test('reject a report with an too short timestamp', async () => {
       ],
     }),
   });
-  expect(response.status).toBe(400);
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({
+    id: expect.any(String),
+    operations: {
+      accepted: 0,
+      rejected: 1,
+    },
+  });
 });
 
 test('reject a report with a negative duration', async () => {
@@ -200,7 +210,6 @@ test('reject a report with a negative duration', async () => {
   const response = await fetch(`http://${usageAddress}`, {
     method: 'POST',
     headers: {
-      'X-Usage-API-Version': '2',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
@@ -226,7 +235,14 @@ test('reject a report with a negative duration', async () => {
       ],
     }),
   });
-  expect(response.status).toBe(400);
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({
+    id: expect.any(String),
+    operations: {
+      accepted: 0,
+      rejected: 1,
+    },
+  });
 });
 
 test('reject a report with a too big duration', async () => {
@@ -240,7 +256,6 @@ test('reject a report with a too big duration', async () => {
   const response = await fetch(`http://${usageAddress}`, {
     method: 'POST',
     headers: {
-      'X-Usage-API-Version': '2',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
@@ -266,7 +281,14 @@ test('reject a report with a too big duration', async () => {
       ],
     }),
   });
-  expect(response.status).toBe(400);
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({
+    id: expect.any(String),
+    operations: {
+      accepted: 0,
+      rejected: 1,
+    },
+  });
 });
 
 test('reject a report with a negative errorsTotal', async () => {
@@ -280,7 +302,6 @@ test('reject a report with a negative errorsTotal', async () => {
   const response = await fetch(`http://${usageAddress}`, {
     method: 'POST',
     headers: {
-      'X-Usage-API-Version': '2',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
@@ -306,7 +327,14 @@ test('reject a report with a negative errorsTotal', async () => {
       ],
     }),
   });
-  expect(response.status).toBe(400);
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({
+    id: expect.any(String),
+    operations: {
+      accepted: 0,
+      rejected: 1,
+    },
+  });
 });
 
 test('reject a report with a too big errorsTotal', async () => {
@@ -320,7 +348,6 @@ test('reject a report with a too big errorsTotal', async () => {
   const response = await fetch(`http://${usageAddress}`, {
     method: 'POST',
     headers: {
-      'X-Usage-API-Version': '2',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
@@ -346,5 +373,12 @@ test('reject a report with a too big errorsTotal', async () => {
       ],
     }),
   });
-  expect(response.status).toBe(400);
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({
+    id: expect.any(String),
+    operations: {
+      accepted: 0,
+      rejected: 1,
+    },
+  });
 });

--- a/packages/services/usage/src/usage-processor-1.ts
+++ b/packages/services/usage/src/usage-processor-1.ts
@@ -138,8 +138,8 @@ export const usageProcessorV1 = traceInlineSync(
     return {
       report: report,
       operations: {
-        accepted: size - report.size,
-        rejected: report.size,
+        accepted: report.size,
+        rejected: size - report.size,
       },
     };
   },

--- a/packages/services/usage/src/usage-processor-1.ts
+++ b/packages/services/usage/src/usage-processor-1.ts
@@ -214,11 +214,25 @@ function isUnixTimestamp(x: number) {
   return unixTimestampRegex.test(String(x));
 }
 
+// This is a custom format for positive integers (0 is allowed, decimals are not)
+// Maximum value is 18_446_744_073_709_551_615, but we stick to Math.pow(2, 63).
+// Using 2^64 in JS is problematic and 2^63 is more than enough.
+// https://clickhouse.com/docs/en/sql-reference/data-types/int-uint
+const maxUint64 = Math.pow(2, 63);
+const maxUInt16 = Math.pow(2, 16) - 1;
 const ajv = new Ajv({
   formats: {
     unix_timestamp_in_ms: {
       type: 'number',
       validate: isUnixTimestamp,
+    },
+    uint64: {
+      type: 'number',
+      validate: (x: number) => Number.isInteger(x) && x >= 0 && x <= maxUint64,
+    },
+    uint16: {
+      type: 'number',
+      validate: (x: number) => Number.isInteger(x) && x >= 0 && x <= maxUInt16,
     },
   },
 });
@@ -248,8 +262,8 @@ const operationSchema: JSONSchemaType<IncomingOperation> = {
       required: ['ok', 'duration', 'errorsTotal'],
       properties: {
         ok: { type: 'boolean' },
-        duration: { type: 'number' },
-        errorsTotal: { type: 'number' },
+        duration: { type: 'number', format: 'uint64' },
+        errorsTotal: { type: 'number', format: 'uint16' },
       },
     },
     metadata: {

--- a/packages/services/usage/src/usage-processor-2.ts
+++ b/packages/services/usage/src/usage-processor-2.ts
@@ -302,12 +302,20 @@ const PersistedDocumentHash = tb.Type.String({
   pattern: '^[a-zA-Z0-9_-]{1,64}~[a-zA-Z0-9._-]{1,64}~([A-Za-z]|[0-9]|_){1,128}$',
 });
 
+const unixTimestampRegex = /^\d{13,}$/;
+function isUnixTimestamp(x: number) {
+  return unixTimestampRegex.test(String(x));
+}
+
+tb.TypeRegistry.Set('UnixTimestampInMs', (_, value) =>
+  typeof value === 'number' ? isUnixTimestamp(value) : false,
+);
+const UnixTimestampInMs = { [tb.Kind]: 'UnixTimestampInMs' } as tb.TSchema;
+
 /** Query + Mutation */
 const RequestOperationSchema = tb.Type.Object(
   {
-    timestamp: tb.Type.Integer({
-      minimum: 1, // TODO: should be valid timestamp
-    }),
+    timestamp: UnixTimestampInMs,
     operationMapKey: tb.Type.String(),
     execution: ExecutionSchema,
     metadata: OptionalAndNullable(MetadataSchema),
@@ -322,9 +330,7 @@ const RequestOperationSchema = tb.Type.Object(
 /** Subscription / Live Query */
 const SubscriptionOperationSchema = tb.Type.Object(
   {
-    timestamp: tb.Type.Integer({
-      minimum: 1, // TODO: should be valid timestamp
-    }),
+    timestamp: UnixTimestampInMs,
     operationMapKey: tb.Type.String(),
     metadata: OptionalAndNullable(MetadataSchema),
     persistedDocumentHash: OptionalAndNullable(PersistedDocumentHash),
@@ -338,7 +344,7 @@ const SubscriptionOperationSchema = tb.Type.Object(
 export const ReportSchema = tb.Type.Object(
   {
     size: tb.Type.Integer({
-      minimum: 1, // TODO: should be valid timestamp
+      minimum: 1,
     }),
     map: tb.Record(tb.String(), OperationMapRecordSchema),
     operations: OptionalAndNullable(tb.Array(RequestOperationSchema)),

--- a/packages/services/usage/src/usage-processor-2.ts
+++ b/packages/services/usage/src/usage-processor-2.ts
@@ -307,10 +307,11 @@ function isUnixTimestamp(x: number) {
   return unixTimestampRegex.test(String(x));
 }
 
-tb.TypeRegistry.Set('UnixTimestampInMs', (_, value) =>
+tb.TypeRegistry.Set<number>('UnixTimestampInMs', (_, value) =>
   typeof value === 'number' ? isUnixTimestamp(value) : false,
 );
-const UnixTimestampInMs = { [tb.Kind]: 'UnixTimestampInMs' } as tb.TSchema;
+
+const UnixTimestampInMs = tb.Type.Unsafe<number>({ [tb.Kind]: 'UnixTimestampInMs' });
 
 /** Query + Mutation */
 const RequestOperationSchema = tb.Type.Object(

--- a/packages/services/usage/src/usage-processor-2.ts
+++ b/packages/services/usage/src/usage-processor-2.ts
@@ -306,7 +306,7 @@ const PersistedDocumentHash = tb.Type.String({
 const RequestOperationSchema = tb.Type.Object(
   {
     timestamp: tb.Type.Integer({
-      minimum: 1,
+      minimum: 1, // TODO: should be valid timestamp
     }),
     operationMapKey: tb.Type.String(),
     execution: ExecutionSchema,
@@ -323,7 +323,7 @@ const RequestOperationSchema = tb.Type.Object(
 const SubscriptionOperationSchema = tb.Type.Object(
   {
     timestamp: tb.Type.Integer({
-      minimum: 1,
+      minimum: 1, // TODO: should be valid timestamp
     }),
     operationMapKey: tb.Type.String(),
     metadata: OptionalAndNullable(MetadataSchema),
@@ -338,7 +338,7 @@ const SubscriptionOperationSchema = tb.Type.Object(
 export const ReportSchema = tb.Type.Object(
   {
     size: tb.Type.Integer({
-      minimum: 1,
+      minimum: 1, // TODO: should be valid timestamp
     }),
     map: tb.Record(tb.String(), OperationMapRecordSchema),
     operations: OptionalAndNullable(tb.Array(RequestOperationSchema)),

--- a/packages/services/usage/src/usage-processor-2.ts
+++ b/packages/services/usage/src/usage-processor-2.ts
@@ -256,8 +256,18 @@ type OperationMapRecord = tb.Static<typeof OperationMapRecordSchema>;
 const ExecutionSchema = tb.Type.Object(
   {
     ok: tb.Type.Boolean(),
-    duration: tb.Type.Integer(),
-    errorsTotal: tb.Type.Integer(),
+    duration: tb.Type.Integer({
+      // https://clickhouse.com/docs/en/sql-reference/data-types/int-uint
+      minimum: 0,
+      // Maximum value is 18_446_744_073_709_551_615, but we stick to Math.pow(2, 63).
+      // Using 2^64 in JS is problematic and 2^63 is more than enough.
+      maximum: Math.pow(2, 63),
+    }),
+    errorsTotal: tb.Type.Integer({
+      // https://clickhouse.com/docs/en/sql-reference/data-types/int-uint
+      minimum: 0,
+      maximum: Math.pow(2, 16) - 1,
+    }),
   },
   {
     title: 'Execution',
@@ -295,7 +305,9 @@ const PersistedDocumentHash = tb.Type.String({
 /** Query + Mutation */
 const RequestOperationSchema = tb.Type.Object(
   {
-    timestamp: tb.Type.Integer(),
+    timestamp: tb.Type.Integer({
+      minimum: 1,
+    }),
     operationMapKey: tb.Type.String(),
     execution: ExecutionSchema,
     metadata: OptionalAndNullable(MetadataSchema),
@@ -310,7 +322,9 @@ const RequestOperationSchema = tb.Type.Object(
 /** Subscription / Live Query */
 const SubscriptionOperationSchema = tb.Type.Object(
   {
-    timestamp: tb.Type.Integer(),
+    timestamp: tb.Type.Integer({
+      minimum: 1,
+    }),
     operationMapKey: tb.Type.String(),
     metadata: OptionalAndNullable(MetadataSchema),
     persistedDocumentHash: OptionalAndNullable(PersistedDocumentHash),
@@ -323,7 +337,9 @@ const SubscriptionOperationSchema = tb.Type.Object(
 
 export const ReportSchema = tb.Type.Object(
   {
-    size: tb.Type.Integer(),
+    size: tb.Type.Integer({
+      minimum: 1,
+    }),
     map: tb.Record(tb.String(), OperationMapRecordSchema),
     operations: OptionalAndNullable(tb.Array(RequestOperationSchema)),
     subscriptionOperations: OptionalAndNullable(tb.Array(SubscriptionOperationSchema)),


### PR DESCRIPTION
Improve validation for operation durations and errorTotals values. Make sure the values that are passed to ClickHouse are valid for column types.
Prevent processing of invalid usage report data and corrupting Kafka messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Validation Improvements**
  - Enhanced data validation for operation metrics.
  - Added stricter constraints for duration and error total fields.
  - Implemented specific type validation for timestamps.
  - Enforced minimum and maximum limits for numeric fields.

- **Data Integrity**
  - Improved type checking for usage reporting.
  - Prevented processing of invalid numeric data.
  - Ensured timestamps are valid 13-digit Unix millisecond values.

- **Testing Enhancements**
  - Introduced comprehensive tests for validating acceptance and rejection of usage reports based on various criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->