### PR TITLE
docs(gateway): remove NestJS to Nodejs redirection

### DIFF
--- a/packages/web/docs/next.config.js
+++ b/packages/web/docs/next.config.js
@@ -241,11 +241,6 @@ export default withGuildDocs({
       destination: '/docs/gateway/deployment/runtimes/nodejs',
       permanent: true,
     },
-    {
-      source: '/docs/gateway/deployment/node-frameworks/nestjs',
-      destination: '/docs/gateway/deployment/runtimes/nodejs',
-      permanent: true,
-    },
   ],
   env: {
     SITE_URL: 'https://the-guild.dev/graphql/hive',


### PR DESCRIPTION
NestJS docs have been added so we no longer need a redirection