### PR TITLE
fix(deployment): adjust the resources needed for otel-collector in each env

### DIFF
--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -72,10 +72,7 @@ const environment = prepareEnvironment({
   rootDns: new pulumi.Config('common').require('dnsZone'),
 });
 deploySentryEventsMonitor({ docker, environment, sentry });
-const observability = deployObservability({
-  envName,
-  tableSuffix: envName === 'prod' ? 'production' : envName,
-});
+const observability = deployObservability({ environment });
 const clickhouse = deployClickhouse();
 const postgres = deployPostgres();
 const redis = deployRedis({ environment });


### PR DESCRIPTION
In https://github.com/graphql-hive/console/pull/6351 we changed some of the resources configurations for otel-collector.

This PR adjusts it back for staging/dev, because they don't such such high amount of cpu/memory.