### PR TITLE
fix: missing client info with response cache

### DIFF
--- a/.changeset/three-stingrays-do.md
+++ b/.changeset/three-stingrays-do.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/yoga': patch
+---
+
+Correctly extract client information when using the response cache plugin.
+
+The client information was not reported for GraphQL responses served from the response cache plugin.

--- a/packages/libraries/yoga/src/index.ts
+++ b/packages/libraries/yoga/src/index.ts
@@ -161,6 +161,7 @@ export function useHive(clientOrOptions: HiveClient | HivePluginOptions): Plugin
                 schema: latestSchema,
                 variableValues: record.paramsArgs.variables,
                 operationName: record.paramsArgs.operationName,
+                contextValue: serverContext,
               },
               result,
               record.experimental__documentId,


### PR DESCRIPTION
### Background

We did not report the client info for responses handled by the response cache.

### Description

Fixes the client info extraction for response cache results and adds a test for it.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
