### PR TITLE
fix: show deprecated schema in explorer when there is no usage reported

### DIFF
--- a/packages/web/app/src/pages/target-explorer-deprecated.tsx
+++ b/packages/web/app/src/pages/target-explorer-deprecated.tsx
@@ -6,7 +6,7 @@ import { SchemaVariantFilter } from '@/components/target/explorer/filter';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { DateRangePicker, presetLast7Days } from '@/components/ui/date-range-picker';
-import { EmptyList, noSchemaVersion } from '@/components/ui/empty-list';
+import { noSchemaVersion } from '@/components/ui/empty-list';
 import { Link } from '@/components/ui/link';
 import { Meta } from '@/components/ui/meta';
 import { Subtitle, Title } from '@/components/ui/page';
@@ -351,22 +351,9 @@ function ExplorerDeprecatedSchemaPageContent(props: {
   }
 
   const currentOrganization = query.data?.organization?.organization;
-  const hasCollectedOperations = query.data?.hasCollectedOperations === true;
 
   if (!currentOrganization) {
     return null;
-  }
-
-  if (!hasCollectedOperations) {
-    return (
-      <div className="py-8">
-        <EmptyList
-          title="Hive is waiting for your first collected operation"
-          description="You can collect usage of your GraphQL API with Hive Client"
-          docsUrl="/features/usage-reporting"
-        />
-      </div>
-    );
   }
 
   return (


### PR DESCRIPTION
### Background

This is a bug I discovered when testing metadata.
When there is no usage, the deprecated schema view does not render. I assume this is because the deprecated view was based on the unused schema view. But for the deprecated schema, it doesnt make any sense to care about usage.
<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

Removes the conditional check on usage for the deprecated schema view.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
