### PR TITLE
fix: allow clearing explorer type selection

### DIFF
--- a/packages/web/app/src/components/target/explorer/filter.tsx
+++ b/packages/web/app/src/components/target/explorer/filter.tsx
@@ -106,6 +106,7 @@ export function TypeFilter(props: {
       options={types}
       onChange={(option: SelectOption | null) => {
         void router.navigate({
+          search: router.latestLocation.search,
           to: '/$organizationSlug/$projectSlug/$targetSlug/explorer/$typename',
           params: {
             organizationSlug: props.organizationSlug,

--- a/packages/web/app/src/components/target/explorer/filter.tsx
+++ b/packages/web/app/src/components/target/explorer/filter.tsx
@@ -16,6 +16,7 @@ import {
   useRouter,
 } from '@tanstack/react-router';
 import { useArgumentListToggle, usePeriodSelector } from './provider';
+import type { SelectOption } from '@/components/v2/radix-select';
 
 const TypeFilter_AllTypes = graphql(`
   query TypeFilter_AllTypes(
@@ -103,14 +104,14 @@ export function TypeFilter(props: {
       placeholder="Search for a type"
       defaultValue={props.typename ? { value: props.typename, label: props.typename } : null}
       options={types}
-      onChange={option => {
+      onChange={(option: SelectOption | null) => {
         void router.navigate({
           to: '/$organizationSlug/$projectSlug/$targetSlug/explorer/$typename',
           params: {
             organizationSlug: props.organizationSlug,
             projectSlug: props.projectSlug,
             targetSlug: props.targetSlug,
-            typename: option.value,
+            typename: option?.value ?? '',
           },
         });
       }}

--- a/packages/web/app/src/components/target/explorer/filter.tsx
+++ b/packages/web/app/src/components/target/explorer/filter.tsx
@@ -7,6 +7,7 @@ import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Autocomplete } from '@/components/v2';
+import type { SelectOption } from '@/components/v2/radix-select';
 import { graphql } from '@/gql';
 import {
   Link,
@@ -16,7 +17,6 @@ import {
   useRouter,
 } from '@tanstack/react-router';
 import { useArgumentListToggle, usePeriodSelector } from './provider';
-import type { SelectOption } from '@/components/v2/radix-select';
 
 const TypeFilter_AllTypes = graphql(`
   query TypeFilter_AllTypes(

--- a/packages/web/app/src/components/v2/autocomplete.tsx
+++ b/packages/web/app/src/components/v2/autocomplete.tsx
@@ -122,6 +122,7 @@ export function Autocomplete(props: {
       defaultValue={props.defaultValue}
       styles={styles}
       isSearchable
+      isClearable
       closeMenuOnSelect
       onChange={option => props.onChange(option as SelectOption)}
       isDisabled={props.disabled}


### PR DESCRIPTION
### Background

Currently to clear the type selection, the user must either go back in their history, must edit the url, or must re-navigate to the explorer. I think it's much more intuitive to offer a way to clear the selection in the dropdown component.
<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description
<img width="1170" alt="Screenshot 2025-02-20 at 12 07 36 PM" src="https://github.com/user-attachments/assets/a96b0b1e-9039-4399-868a-64fe47902517" />
Adds a "X" to clear the type selection and retains the field search param between type selections.


<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
