### PR TITLE
Ensure response body is read before timeout to avoid abort errors

### DIFF
--- a/.changeset/olive-walls-build.md
+++ b/.changeset/olive-walls-build.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Ensure response body is read before timeout to avoid abort errors in S3 client (CDN)

--- a/packages/services/cdn-worker/src/aws.ts
+++ b/packages/services/cdn-worker/src/aws.ts
@@ -211,7 +211,6 @@ export class AwsClient {
             status: response.status,
             statusText: response.statusText,
             headers: response.headers,
-            cf: response.cf,
           });
         }
 

--- a/packages/services/cdn-worker/src/aws.ts
+++ b/packages/services/cdn-worker/src/aws.ts
@@ -196,6 +196,10 @@ export class AwsClient {
             result: { type: 'success', response },
           });
 
+          if (!response.body) {
+            return response;
+          }
+
           // Read the body first, to make sure it won't be aborted by the signal (timeout)
           // If we get a timeout error during the body reading, we can't retry,
           // as it's out of the control of that function.

--- a/packages/services/cdn-worker/src/aws.ts
+++ b/packages/services/cdn-worker/src/aws.ts
@@ -196,7 +196,23 @@ export class AwsClient {
             result: { type: 'success', response },
           });
 
-          return response;
+          // Read the body first, to make sure it won't be aborted by the signal (timeout)
+          // If we get a timeout error during the body reading, we can't retry,
+          // as it's out of the control of that function.
+          // One example of it is when the res.text() is called with a delay due to application logic,
+          // and the timeout is reached at that point. The read will be aborted.
+          //
+          // For this reason, I prefer to read the body first, make it part of the retry logic,
+          // and only then return the response to the consumer,
+          // even at the cost of higher memory footprint (like it matters...).
+          const bodyText = await response.text();
+
+          return new Response(bodyText, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+            cf: response.cf,
+          });
         }
 
         console.log(

--- a/packages/services/cdn-worker/src/index.ts
+++ b/packages/services/cdn-worker/src/index.ts
@@ -147,7 +147,7 @@ const handler: ExportedHandler<Env> = {
           if (i === retries) {
             const res = await fetched;
             if (res.ok) {
-              return res.text();
+              return await res.text();
             }
 
             throw new Error(`Failed to fetch ${url}, status: ${res.status}`);
@@ -156,7 +156,7 @@ const handler: ExportedHandler<Env> = {
           try {
             const res = await fetched;
             if (res.ok) {
-              return res.text();
+              return await res.text();
             }
           } catch (error) {
             // Retry also when there's an exception


### PR DESCRIPTION
Reading the response body (res.text()) after a fetch timeout can lead to an AbortError, making retries impossible. This change ensures the body is read immediately after the response is received, allowing it to be included in the retry logic.

By decoupling the response body from AbortSignal.timeout(), we prevent unexpected failures when the body is accessed later due to application logic delays. While this slightly increases memory usage, it ensures reliability when handling AWS S3 responses.

- [x] changeset

Closes CONSOLE-1064