### PR TITLE
Prevent compositeSchemaSdl from having type extensions

### DIFF
--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -354,7 +354,7 @@ export class SchemaVersionHelper {
     const isFederationV1Output = sdl.includes('@core');
     // Poor's man check for type extensions to avoid parsing the SDL if it's not necessary.
     // Checks if the `extend` keyword is followed by a space or a newline and it's not a part of a word.
-    const hasPotentiallyTypeExtensions = false; // /\bextend(?=[\s\n])/.test(sdl);
+    const hasPotentiallyTypeExtensions = /\bextend(?=[\s\n])/.test(sdl);
 
     /**
      * If the SDL is clean from Supergraph spec or it's an output of @apollo/federation, we don't need to transform it.

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -354,7 +354,7 @@ export class SchemaVersionHelper {
     const isFederationV1Output = sdl.includes('@core');
     // Poor's man check for type extensions to avoid parsing the SDL if it's not necessary.
     // Checks if the `extend` keyword is followed by a space or a newline and it's not a part of a word.
-    const hasPotentiallyTypeExtensions = /\bextend(?=[\s\n])/.test(sdl);
+    const hasPotentiallyTypeExtensions = false; // /\bextend(?=[\s\n])/.test(sdl);
 
     /**
      * If the SDL is clean from Supergraph spec or it's an output of @apollo/federation, we don't need to transform it.

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -12,6 +12,7 @@
     "@apollo/federation": "0.38.1",
     "@graphql-hive/external-composition": "workspace:*",
     "@graphql-hive/federation-link-utils": "workspace:*",
+    "@graphql-tools/merge": "9.0.22",
     "@graphql-tools/stitch": "9.4.13",
     "@graphql-tools/stitching-directives": "3.1.24",
     "@hive/service-common": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1141,6 +1141,9 @@ importers:
       '@graphql-hive/federation-link-utils':
         specifier: workspace:*
         version: link:../../libraries/federation-link-utils/dist
+      '@graphql-tools/merge':
+        specifier: 9.0.22
+        version: 9.0.22(graphql@16.9.0)
       '@graphql-tools/stitch':
         specifier: 9.4.13
         version: 9.4.13(graphql@16.9.0)
@@ -16303,8 +16306,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -16411,11 +16414,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.596.0':
+  '@aws-sdk/client-sso-oidc@3.596.0(@aws-sdk/client-sts@3.596.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -16454,6 +16457,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.723.0(@aws-sdk/client-sts@3.723.0)':
@@ -16587,11 +16591,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.596.0(@aws-sdk/client-sso-oidc@3.596.0)':
+  '@aws-sdk/client-sts@3.596.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.596.0
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/core': 3.592.0
       '@aws-sdk/credential-provider-node': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -16630,7 +16634,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.723.0':
@@ -16744,7 +16747,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.596.0(@aws-sdk/client-sso-oidc@3.596.0)(@aws-sdk/client-sts@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/credential-provider-env': 3.587.0
       '@aws-sdk/credential-provider-http': 3.596.0
       '@aws-sdk/credential-provider-process': 3.587.0
@@ -16863,7 +16866,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.587.0(@aws-sdk/client-sts@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.596.0(@aws-sdk/client-sso-oidc@3.596.0)
+      '@aws-sdk/client-sts': 3.596.0
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.11
       '@smithy/types': 3.7.2
@@ -17038,7 +17041,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.587.0(@aws-sdk/client-sso-oidc@3.596.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.596.0
+      '@aws-sdk/client-sso-oidc': 3.596.0(@aws-sdk/client-sts@3.596.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.11
       '@smithy/shared-ini-file-loader': 3.1.12


### PR DESCRIPTION
Follow-up https://github.com/graphql-hive/console/pull/6586 to apply the merging logic to the schema that's written to db.

Proof it works when the post-fix (#6586) is disabled - https://github.com/graphql-hive/console/actions/runs/13705781167