### PR TITLE
Ensure type extension fields are properly considered in unused schema detection

### DIFF
--- a/.changeset/wet-panthers-notice.md
+++ b/.changeset/wet-panthers-notice.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Corrected an issue where fields from type extensions were not marked as unused when appropriate

--- a/integration-tests/tests/api/schema/unused.spec.ts
+++ b/integration-tests/tests/api/schema/unused.spec.ts
@@ -1,0 +1,161 @@
+import { addDays, formatISO } from 'date-fns';
+import { ProjectType } from 'testkit/gql/graphql';
+import { waitFor } from '../../../testkit/flow';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { graphql } from '../../../testkit/gql';
+import { execute } from '../../../testkit/graphql';
+import { initSeed } from '../../../testkit/seed';
+
+const IntegrationTestsUnusedSchemaQuery = graphql(/* GraphQL */ `
+  query IntegrationTestsUnusedSchema(
+    $usageInput: UnusedSchemaExplorerUsageInput!
+    $targetRef: TargetReferenceInput!
+  ) {
+    latestValidVersion(target: $targetRef) {
+      unusedSchema(usage: $usageInput) {
+        types {
+          __typename
+          ... on GraphQLObjectType {
+            name
+            fields {
+              name
+              usage {
+                isUsed
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`);
+
+test.concurrent(
+  'a field from a type extension should be a part of unused schema if unused',
+  async ({ expect }) => {
+    const { createOrg } = await initSeed().createOwner();
+    const { createProject } = await createOrg();
+    const { createTargetAccessToken, target } = await createProject(ProjectType.Single);
+
+    // Create a token with write rights
+    const writeToken = await createTargetAccessToken({});
+
+    // Publish schema with write rights
+    const publishResult = await writeToken
+      .publishSchema({
+        sdl: /* GraphQL */ `
+          type Query {
+            user: User
+          }
+
+          type User {
+            id: ID!
+          }
+
+          extend type User {
+            name: String
+          }
+        `,
+      })
+      .then(r => r.expectNoGraphQLErrors());
+    // Schema publish should be successful
+    expect(publishResult.schemaPublish.__typename).toBe('SchemaPublishSuccess');
+
+    const period = {
+      from: formatISO(addDays(new Date(), -7)),
+      to: formatISO(addDays(new Date(), 1)),
+    };
+
+    const firstQuery = await execute({
+      document: IntegrationTestsUnusedSchemaQuery,
+      variables: {
+        targetRef: {
+          byId: target.id,
+        },
+        usageInput: {
+          period,
+        },
+      },
+      authToken: writeToken.secret,
+    }).then(r => r.expectNoGraphQLErrors());
+
+    expect(firstQuery.latestValidVersion?.unusedSchema?.types).toHaveLength(2);
+
+    let userType = firstQuery.latestValidVersion?.unusedSchema?.types.find(t =>
+      'name' in t ? t.name === 'User' : false,
+    );
+
+    if (!userType) {
+      throw new Error('User type not found');
+    }
+
+    if (userType.__typename !== 'GraphQLObjectType') {
+      throw new Error('User type is not an object type');
+    }
+
+    let idField = userType.fields.find(f => f.name === 'id');
+    let nameField = userType.fields.find(f => f.name === 'name');
+
+    expect(idField?.usage.isUsed).toEqual(false);
+    expect(nameField, 'User.name should exist').toBeDefined();
+    expect(nameField?.usage.isUsed, 'User.name should be unused').toEqual(false);
+
+    // mark name field as used
+    const collectResult = await writeToken.collectUsage({
+      size: 1,
+      map: {
+        op1: {
+          operation: 'query UserName { user { name } }',
+          operationName: 'UserName',
+          fields: ['Query', 'Query.user', 'User', 'User.name'],
+        },
+      },
+      operations: [
+        {
+          operationMapKey: 'op1',
+          timestamp: Date.now(),
+          execution: {
+            ok: true,
+            duration: 200_000_000,
+            errorsTotal: 0,
+          },
+        },
+      ],
+    });
+    expect(collectResult.status).toEqual(200);
+    await waitFor(8000);
+
+    const secondQuery = await execute({
+      document: IntegrationTestsUnusedSchemaQuery,
+      variables: {
+        targetRef: {
+          byId: target.id,
+        },
+        usageInput: {
+          period,
+        },
+      },
+      authToken: writeToken.secret,
+    }).then(r => r.expectNoGraphQLErrors());
+
+    expect(secondQuery.latestValidVersion?.unusedSchema?.types).toHaveLength(2);
+
+    userType = secondQuery.latestValidVersion?.unusedSchema?.types.find(t =>
+      'name' in t ? t.name === 'User' : false,
+    );
+
+    if (!userType) {
+      throw new Error('User type not found');
+    }
+
+    if (userType.__typename !== 'GraphQLObjectType') {
+      throw new Error('User type is not an object type');
+    }
+
+    idField = userType.fields.find(f => f.name === 'id');
+    nameField = userType.fields.find(f => f.name === 'name');
+
+    expect(idField?.usage.isUsed).toEqual(false);
+    expect(nameField, 'User.name should not be used').toEqual(undefined);
+  },
+);

--- a/integration-tests/tests/api/schema/unused.spec.ts
+++ b/integration-tests/tests/api/schema/unused.spec.ts
@@ -138,7 +138,7 @@ test.concurrent(
       authToken: writeToken.secret,
     }).then(r => r.expectNoGraphQLErrors());
 
-    expect(secondQuery.latestValidVersion?.unusedSchema?.types).toHaveLength(2);
+    expect(secondQuery.latestValidVersion?.unusedSchema?.types).toHaveLength(1);
 
     userType = secondQuery.latestValidVersion?.unusedSchema?.types.find(t =>
       'name' in t ? t.name === 'User' : false,

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -18,6 +18,7 @@
     "@graphql-hive/core": "workspace:*",
     "@graphql-hive/federation-link-utils": "workspace:*",
     "@graphql-inspector/core": "5.1.0-alpha-20231208113249-34700c8a",
+    "@graphql-tools/merge": "9.0.22",
     "@hive/cdn-script": "workspace:*",
     "@hive/emails": "workspace:*",
     "@hive/schema": "workspace:*",

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -135,7 +135,7 @@ export class SchemaVersionHelper {
       'SchemaVersionHelper.getCompositeSchemaAst: Composite',
     );
 
-    return this.autoFixCompositeSchemaAst(compositeSchemaAst);
+    return compositeSchemaAst;
   }
 
   @cache<SchemaVersion>(version => version.id)
@@ -334,61 +334,69 @@ export class SchemaVersionHelper {
   }
 
   /**
-   * There's a possibility that the composite schema contains type extensions.
-   * This is a problem, because other parts of the system may expect it to be clean from type extensions.
-   *
-   * This function will also check for type system extensions and merge them into matching definitions.
-   */
-  private autoFixCompositeSchemaAst(schemaAst: DocumentNode): DocumentNode {
-    const hasTypeExtensions = schemaAst.definitions.some(isTypeSystemExtensionNode);
-
-    if (!hasTypeExtensions) {
-      return schemaAst;
-    }
-
-    this.logger.warn(
-      'Composite schema AST contains type extensions, merging them into matching definitions',
-    );
-
-    return mergeTypeDefs(schemaAst);
-  }
-
-  /**
    * There's a possibility that the composite schema SDL contains parts of the supergraph spec.
+   *
    *
    * This is a problem because we want to show the public schema to the user, and the supergraph spec is not part of that.
    * This may happen when composite schema was produced with an old version of `transformSupergraphToPublicSchema`
    * or when supergraph sdl contained something new.
    *
    * This function will check if the SDL contains supergraph spec and if it does, it will transform it to public schema.
+   *
+   * ---
+   *
+   * There's also a possibility that the composite schema contains type extensions.
+   * This is a problem, because other parts of the system may expect it to be clean from type extensions.
+   *
+   * This function will check for type system extensions and merge them into matching definitions.
    */
-  private autoFixCompositeSchemaSdl(sdl: string, versionId: string) {
+  private autoFixCompositeSchemaSdl(sdl: string, versionId: string): string {
     const isFederationV1Output = sdl.includes('@core');
+    // Poor's man check for type extensions to avoid parsing the SDL if it's not necessary.
+    // Adds a space to the beginning of the SDL to detect type extensions at the beginning of the SDL.
+    const hasPotentiallyTypeExtensions = (' ' + sdl).includes(' extend ');
 
     /**
      * If the SDL is clean from Supergraph spec or it's an output of @apollo/federation, we don't need to transform it.
      * We ignore @apollo/federation, because we never really transformed the output of it to public schema.
      * Doing so might be a breaking change for some users (like: removed join__Graph type).
      */
-    if (isFederationV1Output || !containsSupergraphSpec(sdl)) {
-      return sdl;
+    if (!isFederationV1Output && containsSupergraphSpec(sdl)) {
+      this.logger.warn(
+        'Composite schema SDL contains supergraph spec, transforming to public schema (versionId: %s)',
+        versionId,
+      );
+
+      const transformedSdl = print(
+        transformSupergraphToPublicSchema(parseGraphQLSource(sdl, 'autoFixCompositeSchemaSdl')),
+      );
+
+      this.logger.debug(
+        transformedSdl === sdl
+          ? 'Transformation did not change the original SDL'
+          : 'Transformation changed the original SDL',
+      );
+
+      return transformedSdl;
     }
 
-    this.logger.warn(
-      'Composite schema SDL contains supergraph spec, transforming to public schema (versionId: %s)',
-      versionId,
-    );
+    /**
+     * If the SDL has type extensions, we need to merge them into matching definitions.
+     */
+    if (hasPotentiallyTypeExtensions) {
+      const schemaAst = parseGraphQLSource(sdl, 'autoFixCompositeSchemaSdl');
+      const hasTypeExtensions = schemaAst.definitions.some(isTypeSystemExtensionNode);
 
-    const transformedSdl = print(
-      transformSupergraphToPublicSchema(parseGraphQLSource(sdl, 'autoFixCompositeSchemaSdl')),
-    );
+      if (!hasTypeExtensions) {
+        return sdl;
+      }
 
-    this.logger.debug(
-      transformedSdl === sdl
-        ? 'Transformation did not change the original SDL'
-        : 'Transformation changed the original SDL',
-    );
+      this.logger.warn(
+        'Composite schema AST contains type extensions, merging them into matching definitions',
+      );
+      return print(mergeTypeDefs(schemaAst));
+    }
 
-    return transformedSdl;
+    return sdl;
   }
 }

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -1,5 +1,5 @@
 import type { SchemaVersionMapper as SchemaVersion } from '../module.graphql.mappers';
-import { DocumentNode, isTypeSystemExtensionNode, print } from 'graphql';
+import { isTypeSystemExtensionNode, print } from 'graphql';
 import { Injectable, Scope } from 'graphql-modules';
 import { CriticalityLevel } from '@graphql-inspector/core';
 import { mergeTypeDefs } from '@graphql-tools/merge';

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -353,8 +353,8 @@ export class SchemaVersionHelper {
   private autoFixCompositeSchemaSdl(sdl: string, versionId: string): string {
     const isFederationV1Output = sdl.includes('@core');
     // Poor's man check for type extensions to avoid parsing the SDL if it's not necessary.
-    // Adds a space to the beginning of the SDL to detect type extensions at the beginning of the SDL.
-    const hasPotentiallyTypeExtensions = (' ' + sdl).includes(' extend ');
+    // Checks if the `extend` keyword is followed by a space or a newline and it's not a part of a word.
+    const hasPotentiallyTypeExtensions = /\bextend(?=[\s\n])/.test(sdl);
 
     /**
      * If the SDL is clean from Supergraph spec or it's an output of @apollo/federation, we don't need to transform it.

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -12,6 +12,7 @@
     "@apollo/federation": "0.38.1",
     "@graphql-hive/external-composition": "workspace:*",
     "@graphql-hive/federation-link-utils": "workspace:*",
+    "@graphql-tools/merge": "9.0.22",
     "@graphql-tools/stitch": "9.4.13",
     "@graphql-tools/stitching-directives": "3.1.24",
     "@hive/service-common": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1141,6 +1141,9 @@ importers:
       '@graphql-hive/federation-link-utils':
         specifier: workspace:*
         version: link:../../libraries/federation-link-utils/dist
+      '@graphql-tools/merge':
+        specifier: 9.0.22
+        version: 9.0.22(graphql@16.9.0)
       '@graphql-tools/stitch':
         specifier: 9.4.13
         version: 9.4.13(graphql@16.9.0)
@@ -16303,8 +16306,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -16411,11 +16414,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.596.0':
+  '@aws-sdk/client-sso-oidc@3.596.0(@aws-sdk/client-sts@3.596.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -16454,6 +16457,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0)':
@@ -16587,11 +16591,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.596.0(@aws-sdk/client-sso-oidc@3.596.0)':
+  '@aws-sdk/client-sts@3.596.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -16630,7 +16634,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.723.0':
@@ -16744,7 +16747,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/credential-provider-env': 3.587.0
       '@aws-sdk/credential-provider-http': 3.596.0
       '@aws-sdk/credential-provider-process': 3.587.0
@@ -16863,7 +16866,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.587.0(@aws-sdk/client-sts@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.11
       '@smithy/types': 3.7.2
@@ -17038,7 +17041,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.587.0(@aws-sdk/client-sso-oidc@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.596.0
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.11
       '@smithy/shared-ini-file-loader': 3.1.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -569,7 +569,7 @@ importers:
         version: link:../core/dist
       '@graphql-yoga/plugin-persisted-operations':
         specifier: ^3.9.0
-        version: 3.9.0(@graphql-tools/utils@10.7.2(graphql@16.9.0))(graphql-yoga@5.10.8(graphql@16.9.0))(graphql@16.9.0)
+        version: 3.9.0(@graphql-tools/utils@10.8.4(graphql@16.9.0))(graphql-yoga@5.10.8(graphql@16.9.0))(graphql@16.9.0)
       graphql:
         specifier: ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
         version: 16.9.0
@@ -696,6 +696,9 @@ importers:
       '@graphql-inspector/core':
         specifier: 5.1.0-alpha-20231208113249-34700c8a
         version: 5.1.0-alpha-20231208113249-34700c8a(graphql@16.9.0)
+      '@graphql-tools/merge':
+        specifier: 9.0.22
+        version: 9.0.22(graphql@16.9.0)
       '@hive/cdn-script':
         specifier: workspace:*
         version: link:../cdn-worker
@@ -1236,7 +1239,7 @@ importers:
         version: link:../../libraries/yoga/dist
       '@graphql-yoga/plugin-persisted-operations':
         specifier: 3.9.0
-        version: 3.9.0(@graphql-tools/utils@10.7.2(graphql@16.9.0))(graphql-yoga@5.10.8(graphql@16.9.0))(graphql@16.9.0)
+        version: 3.9.0(@graphql-tools/utils@10.8.4(graphql@16.9.0))(graphql-yoga@5.10.8(graphql@16.9.0))(graphql@16.9.0)
       '@graphql-yoga/plugin-response-cache':
         specifier: 3.9.0
         version: 3.9.0(@envelop/core@5.0.2)(graphql-yoga@5.10.8(graphql@16.9.0))(graphql@16.9.0)
@@ -3978,14 +3981,14 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
-  '@graphql-tools/merge@9.0.13':
-    resolution: {integrity: sha512-OSEOaFOjdkAwR6umRHrTrKjYANbh/0OBb1W8B21dxu8XPaOeoCuShDGXY6ZpragiO8Ke0qFXZGwJGg8ZbDPfvQ==}
+  '@graphql-tools/merge@9.0.17':
+    resolution: {integrity: sha512-3K4g8KKbIqfdmK0L5+VtZsqwAeElPkvT5ejiH+KEhn2wyKNCi4HYHxpQk8xbu+dSwLlm9Lhet1hylpo/mWCkuQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
-  '@graphql-tools/merge@9.0.17':
-    resolution: {integrity: sha512-3K4g8KKbIqfdmK0L5+VtZsqwAeElPkvT5ejiH+KEhn2wyKNCi4HYHxpQk8xbu+dSwLlm9Lhet1hylpo/mWCkuQ==}
+  '@graphql-tools/merge@9.0.22':
+    resolution: {integrity: sha512-bjOs9DlTbo1Yz2UzQcJ78Dn9/pKyY2zNaoqNLfRTTSkO56QFkvqhfjQuqJcqu+V3rtaB2o0VMpWaY6JT8ZTvQA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -4062,6 +4065,12 @@ packages:
 
   '@graphql-tools/utils@10.7.2':
     resolution: {integrity: sha512-Wn85S+hfkzfVFpXVrQ0hjnePa3p28aB6IdAGCiD1SqBCSMDRzL+OFEtyAyb30nV9Mqflqs9lCqjqlR2puG857Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/utils@10.8.4':
+    resolution: {integrity: sha512-HpHBgcmLIE79jWk1v5Bm0Eb8MaPiwSJT/Iy5xIJ+GMe7yAKpCYrbjf7wb+UMDMkLkfEryvo3syCx8k+TMAZ9bA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -8055,6 +8064,10 @@ packages:
   '@whatwg-node/node-fetch@0.7.5':
     resolution: {integrity: sha512-t7kGrt2fdfNvzy1LCAE9/OnIyMtizgFhgJmk7iLJwQsLmR7S86F8Q4aDRPbCfo7pISJP6Fx/tPdfFNjHS23WTA==}
     engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/promise-helpers@1.2.4':
+    resolution: {integrity: sha512-daEUfaHbaMuAcor+FPAVK+pOCSzsAYhK6LN1y81EcakdqQEPQvjm74PTmfwfv8POg8pw4RyCv9LXB1e+mQDwqg==}
+    engines: {node: '>=16.0.0'}
 
   '@whatwg-node/server@0.9.65':
     resolution: {integrity: sha512-CnYTFEUJkbbAcuBXnXirVIgKBfs2YA6sSGjxeq07AUiyXuoQ0fbvTIQoteMglmn09QeGzcH/l0B7nIml83xvVw==}
@@ -17794,7 +17807,7 @@ snapshots:
       '@graphql-codegen/schema-ast': 4.1.0(graphql@16.9.0)
       '@graphql-codegen/typescript': 4.1.2(encoding@0.1.13)(graphql@16.9.0)
       '@graphql-codegen/typescript-resolvers': 4.4.1(encoding@0.1.13)(graphql@16.9.0)
-      '@graphql-tools/merge': 9.0.13(graphql@16.9.0)
+      '@graphql-tools/merge': 9.0.22(graphql@16.9.0)
       '@graphql-tools/utils': 10.7.2(graphql@16.9.0)
       graphql: 16.9.0
       micromatch: 4.0.8
@@ -19181,15 +19194,15 @@ snapshots:
       graphql: 16.9.0
       tslib: 2.8.1
 
-  '@graphql-tools/merge@9.0.13(graphql@16.9.0)':
+  '@graphql-tools/merge@9.0.17(graphql@16.9.0)':
     dependencies:
       '@graphql-tools/utils': 10.7.2(graphql@16.9.0)
       graphql: 16.9.0
       tslib: 2.8.1
 
-  '@graphql-tools/merge@9.0.17(graphql@16.9.0)':
+  '@graphql-tools/merge@9.0.22(graphql@16.9.0)':
     dependencies:
-      '@graphql-tools/utils': 10.7.2(graphql@16.9.0)
+      '@graphql-tools/utils': 10.8.4(graphql@16.9.0)
       graphql: 16.9.0
       tslib: 2.8.1
 
@@ -19265,7 +19278,7 @@ snapshots:
       '@graphql-tools/batch-delegate': 9.0.27(graphql@16.9.0)
       '@graphql-tools/delegate': 10.2.9(graphql@16.9.0)
       '@graphql-tools/executor': 1.3.12(graphql@16.9.0)
-      '@graphql-tools/merge': 9.0.13(graphql@16.9.0)
+      '@graphql-tools/merge': 9.0.22(graphql@16.9.0)
       '@graphql-tools/schema': 10.0.16(graphql@16.9.0)
       '@graphql-tools/utils': 10.7.2(graphql@16.9.0)
       '@graphql-tools/wrap': 10.0.27(graphql@16.9.0)
@@ -19346,6 +19359,15 @@ snapshots:
       graphql: 16.9.0
       tslib: 2.8.1
 
+  '@graphql-tools/utils@10.8.4(graphql@16.9.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@whatwg-node/promise-helpers': 1.2.4
+      cross-inspect: 1.0.1
+      dset: 3.1.4
+      graphql: 16.9.0
+      tslib: 2.8.1
+
   '@graphql-tools/utils@9.2.1(graphql@16.9.0)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
@@ -19407,9 +19429,9 @@ snapshots:
       graphql-sse: 2.5.3(graphql@16.9.0)
       graphql-yoga: 5.10.8(graphql@16.9.0)
 
-  '@graphql-yoga/plugin-persisted-operations@3.9.0(@graphql-tools/utils@10.7.2(graphql@16.9.0))(graphql-yoga@5.10.8(graphql@16.9.0))(graphql@16.9.0)':
+  '@graphql-yoga/plugin-persisted-operations@3.9.0(@graphql-tools/utils@10.8.4(graphql@16.9.0))(graphql-yoga@5.10.8(graphql@16.9.0))(graphql@16.9.0)':
     dependencies:
-      '@graphql-tools/utils': 10.7.2(graphql@16.9.0)
+      '@graphql-tools/utils': 10.8.4(graphql@16.9.0)
       graphql: 16.9.0
       graphql-yoga: 5.10.8(graphql@16.9.0)
 
@@ -24576,6 +24598,10 @@ snapshots:
       fast-querystring: 1.1.2
       tslib: 2.8.1
 
+  '@whatwg-node/promise-helpers@1.2.4':
+    dependencies:
+      tslib: 2.8.1
+
   '@whatwg-node/server@0.9.65':
     dependencies:
       '@whatwg-node/disposablestack': 0.0.5
@@ -27582,7 +27608,7 @@ snapshots:
       '@graphql-tools/graphql-file-loader': 8.0.0(graphql@16.9.0)
       '@graphql-tools/json-file-loader': 8.0.0(graphql@16.9.0)
       '@graphql-tools/load': 8.0.0(graphql@16.9.0)
-      '@graphql-tools/merge': 9.0.13(graphql@16.9.0)
+      '@graphql-tools/merge': 9.0.22(graphql@16.9.0)
       '@graphql-tools/url-loader': 8.0.0(@types/node@22.10.5)(encoding@0.1.13)(graphql@16.9.0)
       '@graphql-tools/utils': 10.7.2(graphql@16.9.0)
       cosmiconfig: 8.3.6(typescript@5.7.3)


### PR DESCRIPTION
The logic that converts SDL into a GraphQL schema representation was ignoring fields from type extensions. Since this representation is what gets fed into the resolvers, those fields were never rendered as unused parts of the schema in the app. It only affected monolithic schemas (`single` projects).

I used `@graphql-tools/merge` to merge type extensions into their base types. Now, type extensions aren't left behind.