### PR TITLE
fix: members page with member:modify

### DIFF
--- a/packages/services/api/src/modules/oidc-integrations/providers/oidc-integrations.provider.ts
+++ b/packages/services/api/src/modules/oidc-integrations/providers/oidc-integrations.provider.ts
@@ -60,13 +60,17 @@ export class OIDCIntegrationsProvider {
       return null;
     }
 
-    await this.session.assertPerformAction({
+    const canPerformAction = await this.session.canPerformAction({
       organizationId: args.organizationId,
       action: 'oidc:modify',
       params: {
         organizationId: args.organizationId,
       },
     });
+
+    if (canPerformAction === false) {
+      return null;
+    }
 
     return await this.storage.getOIDCIntegrationForOrganization({
       organizationId: args.organizationId,

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -239,7 +239,7 @@ export class OrganizationManager {
 
   @cache((selector: OrganizationSelector) => selector.organizationId)
   async getInvitations(selector: OrganizationSelector) {
-    await this.session.assertPerformAction({
+    const canAccessInvitations = await this.session.canPerformAction({
       action: 'member:modify',
       organizationId: selector.organizationId,
       params: {
@@ -247,7 +247,11 @@ export class OrganizationManager {
       },
     });
 
-    return this.storage.getOrganizationInvitations(selector);
+    if (!canAccessInvitations) {
+      return null;
+    }
+
+    return await this.storage.getOrganizationInvitations(selector);
   }
 
   async getOrganizationOwner(selector: OrganizationSelector) {

--- a/packages/services/api/src/modules/organization/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Organization.ts
@@ -66,6 +66,10 @@ export const Organization: Pick<
       organizationId: organization.id,
     });
 
+    if (invitations === null) {
+      return null;
+    }
+
     return {
       total: invitations.length,
       nodes: invitations,


### PR DESCRIPTION
### Background

https://linear.app/the-guild/issue/CONSOLE-1097/dashboard-membermodify-permission-error

### Description

The dashboard shows an error page when having `member:describe` but not `member:modify` permissions.

![image](https://github.com/user-attachments/assets/4f348ae3-f2be-4d88-b952-924efefd069b)


### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
