### PR TITLE
fix(install-gateway-script): use escaped version of `@` to support CURL versions not escaping

### DIFF
--- a/packages/web/docs/public/install-gateway.sh
+++ b/packages/web/docs/public/install-gateway.sh
@@ -24,7 +24,7 @@ fetch_and_prepare_binary() {
   architecture="$ARCH_DETECTED"
   check_non_empty "$architecture" "architecture"
 
-  RELEASE_TAG="hive-gateway@$TARGET_VERSION"
+  RELEASE_TAG="hive-gateway%40$TARGET_VERSION"
 
   DOWNLOAD_URL="https://github.com/$GITHUB_OWNER/$GITHUB_REPO/releases/download/$RELEASE_TAG/$BINARY_NAME-${architecture}.gz"
 


### PR DESCRIPTION

Fixes https://github.com/graphql-hive/gateway/issues/558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated installation script to improve URL compatibility for downloading gateway binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->