### PR TITLE
fix: show meta filter on explorer only if there is meta

### DIFF
--- a/packages/web/app/src/pages/target-explorer-deprecated.tsx
+++ b/packages/web/app/src/pages/target-explorer-deprecated.tsx
@@ -259,7 +259,7 @@ function DeprecatedSchemaExplorer(props: {
             targetSlug={props.targetSlug}
             variant="deprecated"
           />
-          {latestValidSchemaVersion?.explorer?.metadataAttributes ? (
+          {latestValidSchemaVersion?.explorer?.metadataAttributes?.length ? (
             <MetadataFilter options={latestValidSchemaVersion.explorer.metadataAttributes} />
           ) : null}
         </div>

--- a/packages/web/app/src/pages/target-explorer-type.tsx
+++ b/packages/web/app/src/pages/target-explorer-type.tsx
@@ -244,7 +244,7 @@ function TypeExplorerPageContent(props: {
                 targetSlug={props.targetSlug}
                 variant="all"
               />
-              {latestSchemaVersion?.explorer?.metadataAttributes ? (
+              {latestSchemaVersion?.explorer?.metadataAttributes?.length ? (
                 <MetadataFilter options={latestSchemaVersion.explorer.metadataAttributes} />
               ) : null}
             </>

--- a/packages/web/app/src/pages/target-explorer.tsx
+++ b/packages/web/app/src/pages/target-explorer.tsx
@@ -221,7 +221,7 @@ function ExplorerPageContent(props: {
                 targetSlug={props.targetSlug}
                 variant="all"
               />
-              {latestValidSchemaVersion?.explorer?.metadataAttributes ? (
+              {latestValidSchemaVersion?.explorer?.metadataAttributes?.length ? (
                 <MetadataFilter options={latestValidSchemaVersion.explorer.metadataAttributes} />
               ) : null}
             </>


### PR DESCRIPTION
### Background

Small bug on the metadata filter where when metadata is all removed from a subgraph, an empty array is returned from the API which causes the filter to still show even though it's empty.
<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

This correctly hides the metadata filter on the explorer if there are no values in the metadata returned.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
