### PR TITLE
Correct Hive Gateway Next.js example

### DIFF
--- a/packages/web/docs/src/content/gateway/deployment/node-frameworks/nextjs.mdx
+++ b/packages/web/docs/src/content/gateway/deployment/node-frameworks/nextjs.mdx
@@ -18,7 +18,7 @@ Please read the
 [relevant Next.js documentation on custom router handlers](https://nextjs.org/docs/app/building-your-application/routing/router-handlers)
 first.
 
-```ts
+```ts filename="app/api/route.ts"
 import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
 import { supergraph } from './my-supergraph'
 

--- a/packages/web/docs/src/content/gateway/deployment/node-frameworks/nextjs.mdx
+++ b/packages/web/docs/src/content/gateway/deployment/node-frameworks/nextjs.mdx
@@ -14,7 +14,9 @@ Hive Gateway can be integrated with Next.js easily as
 
 ## Example
 
-Please read the https://nextjs.org/docs/app/building-your-application/routing/router-handlers first.
+Please read the
+[relevant Next.js documentation on custom router handlers](https://nextjs.org/docs/app/building-your-application/routing/router-handlers)
+first.
 
 ```ts
 import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'

--- a/packages/web/docs/src/content/gateway/deployment/node-frameworks/nextjs.mdx
+++ b/packages/web/docs/src/content/gateway/deployment/node-frameworks/nextjs.mdx
@@ -14,21 +14,16 @@ Hive Gateway can be integrated with Next.js easily as
 
 ## Example
 
-```ts
-// Next.js Custom Route Handler: https://nextjs.org/docs/app/building-your-application/routing/router-handlers
+Please read the https://nextjs.org/docs/app/building-your-application/routing/router-handlers first.
 
+```ts
 import { createGatewayRuntime } from '@graphql-hive/gateway-runtime'
+import { supergraph } from './my-supergraph'
 
 const { handleRequest } = createGatewayRuntime({
-  /* Your configuration here before the following required settings */
-
-  // While using Next.js file convention for routing, we need to configure Hive Gateway to use the correct endpoint
-  graphqlEndpoint: '/api/graphql',
-
-  // Hive Gateway needs to know how to create a valid Next response
-  fetchAPI: { Response }
+  supergraph,
+  graphqlEndpoint: '/api/graphql'
 })
 
-// Export the handler to be used with the following HTTP methods
 export { handleRequest as GET, handleRequest as POST, handleRequest as OPTIONS }
 ```


### PR DESCRIPTION
Fixes #6453

Examples should be copy-pasteable and not include changes that don't work or lack context.