### PR TITLE
Stop overflowing the upsell block on top of the footer

### DIFF
--- a/packages/web/docs/src/app/case-studies/(posts)/layout.tsx
+++ b/packages/web/docs/src/app/case-studies/(posts)/layout.tsx
@@ -9,15 +9,16 @@ import { LookingToUseHiveUpsellBlock } from '../looking-to-use-hive-upsell-block
 // because the class responsible for dark mode gets transformed
 // so `dark:` prefixes don't work.
 const ONE_OFF_CLASS_CASE_STUDIES = 'case-studies';
+const MAIN_CONTENT = 'main-content';
 
 export default function CaseStudiesLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className={cn(ONE_OFF_CLASS_CASE_STUDIES, 'mx-auto box-content max-w-[90rem]')}>
       <CaseStudiesHeader className="mx-auto max-w-[--nextra-content-width] pl-6 sm:my-12 md:pl-12 lg:my-24" />
-      <aside className="sticky top-[92px] mx-auto max-w-[--nextra-content-width]">
-        <LookingToUseHiveUpsellBlock className="absolute right-2 top-4 max-lg:hidden lg:w-[320px] xl:w-[400px]" />
-      </aside>
-      {children}
+      <div className={cn(MAIN_CONTENT, 'mx-auto flex')}>
+        {children}
+        <LookingToUseHiveUpsellBlock className="sticky right-2 top-[108px] mb-16 h-min max-lg:hidden lg:w-[320px] xl:w-[400px]" />
+      </div>
       <MoreStoriesSection />
       <GetYourAPIGameWhite className="sm:my-24" />
     </div>

--- a/packages/web/docs/src/app/case-studies/(posts)/layout.tsx
+++ b/packages/web/docs/src/app/case-studies/(posts)/layout.tsx
@@ -17,7 +17,7 @@ export default function CaseStudiesLayout({ children }: { children: React.ReactN
       <CaseStudiesHeader className="mx-auto max-w-[--nextra-content-width] pl-6 sm:my-12 md:pl-12 lg:my-24" />
       <div className={cn(MAIN_CONTENT, 'mx-auto flex')}>
         {children}
-        <LookingToUseHiveUpsellBlock className="sticky right-2 top-[108px] mb-16 h-min max-lg:hidden lg:w-[320px] xl:w-[400px]" />
+        <LookingToUseHiveUpsellBlock className="sticky right-2 top-[108px] mb-8 h-min max-lg:hidden lg:w-[320px] xl:w-[400px]" />
       </div>
       <MoreStoriesSection />
       <GetYourAPIGameWhite className="sm:my-24" />

--- a/packages/web/docs/src/app/case-studies/case-studies-styles.css
+++ b/packages/web/docs/src/app/case-studies/case-studies-styles.css
@@ -3,16 +3,28 @@
   --article-max-width: 640px;
 
   & > .main-content {
+    box-sizing: content-box;
     width: var(--nextra-content-width);
+    max-width: 100%;
 
     /* hide leftmost column to left-align the case study */
     & > div:first-of-type > :first-child {
       @apply hidden;
     }
 
+    & > div {
+      @apply ml-0 pl-6 md:pl-12;
+    }
+
     & > div > article {
       box-sizing: content-box;
-      max-width: var(--article-max-width);
+      max-width: 100%;
+      width: var(--article-max-width);
+      padding: 0;
+    }
+
+    & nav.nextra-toc {
+      @apply hidden;
     }
   }
 

--- a/packages/web/docs/src/app/case-studies/case-studies-styles.css
+++ b/packages/web/docs/src/app/case-studies/case-studies-styles.css
@@ -2,14 +2,18 @@
   --nextra-content-width: 1208px;
   --article-max-width: 640px;
 
-  /* hide leftmost column to left-align the case study */
-  & > div:first-of-type > :first-child {
-    @apply hidden;
-  }
+  & > .main-content {
+    width: var(--nextra-content-width);
 
-  & > div > article {
-    box-sizing: content-box;
-    max-width: var(--article-max-width);
+    /* hide leftmost column to left-align the case study */
+    & > div:first-of-type > :first-child {
+      @apply hidden;
+    }
+
+    & > div > article {
+      box-sizing: content-box;
+      max-width: var(--article-max-width);
+    }
   }
 
   @apply text-green-1000 dark:text-white;


### PR DESCRIPTION
### Description

The yellow block now stops on the same level as the article text.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d66ccab0-824a-4b76-91ef-e36e1f8567b7" />

