### PR TITLE
Make the CTA block sticky

### DIFF
--- a/packages/web/docs/src/app/case-studies/(posts)/layout.tsx
+++ b/packages/web/docs/src/app/case-studies/(posts)/layout.tsx
@@ -14,7 +14,7 @@ export default function CaseStudiesLayout({ children }: { children: React.ReactN
   return (
     <div className={cn(ONE_OFF_CLASS_CASE_STUDIES, 'mx-auto box-content max-w-[90rem]')}>
       <CaseStudiesHeader className="mx-auto max-w-[--nextra-content-width] pl-6 sm:my-12 md:pl-12 lg:my-24" />
-      <aside className="relative mx-auto max-w-[--nextra-content-width]">
+      <aside className="sticky top-[92px] mx-auto max-w-[--nextra-content-width]">
         <LookingToUseHiveUpsellBlock className="absolute right-2 top-4 max-lg:hidden lg:w-[320px] xl:w-[400px]" />
       </aside>
       {children}


### PR DESCRIPTION
### Background

[Saihaj's request](https://northstar-e5s5760.slack.com/archives/C07DYCW4NUD/p1738155408019639)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the positioning of the case studies layout sidebar to be sticky with a top offset of 92 pixels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->