### PR TITLE
fix: if insights start and end is the same, then set the range to tha…

### DIFF
--- a/.changeset/big-cars-tie.md
+++ b/.changeset/big-cars-tie.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Fix insights range if selecting same start and end

--- a/packages/web/app/src/lib/hooks/use-date-range-controller.ts
+++ b/packages/web/app/src/lib/hooks/use-date-range-controller.ts
@@ -60,7 +60,7 @@ export function useDateRangeController(args: {
     let to = new Date(parsed.to);
 
     if (from.getTime() === to.getTime()) {
-      to = subSeconds(addHours(new Date(), 20), 1);
+      to = subSeconds(addHours(to, 24), 1);
     }
 
     const resolved = resolveRangeAndResolution({


### PR DESCRIPTION
…t entire day

### Background

https://linear.app/the-guild/issue/CONSOLE-1007/absolute-date-range-issue-in-hive-insights-when-setting-start-and-end

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

The most intuitive solution I could come up with is to set the window to the entire day that is selected.
Another option is that we prevent users from selecting the same day, but I think this solution provides the least friction and best experience.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
