### PR TITLE
docs: fix example schema:check commands in apollo-federation docs

### DIFF
--- a/packages/web/docs/src/content/get-started/apollo-federation.mdx
+++ b/packages/web/docs/src/content/get-started/apollo-federation.mdx
@@ -742,7 +742,6 @@ file:
 hive schema:check \
   --registry.accessToken YOUR_TOKEN_HERE \
   --service="reviews" \
-  --url="https://federation-demo.theguild.workers.dev/reviews" \
   subgraphs/reviews.graphql
 ```
 
@@ -756,7 +755,6 @@ hive schema:check \
 npx hive schema:check \
   --registry.accessToken YOUR_TOKEN_HERE \
   --service="reviews" \
-  --url="https://federation-demo.theguild.workers.dev/reviews" \
   subgraphs/reviews.graphql
 ```
 
@@ -775,7 +773,6 @@ docker run --name graphql-hive-cli --rm \
   schema:check \
   --registry.accessToken "<YOUR_TOKEN_HERE>" \
   --service="reviews" \
-  --url="https://federation-demo.theguild.workers.dev/reviews" \
   ./subgraphs/reviews.graphql
 ```
 
@@ -825,7 +822,6 @@ extend type Product @key(fields: "upc") {
 hive schema:check \
   --registry.accessToken YOUR_TOKEN_HERE \
   --service="reviews" \
-  --url="https://federation-demo.theguild.workers.dev/reviews" \
   subgraphs/reviews.graphql
 ```
 
@@ -839,7 +835,6 @@ hive schema:check \
 npx hive schema:check \
   --registry.accessToken YOUR_TOKEN_HERE \
   --service="reviews" \
-  --url="https://federation-demo.theguild.workers.dev/reviews" \
   subgraphs/reviews.graphql
 ```
 
@@ -858,7 +853,6 @@ docker run --name graphql-hive-cli --rm \
   schema:check \
   --registry.accessToken "<YOUR_TOKEN_HERE>" \
   --service="reviews" \
-  --url="https://federation-demo.theguild.workers.dev/reviews" \
   ./subgraphs/reviews.graphql
 ```
 
@@ -921,7 +915,6 @@ file:
 hive schema:check \
   --registry.accessToken YOUR_TOKEN_HERE \
   --service="reviews" \
-  --url="https://federation-demo.theguild.workers.dev/reviews" \
   subgraphs/reviews.graphql
 ```
 
@@ -935,7 +928,6 @@ hive schema:check \
 npx hive schema:check \
   --registry.accessToken YOUR_TOKEN_HERE \
   --service="reviews" \
-  --url="https://federation-demo.theguild.workers.dev/reviews" \
   subgraphs/reviews.graphql
 ```
 
@@ -954,7 +946,6 @@ docker run --name graphql-hive-cli --rm \
   schema:check \
   --registry.accessToken "<YOUR_TOKEN_HERE>" \
   --service="reviews" \
-  --url="https://federation-demo.theguild.workers.dev/reviews" \
   ./subgraphs/reviews.graphql
 ```
 


### PR DESCRIPTION
### Background

Checks dont take a URL -- only publish does
<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

Fixes the examples in our apollo-federation documentation so that they are valid commands.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
