### PR TITLE
improve errors for usage processor 2 format

### DIFF
--- a/.changeset/small-readers-melt.md
+++ b/.changeset/small-readers-melt.md
@@ -1,0 +1,6 @@
+---
+'hive': patch
+---
+
+Improve the usage reporting endpoint error responses to include all the errors for invalid JSON
+bodies.

--- a/packages/services/usage/__tests__/usage-processor-2-validation.spec.ts
+++ b/packages/services/usage/__tests__/usage-processor-2-validation.spec.ts
@@ -1009,3 +1009,50 @@ test('$.operations.execution.errorsTotal is required', () => {
     success: false,
   });
 });
+
+test('invalid duration and timestamp (-1) gives helpful error response', () => {
+  expect(
+    decodeReport({
+      size: 1,
+      map: {
+        op1Key: {
+          operation: `query op1Name { field1 }`,
+          fields: ['Query.field1'],
+        },
+      },
+      operations: [
+        {
+          operationMapKey: 'op1Key',
+          timestamp: -1,
+          execution: {
+            ok: true,
+            duration: -1,
+            errorsTotal: 1,
+          },
+        },
+      ],
+    }),
+  ).toEqual({
+    errors: [
+      {
+        errors: [
+          {
+            message: 'Expected valid unix timestamp in milliseconds',
+            path: '/operations/0/timestamp',
+          },
+          {
+            message: 'Expected integer to be greater or equal to 0',
+            path: '/operations/0/execution/duration',
+          },
+          {
+            message: 'Expected null',
+            path: '/operations',
+          },
+        ],
+        message: 'Expected union value',
+        path: '/operations',
+      },
+    ],
+    success: false,
+  });
+});

--- a/packages/services/usage/src/usage-processor-2.ts
+++ b/packages/services/usage/src/usage-processor-2.ts
@@ -8,6 +8,7 @@ import {
 } from '@hive/usage-common';
 import * as tb from '@sinclair/typebox';
 import * as tc from '@sinclair/typebox/compiler';
+import * as tbe from '@sinclair/typebox/errors';
 import { invalidRawOperations, rawOperationsSize, totalOperations, totalReports } from './metrics';
 import { TokensResponse } from './tokens';
 import { isValidOperationBody } from './usage-processor-1';
@@ -306,6 +307,12 @@ const unixTimestampRegex = /^\d{13,}$/;
 function isUnixTimestamp(x: number) {
   return unixTimestampRegex.test(String(x));
 }
+
+tbe.SetErrorFunction(param => {
+  return param.schema[tb.Kind] === 'UnixTimestampInMs'
+    ? 'Expected valid unix timestamp in milliseconds'
+    : tbe.DefaultErrorFunction(param);
+});
 
 tb.TypeRegistry.Set<number>('UnixTimestampInMs', (_, value) =>
   typeof value === 'number' ? isUnixTimestamp(value) : false,

--- a/packages/services/usage/src/usage-processor-2.ts
+++ b/packages/services/usage/src/usage-processor-2.ts
@@ -361,10 +361,11 @@ type ReportType = tb.Static<typeof ReportSchema>;
 
 const ReportModel = tc.TypeCompiler.Compile(ReportSchema);
 
-type ValueError = {
+interface ValueError {
   path: string;
   message: string;
-};
+  errors?: ValueError[];
+}
 
 export function decodeReport(
   report: unknown,
@@ -384,13 +385,14 @@ export function decodeReport(
 }
 
 function getTypeBoxErrors(errors: tc.ValueErrorIterator): Array<ValueError> {
-  return [...errors].flatMap(error => [
-    {
+  return Array.from(errors).map(error => {
+    const errors = error.errors.flatMap(errors => getTypeBoxErrors(errors));
+    return {
       path: error.path,
       message: error.message,
-    },
-    ...error.errors.flatMap(errors => getTypeBoxErrors(errors)),
-  ]);
+      errors: errors.length ? errors : undefined,
+    };
+  });
 }
 
 const DAY_IN_MS = 86_400_000;

--- a/packages/web/docs/src/content/specs/usage-reports.mdx
+++ b/packages/web/docs/src/content/specs/usage-reports.mdx
@@ -19,8 +19,9 @@ them in batches (as a single report, when a buffer is full or every few seconds)
 | Authorization Header | `Authorization: Bearer token-here`   |
 | API version Header   | `X-Usage-API-Version: 2`             |
 | Method               | `POST`                               |
+| Content-Type Header  | `Content-Type: application/json`     |
 
-## Data structure
+## JSON Body structure
 
 <details>
   <summary>TypeScript schema</summary>
@@ -192,4 +193,59 @@ curl -X POST \
   -H 'X-Usage-API-Version: 2' \
   -H 'content-type: application/json' \
   -d '{ "size": 1, "map": { "aaa": { "operationName": "me", "operation": "query me { me { id } }", "fields": ["Query", "Query.me", "User", "User.id"] } }, "operations": [{ "operationMapKey" : "c3b6d9b0", "timestamp" : 1663158676535, "execution" : { "ok" : true, "duration" : 150000000, "errorsTotal" : 0 }, "metadata" : { "client" : { "name" : "demo" , "version" : "0.0.1" } } } ] }'
+```
+
+## Response
+
+| Status Code | Meaning                                              |
+| ----------- | ---------------------------------------------------- |
+| `200`       | Usage data was successfully accepted.                |
+| `400`       | Errors while processing the sent JSON body.          |
+| `401`       | Invalid `X-Usage-API-Version` header provided.       |
+| `429`       | Rate limited due to exceeding usage reporting quota. |
+| `500`       | An unexpected error occured.                         |
+
+The endpoint will return a JSON body response body for `200` and `400` status codes.
+
+### 200 Status Body
+
+```json filename="Response 200"
+{
+  "id": "c6ba1f9c-44c0-40a1-8089-65f7e4de5de5",
+  "operations": {
+    "accepted": 20,
+    "rejected": 0
+  }
+}
+```
+
+### 400 Status Body
+
+A response with status 400 indicates that the report sent within the request body is not valid. The
+response body will contain a JSON Schema validation errors that can be used to debug the faulty
+request body.
+
+```json filename="Response 400"
+{
+  "errors": [
+    {
+      "message": "Expected union value",
+      "path": "/operations",
+      "errors": [
+        {
+          "message": "Expected valid unix timestamp in milliseconds",
+          "path": "/operations/0/timestamp"
+        },
+        {
+          "message": "Expected integer to be greater or equal to 0",
+          "path": "/operations/0/execution/duration"
+        },
+        {
+          "message": "Expected null",
+          "path": "/operations"
+        }
+      ]
+    }
+  ]
+}
 ```


### PR DESCRIPTION
### Background

https://github.com/graphql-hive/console/issues/6468

### Description

- Improves the errors returned from the usage endpoint for an invalid JSON body.
- Updates the documentation to give an example of the response JSON body and expected status codes

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
