### PR TITLE
Adds bloom filter index to coordinates agg views

### DIFF
--- a/.changeset/three-gifts-battle.md
+++ b/.changeset/three-gifts-battle.md
@@ -1,0 +1,8 @@
+---
+'hive': patch
+---
+
+Adds an index to coordinates\_(daily,hourly,minutely) tables to speedup the
+get_top_operations_for_types ClickHoue query.
+
+Reading of type and fields usage statisticts should be noticeably faster now on big datasets.

--- a/packages/migrations/src/clickhouse-actions/012-coordinates-typename-index.ts
+++ b/packages/migrations/src/clickhouse-actions/012-coordinates-typename-index.ts
@@ -29,7 +29,7 @@ export const action: Action = async (exec, query) => {
       table String,
       idx_created Bool DEFAULT false,
       idx_materialized Bool DEFAULT false
-    ) ENGINE = MergeTree()
+    ) ENGINE = MergeTree() ORDER BY tuple()
   `);
 
   const tables = await query(`

--- a/packages/migrations/src/clickhouse-actions/012-coordinates-typename-index.ts
+++ b/packages/migrations/src/clickhouse-actions/012-coordinates-typename-index.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import type { Action } from '../clickhouse';
+
+const SystemTablesModel = z.array(
+  z.object({
+    name: z.string(),
+    uuid: z.string(),
+  }),
+);
+
+const DataSkippingIndicesModel = z.array(
+  z.object({
+    name: z.string(),
+  }),
+);
+
+// This migration adds an index for the `coordinate` field.
+// Improve the performance of the queries that filter the rows by the type's name.
+//
+// For example, when looking for `Member.*` coordinates we elimiate the need to scan the whole table,
+// by laveraging the idx_typename index.
+// We filter rows by the first part of the `coordinate` field (substringIndex(coordinate, '.', 1)).
+export const action: Action = async (exec, query, hiveCloudEnvironment) => {
+  const tables = await query(`
+    SELECT uuid, name FROM system.tables WHERE name IN (
+      'coordinates_daily',
+      'coordinates_hourly',
+      'coordinates_minutely'
+    );
+  `).then(async r => SystemTablesModel.parse(r.data));
+
+  if (tables.length !== 3) {
+    throw new Error('Expected 3 tables');
+  }
+
+  for (const { uuid, name } of tables) {
+    console.log(`Creating idx_typename for table ${name}`);
+    await exec(
+      `ALTER TABLE ".inner_id.${uuid}" ADD INDEX idx_typename (substringIndex(coordinate, '.', 1)) TYPE ngrambf_v1(4, 1024, 2, 0) GRANULARITY 1`,
+    );
+    const indexes = await query(`
+      SELECT name FROM system.data_skipping_indices WHERE table = ${'.inner_id.' + uuid} AND name = 'idx_typename'
+    `).then(async r => DataSkippingIndicesModel.parse(r.data));
+
+    if (indexes.some(i => i.name)) {
+      console.log(`Materializing the idx_typename for table ${name}`);
+      await exec(`ALTER TABLE ".inner_id.${uuid}" MATERIALIZE INDEX idx_typename`);
+    } else {
+      console.error(`Failed to find idx_typename for table ${name}`);
+    }
+  }
+};

--- a/packages/migrations/src/clickhouse-actions/012-coordinates-typename-index.ts
+++ b/packages/migrations/src/clickhouse-actions/012-coordinates-typename-index.ts
@@ -20,7 +20,7 @@ const DataSkippingIndicesModel = z.array(
 // For example, when looking for `Member.*` coordinates we elimiate the need to scan the whole table,
 // by laveraging the idx_typename index.
 // We filter rows by the first part of the `coordinate` field (substringIndex(coordinate, '.', 1)).
-export const action: Action = async (exec, query, hiveCloudEnvironment) => {
+export const action: Action = async (exec, query) => {
   const tables = await query(`
     SELECT uuid, name FROM system.tables WHERE name IN (
       'coordinates_daily',

--- a/packages/migrations/src/clickhouse-actions/012-coordinates-typename-index.ts
+++ b/packages/migrations/src/clickhouse-actions/012-coordinates-typename-index.ts
@@ -39,7 +39,7 @@ export const action: Action = async (exec, query) => {
       `ALTER TABLE ".inner_id.${uuid}" ADD INDEX idx_typename (substringIndex(coordinate, '.', 1)) TYPE ngrambf_v1(4, 1024, 2, 0) GRANULARITY 1`,
     );
     const indexes = await query(`
-      SELECT name FROM system.data_skipping_indices WHERE table = ${'.inner_id.' + uuid} AND name = 'idx_typename'
+      SELECT name FROM system.data_skipping_indices WHERE table = '${'.inner_id.' + uuid}' AND name = 'idx_typename'
     `).then(async r => DataSkippingIndicesModel.parse(r.data));
 
     if (indexes.some(i => i.name)) {

--- a/packages/migrations/src/clickhouse.ts
+++ b/packages/migrations/src/clickhouse.ts
@@ -169,6 +169,7 @@ export async function migrateClickHouse(
     import('./clickhouse-actions/009-ttl-1-year'),
     import('./clickhouse-actions/010-app-deployment-operations'),
     import('./clickhouse-actions/011-audit-logs'),
+    import('./clickhouse-actions/012-coordinates-typename-index'),
   ]);
 
   async function actionRunner(action: Action, index: number) {


### PR DESCRIPTION
Improves the performance of the queries that filter the rows by the type's name.

For example, when looking for `Member.*` coordinates we eliminate the need to scan the whole table, by leveraging the `idx_typename` index. We filter rows by the first part of the coordinate field (`substringIndex(coordinate, '.', 1)`).

It helps ClickHouse to make 10% of the original work :)

Some numbers. Big queries that took 8-17s are now around 2s.