### PR TITLE
track error count for unexpected errors during schema publish/check

### DIFF
--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -69,6 +69,16 @@ const schemaPublishCount = new promClient.Counter({
   labelNames: ['model', 'projectType', 'conclusion'],
 });
 
+const schemaPublishUnexpectedErrorCount = new promClient.Counter({
+  name: 'registry_publish_unexpected_error_count',
+  help: 'Unexpected, not gracefully handled errors. E.g. from GitHub or other third-party services.',
+});
+
+const schemaCheckUnexpectedErrorCount = new promClient.Counter({
+  name: 'registry_check_unexpected_error_count',
+  help: 'Unexpected, not gracefully handled errors. E.g. from GitHub or other third-party services.',
+});
+
 const schemaDeleteCount = new promClient.Counter({
   name: 'registry_delete_count',
   help: 'Number of schema deletes',
@@ -250,7 +260,7 @@ export class SchemaPublisher {
     };
   }
 
-  @traceFn('SchemaPublisher.check', {
+  @traceFn('SchemaPublisher.internalCheck', {
     initAttributes: input => ({
       'hive.organization.slug': input.target?.bySelector?.organizationSlug,
       'hive.project.slug': input.target?.bySelector?.projectSlug,
@@ -261,7 +271,7 @@ export class SchemaPublisher {
       'hive.check.result': result.__typename,
     }),
   })
-  async check(input: CheckInput) {
+  private async internalCheck(input: CheckInput) {
     this.logger.info('Checking schema (input=%o)', lodash.omit(input, ['sdl']));
 
     const selector = await this.idTranslator.resolveTargetReference({
@@ -959,6 +969,16 @@ export class SchemaPublisher {
     } as const;
   }
 
+  check(input: CheckInput) {
+    return this.internalCheck(input).catch(err => {
+      if (err instanceof HiveError === false) {
+        schemaCheckUnexpectedErrorCount.inc();
+      }
+
+      throw err;
+    });
+  }
+
   @traceFn('SchemaPublisher.publish', {
     initAttributes: (input, _) => ({
       'hive.organization.slug': input.target?.bySelector?.organizationSlug,
@@ -1080,6 +1100,8 @@ export class SchemaPublisher {
             __typename: 'SchemaPublishRetry',
             reason: 'Another schema publish is currently in progress.',
           } satisfies PublishResult;
+        } else if (error instanceof HiveError === false) {
+          schemaPublishUnexpectedErrorCount.inc();
         }
 
         throw error;

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -1104,7 +1104,9 @@ export class SchemaPublisher {
             __typename: 'SchemaPublishRetry',
             reason: 'Another schema publish is currently in progress.',
           } satisfies PublishResult;
-        } else if (error instanceof HiveError === false) {
+        }
+
+        if (error instanceof HiveError === false) {
           schemaPublishUnexpectedErrorCount.inc({
             errorName: (error instanceof Error && error.name) || 'unknown',
           });


### PR DESCRIPTION
### Description

Introduces metrics `registry_publish_unexpected_error_count` and `registry_check_unexpected_error_count` for having a metric that shows us if we are having any unexpected errors aka potential outage of a third party service.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
