### PR TITLE
use logger from request for request id reference

### DIFF
--- a/packages/services/server/src/supertokens.ts
+++ b/packages/services/server/src/supertokens.ts
@@ -87,7 +87,6 @@ export const backendConfig = (requirements: {
       createOIDCSuperTokensProvider({
         internalApi,
         broadcastLog: requirements.broadcastLog,
-        logger,
       }),
     );
   }


### PR DESCRIPTION
### Description

Logs here did not contain a request id, by using the logger from the request, will make debugging more simple.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
