### PR TITLE
send request id from cli

### DIFF
--- a/packages/libraries/cli/src/base-command.ts
+++ b/packages/libraries/cli/src/base-command.ts
@@ -189,7 +189,7 @@ export default abstract class BaseCommand<T extends typeof Command> extends Comm
       'Content-Type': 'application/json',
       Accept: 'application/json',
       'User-Agent': `hive-cli/${this.config.version}`,
-      'x-request-id': requestId
+      'x-request-id': requestId,
       ...additionalHeaders,
     };
 

--- a/packages/libraries/cli/src/commands/whoami.ts
+++ b/packages/libraries/cli/src/commands/whoami.ts
@@ -93,8 +93,11 @@ export default class WhoAmI extends Command<typeof WhoAmI> {
       throw new MissingRegistryTokenError();
     }
 
+    const requestId = crypto.randomUUID();
+
     const result = await this.registryApi(registry, token).request({
       operation: myTokenInfoQuery,
+      requestId,
     });
 
     if (result.tokenInfo.__typename === 'TokenInfo') {
@@ -127,10 +130,11 @@ export default class WhoAmI extends Command<typeof WhoAmI> {
       this.log(print());
     } else if (result.tokenInfo.__typename === 'TokenNotFoundError') {
       this.debug(result.tokenInfo.message);
-      throw new InvalidRegistryTokenError();
+      throw new InvalidRegistryTokenError(requestId);
     } else {
       throw new UnexpectedError(
         `Token response got an unsupported type: ${(result.tokenInfo as any).__typename}`,
+        requestId,
       );
     }
   }

--- a/packages/libraries/cli/src/helpers/errors.ts
+++ b/packages/libraries/cli/src/helpers/errors.ts
@@ -108,11 +108,11 @@ export class MissingEndpointError extends HiveCLIError {
 }
 
 export class InvalidRegistryTokenError extends HiveCLIError {
-  constructor() {
+  constructor(requestId: string) {
     super(
       ExitCode.ERROR,
       errorCode(ErrorCategory.GENERIC, 6),
-      `A valid registry token is required to perform the action. The registry token used does not exist or has been revoked.`,
+      `A valid registry token is required to perform the action. The registry token used does not exist or has been revoked. (requestId=${requestId})`,
     );
   }
 }
@@ -203,22 +203,22 @@ export class SchemaPublishFailedError extends HiveCLIError {
 }
 
 export class HTTPError extends HiveCLIError {
-  constructor(endpoint: string, status: number, message: string) {
+  constructor(endpoint: string, status: number, message: string, requestId: string) {
     const is400 = status >= 400 && status < 500;
     super(
       ExitCode.ERROR,
       errorCode(ErrorCategory.GENERIC, 13),
-      `A ${is400 ? 'client' : 'server'} error occurred while performing the action. A call to "${endpoint}" failed with Status: ${status}, Text: ${message}`,
+      `A ${is400 ? 'client' : 'server'} error occurred while performing the action. A call to "${endpoint}" failed with Status: ${status}, Text: ${message}, RequestId: ${requestId}`,
     );
   }
 }
 
 export class NetworkError extends HiveCLIError {
-  constructor(cause: Error | string) {
+  constructor(cause: Error | string, requestId: string) {
     super(
       ExitCode.ERROR,
       errorCode(ErrorCategory.GENERIC, 14),
-      `A network error occurred while performing the action: "${cause instanceof Error ? `${cause.name}: ${cause.message}` : cause}"`,
+      `A network error occurred while performing the action: "${cause instanceof Error ? `${cause.name}: ${cause.message}` : cause}" (requestId=${requestId})`,
     );
   }
 }

--- a/packages/libraries/cli/src/helpers/errors.ts
+++ b/packages/libraries/cli/src/helpers/errors.ts
@@ -112,7 +112,7 @@ export class InvalidRegistryTokenError extends HiveCLIError {
     super(
       ExitCode.ERROR,
       errorCode(ErrorCategory.GENERIC, 6),
-      `A valid registry token is required to perform the action. The registry token used does not exist or has been revoked. (requestId=${requestId})`,
+      `A valid registry token is required to perform the action. The registry token used does not exist or has been revoked.\nRequestId: ${requestId}`,
     );
   }
 }
@@ -218,7 +218,7 @@ export class NetworkError extends HiveCLIError {
     super(
       ExitCode.ERROR,
       errorCode(ErrorCategory.GENERIC, 14),
-      `A network error occurred while performing the action: "${cause instanceof Error ? `${cause.name}: ${cause.message}` : cause}" (requestId=${requestId})`,
+      `A network error occurred while performing the action: "${cause instanceof Error ? `${cause.name}: ${cause.message}` : cause}"\nRequestId: ${requestId}`,
     );
   }
 }
@@ -409,7 +409,7 @@ export class InvalidSchemaError extends HiveCLIError {
 }
 
 export class UnexpectedError extends HiveCLIError {
-  constructor(cause: unknown) {
+  constructor(cause: unknown, requestId?: string) {
     const message =
       cause instanceof Error
         ? cause.message
@@ -419,7 +419,8 @@ export class UnexpectedError extends HiveCLIError {
     super(
       ExitCode.ERROR,
       errorCode(ErrorCategory.GENERIC, 99),
-      `An unexpected error occurred: ${message}\n> Enable DEBUG=* for more details.`,
+      `An unexpected error occurred: ${message}\n> Enable DEBUG=* for more details.` +
+        (requestId ? `\nRequestId: ${requestId}` : ''),
     );
   }
 }


### PR DESCRIPTION
### Background

If a request from a customer fails, we have to dig our logs in order to find the affected request. Instead, we should specify the request id on the CLI level and log it so a customer can easily share it with us.


### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
