### PR TITLE
Fix flaky test: sendImmediately should not stop the schedule

### DIFF
--- a/packages/libraries/core/tests/usage.spec.ts
+++ b/packages/libraries/core/tests/usage.spec.ts
@@ -441,10 +441,9 @@ test('sendImmediately should not stop the schedule', async () => {
   expect(logger.getLogs()).toMatch('Sending immediately');
   expect(logger.getLogs()).toMatch('Sending report (queue 2)');
   logger.clear();
-  await waitFor(100);
   // Let's check if the scheduled send task is still running
   await collect(args, {});
-  await waitFor(40);
+  await waitFor(60);
   expect(logger.getLogs()).toMatch('Sending report (queue 1)');
 
   await hive.dispose();


### PR DESCRIPTION
I ran it 10 times locally before my change and it broke once

After the change, I ran it 30 times and did not get any failures