### PR TITLE
Write a heap dump to a disk when SIGUSR1 signal is received

### DIFF
--- a/.changeset/honest-apples-tap.md
+++ b/.changeset/honest-apples-tap.md
@@ -2,4 +2,4 @@
 'hive': patch
 ---
 
-Adds ability to all services to write a heap dump to a disk when USR2 signal is received
+Adds ability to all services to write a heap dump to a disk when SIGUSR1 signal is received

--- a/.changeset/honest-apples-tap.md
+++ b/.changeset/honest-apples-tap.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Adds ability to all services to write a heap dump to a disk when USR2 signal is received

--- a/docker/shared/entrypoint.sh
+++ b/docker/shared/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 echo "Release: $RELEASE"
-node index.js
+node --heapsnapshot-signal=SIGUSR2 index.js

--- a/docker/shared/entrypoint.sh
+++ b/docker/shared/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 echo "Release: $RELEASE"
-node --heapsnapshot-signal=SIGRTMIN+1 index.js
+node --heapsnapshot-signal=SIGUSR1 index.js

--- a/docker/shared/entrypoint.sh
+++ b/docker/shared/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 echo "Release: $RELEASE"
-node --heapsnapshot-signal=SIGUSR2 index.js
+node --heapsnapshot-signal=SIGRTMIN+1 index.js


### PR DESCRIPTION
For us (and potentially self-hosters) to take a heap snapshot of running processes.

```
$ ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
node         1  5.5  6.1 787252 247004 ?       Ssl  16:43   0:02 node --heapsnapshot-signal=SIGUSR1 index.js
$ kill -USR1 1
$ ls
Heap.20190718.133405.15554.0.001.heapsnapshot 
```