### PR TITLE
include request id header in http-client

### DIFF
--- a/.changeset/gentle-badgers-itch.md
+++ b/.changeset/gentle-badgers-itch.md
@@ -1,0 +1,10 @@
+---
+'@graphql-hive/core': minor
+'@graphql-hive/apollo': minor
+'@graphql-hive/cli': minor
+'@graphql-hive/envelop': minor
+'@graphql-hive/yoga': minor
+---
+
+Include and log a `x-request-id` header for all requests sent to the Hive API. This helps users to
+share more context with Hive staff when encountering errors.

--- a/packages/libraries/core/tests/gateways.spec.ts
+++ b/packages/libraries/core/tests/gateways.spec.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
-import { maskRequestId } from 'test-utils';
 import { createSchemaFetcher, createServicesFetcher } from '../src/client/gateways';
+import { maskRequestId } from './test-utils.js';
 
 afterEach(() => {
   nock.cleanAll();

--- a/packages/libraries/core/tests/gateways.spec.ts
+++ b/packages/libraries/core/tests/gateways.spec.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import { maskRequestId } from 'test-utils';
 import { createSchemaFetcher, createServicesFetcher } from '../src/client/gateways';
 
 afterEach(() => {
@@ -288,9 +289,9 @@ test('fail in case of unexpected CDN status code (nRetryCount=11)', async () => 
 
   try {
     await fetcher();
-  } catch (e) {
-    expect(e).toMatchInlineSnapshot(
-      `[Error: GET http://localhost/services failed with status 500.]`,
+  } catch (error: any) {
+    expect(maskRequestId(error.message)).toMatchInlineSnapshot(
+      `GET http://localhost/services (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed with status 500.`,
     );
   }
 });

--- a/packages/libraries/core/tests/http-client.spec.ts
+++ b/packages/libraries/core/tests/http-client.spec.ts
@@ -15,9 +15,9 @@ test('HTTP call without retries and system level error', async () => {
   }
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop
+    [INF] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
     [ERR] Error: getaddrinfo ENOTFOUND ap.localhost.noop
-    [ERR] GET https://ap.localhost.noop failed (666ms). getaddrinfo ENOTFOUND ap.localhost.noop
+    [ERR] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed (666ms). getaddrinfo ENOTFOUND ap.localhost.noop
   `);
 });
 
@@ -33,12 +33,12 @@ test('HTTP with retries and system', async () => {
   }).catch(_ => {});
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop Attempt (1/2)
+    [INF] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/2)
     [ERR] Error: getaddrinfo ENOTFOUND ap.localhost.noop
-    [ERR] GET https://ap.localhost.noop failed (666ms). getaddrinfo ENOTFOUND ap.localhost.noop
-    [INF] GET https://ap.localhost.noop Attempt (2/2)
+    [ERR] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed (666ms). getaddrinfo ENOTFOUND ap.localhost.noop
+    [INF] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (2/2)
     [ERR] Error: getaddrinfo ENOTFOUND ap.localhost.noop
-    [ERR] GET https://ap.localhost.noop failed (666ms). getaddrinfo ENOTFOUND ap.localhost.noop
+    [ERR] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed (666ms). getaddrinfo ENOTFOUND ap.localhost.noop
   `);
 });
 
@@ -60,8 +60,8 @@ test('HTTP with 4xx status code will not be retried', async () => {
   }).catch(_ => {});
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop Attempt (1/2)
-    [ERR] GET https://ap.localhost.noop failed with status 404 (666ms): Bubatzbieber
+    [INF] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/2)
+    [ERR] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed with status 404 (666ms): Bubatzbieber
     [ERR] Abort retry because of status code 404.
   `);
 });
@@ -85,11 +85,11 @@ test('HTTP with 5xx status code will be retried', async () => {
   }).catch(_ => {});
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop Attempt (1/2)
-    [ERR] GET https://ap.localhost.noop failed with status 500 (666ms): Bubatzbieber
-    [INF] GET https://ap.localhost.noop Attempt (2/2)
-    [ERR] GET https://ap.localhost.noop failed with status 500 (666ms): Bubatzbieber
-    [ERR] GET https://ap.localhost.noop retry limit exceeded after 2 attempts.
+    [INF] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/2)
+    [ERR] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed with status 500 (666ms): Bubatzbieber
+    [INF] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (2/2)
+    [ERR] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed with status 500 (666ms): Bubatzbieber
+    [ERR] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) retry limit exceeded after 2 attempts.
   `);
 });
 
@@ -112,11 +112,11 @@ test('HTTP with status 3xx will be retried', async () => {
   }).catch(_ => {});
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop Attempt (1/2)
-    [ERR] GET https://ap.localhost.noop failed with status 302 (666ms): Bubatzbieber
-    [INF] GET https://ap.localhost.noop Attempt (2/2)
-    [ERR] GET https://ap.localhost.noop failed with status 302 (666ms): Bubatzbieber
-    [ERR] GET https://ap.localhost.noop retry limit exceeded after 2 attempts.
+    [INF] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/2)
+    [ERR] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed with status 302 (666ms): Bubatzbieber
+    [INF] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (2/2)
+    [ERR] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed with status 302 (666ms): Bubatzbieber
+    [ERR] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) retry limit exceeded after 2 attempts.
   `);
 });
 
@@ -140,7 +140,7 @@ test('HTTP with status 3xx will not be retried with custom "isRequestOk" impleme
   }).catch(_ => {});
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop Attempt (1/2)
-    [INF] GET https://ap.localhost.noop succeeded with status 302 (666ms).
+    [INF] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/2)
+    [INF] GET https://ap.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 302 (666ms).
   `);
 });

--- a/packages/libraries/core/tests/reporting.spec.ts
+++ b/packages/libraries/core/tests/reporting.spec.ts
@@ -50,10 +50,10 @@ test('should not leak the exception', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://127.0.0.1:55404 Attempt (1/6)
+    [INF] [hive][reporting] POST http://127.0.0.1:55404 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)
     [ERR] [hive][reporting] Error: connect ECONNREFUSED 127.0.0.1:55404
     [ERR] [hive][reporting]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:666:666)
-    [ERR] [hive][reporting] POST http://127.0.0.1:55404 failed (666ms). connect ECONNREFUSED 127.0.0.1:55404
+    [ERR] [hive][reporting] POST http://127.0.0.1:55404 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed (666ms). connect ECONNREFUSED 127.0.0.1:55404
   `);
 });
 
@@ -125,8 +125,8 @@ test('should send data to Hive', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][reporting] Published schema
   `);
 });
@@ -198,8 +198,8 @@ test('should send data to Hive (deprecated endpoint)', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][reporting] Published schema
   `);
 
@@ -273,8 +273,8 @@ test('should send data to app.graphql-hive.com/graphql by default', async () => 
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST https://app.graphql-hive.com/graphql Attempt (1/6)
-    [INF] [hive][reporting] POST https://app.graphql-hive.com/graphql succeeded with status 200 (666ms).
+    [INF] [hive][reporting] POST https://app.graphql-hive.com/graphql (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)
+    [INF] [hive][reporting] POST https://app.graphql-hive.com/graphql (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][reporting] Published schema
   `);
 
@@ -349,8 +349,8 @@ test('should send data to Hive immediately', async () => {
   logger.clear();
   await waitFor(50);
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][reporting] Successfully published schema
   `);
   expect(body.variables.input.sdl).toBe(`type Query{foo:String}`);
@@ -362,8 +362,8 @@ test('should send data to Hive immediately', async () => {
 
   await waitFor(100);
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][reporting] Successfully published schema
   `);
 
@@ -433,8 +433,8 @@ test('should send original schema of a federated (v1) service', async () => {
   const logs = logger.getLogs();
   expect(logs).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][reporting] Published schema
   `);
   http.done();
@@ -502,8 +502,8 @@ test('should send original schema of a federated (v2) service', async () => {
   const logs = logger.getLogs();
   expect(logs).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][reporting] Published schema
   `);
   http.done();
@@ -563,8 +563,8 @@ test('should display SchemaPublishMissingServiceError', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [ERR] [hive][reporting] Failed to report schema: Service name is not defined
   `);
 });
@@ -624,12 +624,14 @@ test('should display SchemaPublishMissingUrlError', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)
+    [INF] [hive][reporting] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [ERR] [hive][reporting] Failed to report schema: Service url is not defined
   `);
 
-  expect(logger.getLogs()).toContain('POST http://localhost/200 Attempt (1/6)');
+  expect(logger.getLogs()).toContain(
+    'POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)',
+  );
   expect(logger.getLogs()).toContain('Service url is not defined');
 });
 
@@ -675,13 +677,13 @@ test('retry on non-200', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/registry Attempt (1/6)
+    [INF] [hive][reporting] POST http://localhost/registry (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/6)
     [ERR] [hive][reporting] Error: connect ECONNREFUSED ::1:80
     [ERR] [hive][reporting]     at createConnectionError (node:net:666:666)
     [ERR] [hive][reporting]     at afterConnectMultiple (node:net:666:666)
     [ERR] [hive][reporting] Error: connect ECONNREFUSED 127.0.0.1:80
     [ERR] [hive][reporting]     at createConnectionError (node:net:666:666)
     [ERR] [hive][reporting]     at afterConnectMultiple (node:net:666:666)
-    [ERR] [hive][reporting] POST http://localhost/registry failed (666ms).
+    [ERR] [hive][reporting] POST http://localhost/registry (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed (666ms).
   `);
 });

--- a/packages/libraries/core/tests/supergraph.spec.ts
+++ b/packages/libraries/core/tests/supergraph.spec.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import { maskRequestId } from 'test-utils.js';
 import { describe, expect, test } from 'vitest';
 import { createSupergraphSDLFetcher } from '../src/index.js';
 import { version } from '../src/version';
@@ -131,9 +132,9 @@ describe('supergraph SDL fetcher', async () => {
 
     try {
       await fetcher();
-    } catch (err) {
-      expect(err).toMatchInlineSnapshot(
-        `[Error: GET http://localhost/supergraph failed with status 500.]`,
+    } catch (err: any) {
+      expect(maskRequestId(err.message)).toMatchInlineSnapshot(
+        `GET http://localhost/supergraph (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed with status 500.`,
       );
     }
   });

--- a/packages/libraries/core/tests/supergraph.spec.ts
+++ b/packages/libraries/core/tests/supergraph.spec.ts
@@ -1,8 +1,8 @@
 import nock from 'nock';
-import { maskRequestId } from 'test-utils.js';
 import { describe, expect, test } from 'vitest';
 import { createSupergraphSDLFetcher } from '../src/index.js';
 import { version } from '../src/version';
+import { maskRequestId } from './test-utils.js';
 
 describe('supergraph SDL fetcher', async () => {
   test('createSupergraphSDLFetcher without ETag', async () => {

--- a/packages/libraries/core/tests/test-utils.ts
+++ b/packages/libraries/core/tests/test-utils.ts
@@ -14,7 +14,12 @@ function getLogLines(calls: Array<Array<unknown>>) {
         .replace(/\(\d{1,4}ms\)/, '(666ms)')
         // Replace stack trace line numbers with static value
         .replace(/\(node:net:\d+:\d+\)/, '(node:net:666:666)')
-        .replace(/\(node:dns:\d+:\d+\)/, '(node:dns:666:666)');
+        .replace(/\(node:dns:\d+:\d+\)/, '(node:dns:666:666)')
+        // request UUIDsu
+        .replace(
+          /[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}/,
+          'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+        );
     } else {
       msg = String(log[1]);
     }

--- a/packages/libraries/core/tests/test-utils.ts
+++ b/packages/libraries/core/tests/test-utils.ts
@@ -9,17 +9,15 @@ function getLogLines(calls: Array<Array<unknown>>) {
   return calls.map(log => {
     let msg: string;
     if (typeof log[1] === 'string') {
-      msg = log[1]
-        // Replace milliseconds with static value
-        .replace(/\(\d{1,4}ms\)/, '(666ms)')
-        // Replace stack trace line numbers with static value
-        .replace(/\(node:net:\d+:\d+\)/, '(node:net:666:666)')
-        .replace(/\(node:dns:\d+:\d+\)/, '(node:dns:666:666)')
+      msg = maskRequestId(
+        log[1]
+          // Replace milliseconds with static value
+          .replace(/\(\d{1,4}ms\)/, '(666ms)')
+          // Replace stack trace line numbers with static value
+          .replace(/\(node:net:\d+:\d+\)/, '(node:net:666:666)')
+          .replace(/\(node:dns:\d+:\d+\)/, '(node:dns:666:666)'),
         // request UUIDsu
-        .replace(
-          /[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}/,
-          'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
-        );
+      );
     } else {
       msg = String(log[1]);
     }
@@ -40,4 +38,11 @@ export function createHiveTestingLogger() {
       fn = vi.fn();
     },
   };
+}
+
+export function maskRequestId(errorMessage: string) {
+  return errorMessage.replace(
+    /[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}/,
+    'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+  );
 }

--- a/packages/libraries/core/tests/usage.spec.ts
+++ b/packages/libraries/core/tests/usage.spec.ts
@@ -167,8 +167,8 @@ test('should send data to Hive', async () => {
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Disposing
     [INF] [hive][usage] Sending report (queue 1)
-    [INF] [hive][usage] POST http://localhost/200
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][usage] Report sent!
   `);
 
@@ -277,8 +277,8 @@ test('should send data to Hive (deprecated endpoint)', async () => {
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Disposing
     [INF] [hive][usage] Sending report (queue 1)
-    [INF] [hive][usage] POST http://localhost/200
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][usage] Report sent!
   `);
 
@@ -366,10 +366,10 @@ test('should not leak the exception', { retry: 3 }, async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Sending report (queue 1)
-    [INF] [hive][usage] POST http://404.localhost.noop Attempt (1/2)
+    [INF] [hive][usage] POST http://404.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/2)
     [ERR] [hive][usage] Error: getaddrinfo ENOTFOUND 404.localhost.noop
     [ERR] [hive][usage]     at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:666:666)
-    [ERR] [hive][usage] POST http://404.localhost.noop failed (666ms). getaddrinfo ENOTFOUND 404.localhost.noop
+    [ERR] [hive][usage] POST http://404.localhost.noop (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed (666ms). getaddrinfo ENOTFOUND 404.localhost.noop
     [INF] [hive][usage] Disposing
   `);
 });
@@ -433,8 +433,8 @@ test('sendImmediately should not stop the schedule', { retry: 3 }, async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Sending report (queue 1)
-    [INF] [hive][usage] POST http://localhost/200
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][usage] Report sent!
   `);
   logger.clear();
@@ -446,7 +446,7 @@ test('sendImmediately should not stop the schedule', { retry: 3 }, async () => {
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Sending immediately
     [INF] [hive][usage] Sending report (queue 2)
-    [INF] [hive][usage] POST http://localhost/200
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
   `);
   logger.clear();
   await waitFor(100);
@@ -454,12 +454,10 @@ test('sendImmediately should not stop the schedule', { retry: 3 }, async () => {
   await collect(args, {});
   await waitFor(40);
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][usage] Report sent!
     [INF] [hive][usage] Sending report (queue 1)
-    [INF] [hive][usage] POST http://localhost/200
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
-    [INF] [hive][usage] Report sent!
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
   `);
 
   await hive.dispose();
@@ -554,8 +552,8 @@ test('should send data to Hive at least once when using atLeastOnceSampler', asy
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Disposing
     [INF] [hive][usage] Sending report (queue 2)
-    [INF] [hive][usage] POST http://localhost/200
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][usage] Report sent!
   `);
 
@@ -658,8 +656,8 @@ test('should not send excluded operation name data to Hive', async () => {
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Disposing
     [INF] [hive][usage] Sending report (queue 2)
-    [INF] [hive][usage] POST http://localhost/200
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) succeeded with status 200 (666ms).
     [INF] [hive][usage] Report sent!
   `);
 
@@ -758,8 +756,8 @@ test('retry on non-200', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Sending report (queue 1)
-    [INF] [hive][usage] POST http://localhost/200 Attempt (1/2)
-    [ERR] [hive][usage] POST http://localhost/200 failed with status 500 (666ms): No no no
+    [INF] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) Attempt (1/2)
+    [ERR] [hive][usage] POST http://localhost/200 (x-request-id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) failed with status 500 (666ms): No no no
     [INF] [hive][usage] Disposing
   `);
 });


### PR DESCRIPTION
### Background

If a request from a customer fails, we have to dig into our logs to find the affected request. Instead, we should specify the request-id on the CLI/library level and log it so a customer can easily share it with us.

The main reason for this was the CLI, but it is useful for all our SDKs.

### Description

Instead of setting a request id on our gateway entry level, we can already start setting the request-id on the SDK/CLI level. This allows users to share the request id with us even if we fail to send a proper response due to unexpected errors.

Closes https://github.com/graphql-hive/console/issues/6487

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
