### PR TITLE
Fix log format environment variable name

### DIFF
--- a/packages/web/docs/src/content/gateway/logging-and-error-handling.mdx
+++ b/packages/web/docs/src/content/gateway/logging-and-error-handling.mdx
@@ -26,7 +26,7 @@ a custom logger implementation.
 
 By default without any production environment variable, Hive Gateway prints the logs in human
 readable format. However, in production (when `NODE_ENV` is `production`) Hive Gateway prints the
-logs in JSON format, but if you want to enable it in regular mode, you can pass `LOG_LEVEL=json` as
+logs in JSON format, but if you want to enable it in regular mode, you can pass `LOG_FORMAT=json` as
 an environment variable.
 
 ### Log Levels


### PR DESCRIPTION
To enable JSON logging, it should be `LOG_FORMAT=json` not `LOG_LEVEL=json`