### PR TITLE
feat: add request id to auth logs

### DIFF
--- a/packages/services/api/src/modules/auth/lib/supertokens-strategy.ts
+++ b/packages/services/api/src/modules/auth/lib/supertokens-strategy.ts
@@ -1,6 +1,6 @@
 import SessionNode from 'supertokens-node/recipe/session/index.js';
 import * as zod from 'zod';
-import type { FastifyReply, FastifyRequest, ServiceLogger } from '@hive/service-common';
+import type { FastifyReply, FastifyRequest } from '@hive/service-common';
 import { captureException } from '@sentry/node';
 import type { User } from '../../../shared/entities';
 import { AccessError, HiveError } from '../../../shared/errors';
@@ -211,12 +211,12 @@ export class SuperTokensCookieBasedSession extends Session {
 }
 
 export class SuperTokensUserAuthNStrategy extends AuthNStrategy<SuperTokensCookieBasedSession> {
-  private logger: ServiceLogger;
+  private logger: Logger;
   private organizationMembers: OrganizationMembers;
   private storage: Storage;
 
   constructor(deps: {
-    logger: ServiceLogger;
+    logger: Logger;
     storage: Storage;
     organizationMembers: OrganizationMembers;
   }) {

--- a/packages/services/api/src/modules/auth/lib/target-access-token-strategy.ts
+++ b/packages/services/api/src/modules/auth/lib/target-access-token-strategy.ts
@@ -1,9 +1,4 @@
-import {
-  maskToken,
-  type FastifyReply,
-  type FastifyRequest,
-  type ServiceLogger,
-} from '@hive/service-common';
+import { maskToken, type FastifyReply, type FastifyRequest } from '@hive/service-common';
 import { Logger } from '../../shared/providers/logger';
 import { TokenStorage } from '../../token/providers/token-storage';
 import { TokensConfig } from '../../token/providers/tokens';
@@ -59,10 +54,10 @@ export class TargetAccessTokenSession extends Session {
 }
 
 export class TargetAccessTokenStrategy extends AuthNStrategy<TargetAccessTokenSession> {
-  private logger: ServiceLogger;
+  private logger: Logger;
   private tokensConfig: TokensConfig;
 
-  constructor(deps: { logger: ServiceLogger; tokensConfig: TokensConfig }) {
+  constructor(deps: { logger: Logger; tokensConfig: TokensConfig }) {
     super();
     this.logger = deps.logger.child({ module: 'TargetAccessTokenStrategy' });
     this.tokensConfig = deps.tokensConfig;

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -406,22 +406,24 @@ export async function main() {
 
     const authN = new AuthN({
       strategies: [
-        new SuperTokensUserAuthNStrategy({
-          logger: server.log,
-          storage,
-          organizationMembers: new OrganizationMembers(
-            storage.pool,
-            new OrganizationMemberRoles(storage.pool, server.log),
+        (logger: Logger) =>
+          new SuperTokensUserAuthNStrategy({
+            logger,
             storage,
-            server.log,
-          ),
-        }),
-        new TargetAccessTokenStrategy({
-          logger: server.log,
-          tokensConfig: {
-            endpoint: env.hiveServices.tokens.endpoint,
-          },
-        }),
+            organizationMembers: new OrganizationMembers(
+              storage.pool,
+              new OrganizationMemberRoles(storage.pool, logger),
+              storage,
+              logger,
+            ),
+          }),
+        (logger: Logger) =>
+          new TargetAccessTokenStrategy({
+            logger,
+            tokensConfig: {
+              endpoint: env.hiveServices.tokens.endpoint,
+            },
+          }),
       ],
     });
 


### PR DESCRIPTION
### Background

I noticed that we are not logging the request-id for the new authorization layer logic.

### Description

Not sure if this is the best way to implement it, to be honest. I first tried to move this logic to a `graphql-modules` provider, but figured out that they cannot return a `Promise`.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
