### PR TITLE
Fix Ecosystem Management absolute positioning bug

### DIFF
--- a/packages/web/docs/src/components/ecosystem-management/index.tsx
+++ b/packages/web/docs/src/components/ecosystem-management/index.tsx
@@ -16,7 +16,7 @@ export function EcosystemManagementSection({ className }: { className?: string }
     <section
       className={cn(
         'bg-green-1000 relative isolate overflow-hidden rounded-3xl text-white',
-        'p-8 pb-[160px] sm:pb-[112px] md:p-[72px] md:pb-[112px] lg:pb-[72px]',
+        'p-8 pb-[180px] sm:pb-[128px] md:p-[72px] md:pb-[128px] lg:pb-[72px]',
         className,
       )}
     >
@@ -86,7 +86,7 @@ export function EcosystemManagementSection({ className }: { className?: string }
               </li>
             ))}
           </ul>
-          <div className="bottom-0 flex w-full flex-col gap-x-4 gap-y-2 max-lg:absolute max-lg:translate-y-[calc(100%+24px)]">
+          <div className="bottom-0 flex w-full gap-x-4 gap-y-2 max-lg:absolute max-lg:translate-y-[calc(100%+40px)] max-sm:flex-col lg:flex-col">
             <CallToAction
               href="/federation"
               variant="primary-inverted"


### PR DESCRIPTION
### Background

This is using absolute positioning, because the position differs among breakpoints and we had a deadline :)
It's usually not a problem, but we didn't test it on mobiles after changing the texts of buttons, so we had a slight cutoff.

### Description

This tiny change makes the long buttons fit nicely on small, medium and large screen sizes.

We could consider rewriting it to overlapping named grid areas, but I'm not sure 100% if this would prevent the any layout bugs next time we change the buttons or add more of them.

