### PR TITLE
feat(deployment): use organization access tokens

### DIFF
--- a/.changeset/sixty-chicken-swim.md
+++ b/.changeset/sixty-chicken-swim.md
@@ -1,0 +1,11 @@
+---
+'hive': major
+---
+
+Restructure the environment variables used for the Hive Cloud hosting. While this is techincally a breaking change it will not really affect people self-hosting Hive.
+
+**Breaking**: Remove unused environment variable options `HIVE_REPORTING`, `HIVE_REPORTING_ENDPOINT` and `HIVE_USAGE_DATA_RETENTION_PURGE_INTERVAL_MINUTES` from the `server` service.
+
+These environment variables are obsolete since the Hive GraphQL schema is reported via the Hive CLI instead.
+
+**Breaking**: Replace the environment variable option `HIVE` with `HIVE_USAGE`, rename environment variable option `HIVE_API_TOKEN` to `HIVE_USAGE_ACCESS_TOKEN` for the `server` service. Require providing the `HIVE_USAGE_ACCESS_TOKEN` environment variable if `HIVE_USAGE` is set to `1`.

--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -33,6 +33,7 @@ import { optimizeAzureCluster } from './utils/azure-helpers';
 import { isDefined } from './utils/helpers';
 import { publishAppDeployment } from './utils/publish-app-deployment';
 import { publishGraphQLSchema } from './utils/publish-graphql-schema';
+import { ServiceSecret } from './utils/secrets';
 
 // eslint-disable-next-line no-process-env
 const imagesTag = process.env.DOCKER_IMAGE_TAG as string;
@@ -229,14 +230,17 @@ const graphql = deployGraphQL({
   observability,
 });
 
-const apiConfig = new pulumi.Config('api');
-const apiEnv = apiConfig.requireObject<Record<string, string>>('env');
+const hiveConfig = new pulumi.Config('hive');
+const hiveConfigSecret = new ServiceSecret('hive-config-secret', {
+  usageAccessToken: hiveConfig.requireSecret('cliAccessToken'),
+});
 
 const publishGraphQLSchemaCommand = publishGraphQLSchema({
   graphql,
   registry: {
     endpoint: `https://${environment.appDns}/registry`,
-    accessToken: apiEnv.HIVE_API_TOKEN,
+    accessToken: hiveConfigSecret.raw.usageAccessToken.get(),
+    target: hiveConfig.require('target'),
   },
   version: {
     commit: imagesTag,
@@ -251,7 +255,8 @@ if (hiveAppPersistedDocumentsAbsolutePath) {
     appName: 'hive-app',
     registry: {
       endpoint: `https://${environment.appDns}/registry`,
-      accessToken: apiEnv.HIVE_API_TOKEN,
+      accessToken: hiveConfigSecret.raw.usageAccessToken.get(),
+      target: hiveConfig.require('target'),
     },
     version: {
       commit: imagesTag,

--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -239,7 +239,7 @@ const publishGraphQLSchemaCommand = publishGraphQLSchema({
   graphql,
   registry: {
     endpoint: `https://${environment.appDns}/registry`,
-    accessToken: hiveConfigSecret.raw.usageAccessToken.get(),
+    accessToken: hiveConfigSecret.raw.usageAccessToken,
     target: hiveConfig.require('target'),
   },
   version: {
@@ -255,7 +255,7 @@ if (hiveAppPersistedDocumentsAbsolutePath) {
     appName: 'hive-app',
     registry: {
       endpoint: `https://${environment.appDns}/registry`,
-      accessToken: hiveConfigSecret.raw.usageAccessToken.get(),
+      accessToken: hiveConfigSecret.raw.usageAccessToken,
       target: hiveConfig.require('target'),
     },
     version: {

--- a/deployment/utils/publish-app-deployment.ts
+++ b/deployment/utils/publish-app-deployment.ts
@@ -5,7 +5,7 @@ import * as pulumi from '@pulumi/pulumi';
 import { ClickhouseConnectionSecret } from '../services/clickhouse';
 import { ServiceDeployment } from './service-deployment';
 
-const dockerImage = 'ghcr.io/graphql-hive/cli:0.44.4';
+const dockerImage = 'ghcr.io/graphql-hive/cli:0.49.0';
 
 /** Publish API GraphQL schema to Hive schema registry. */
 export function publishAppDeployment(args: {

--- a/deployment/utils/publish-app-deployment.ts
+++ b/deployment/utils/publish-app-deployment.ts
@@ -1,6 +1,7 @@
 import { local } from '@pulumi/command';
 import { Secret } from '@pulumi/kubernetes/core/v1';
 import { Resource } from '@pulumi/pulumi';
+import * as pulumi from '@pulumi/pulumi';
 import { ClickhouseConnectionSecret } from '../services/clickhouse';
 import { ServiceDeployment } from './service-deployment';
 
@@ -9,7 +10,7 @@ const dockerImage = 'ghcr.io/graphql-hive/cli:0.44.4';
 /** Publish API GraphQL schema to Hive schema registry. */
 export function publishAppDeployment(args: {
   appName: string;
-  registry: { accessToken: string; endpoint: string; target: string };
+  registry: { accessToken: pulumi.Output<string>; endpoint: string; target: string };
   version: {
     commit: string;
   };
@@ -49,13 +50,15 @@ export function publishAppDeployment(args: {
   const createCommand = new local.Command(
     `create-app-deployment-${args.appName}`,
     {
-      create:
-        `docker run --name "create-app-deployment-${args.appName}"` +
-        ` --rm -v ${args.persistedDocumentsPath}:/usr/src/app/persisted-documents.json` +
-        ` ${dockerImage}` +
-        ` app:create` +
-        ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken} --target ${args.registry.target}` +
-        ` --name ${args.appName} --version ${args.version.commit} ./persisted-documents.json`,
+      create: args.registry.accessToken.apply(
+        accessToken =>
+          `docker run --name "create-app-deployment-${args.appName}"` +
+          ` --rm -v ${args.persistedDocumentsPath}:/usr/src/app/persisted-documents.json` +
+          ` ${dockerImage}` +
+          ` app:create` +
+          ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${accessToken} --target ${args.registry.target}` +
+          ` --name ${args.appName} --version ${args.version.commit} ./persisted-documents.json`,
+      ),
     },
     {
       dependsOn: [wakeupCommandJob, ...(args.dependsOn || [])].filter(v => v !== null),
@@ -66,12 +69,14 @@ export function publishAppDeployment(args: {
   return new local.Command(
     `publish-app-deployment-${args.appName}`,
     {
-      create:
-        `docker run --rm --name "publish-app-deployment-${args.appName}"` +
-        ` ${dockerImage}` +
-        ` app:publish` +
-        ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken} --target ${args.registry.target}` +
-        ` --name ${args.appName} --version ${args.version.commit}`,
+      create: args.registry.accessToken.apply(
+        accessToken =>
+          `docker run --rm --name "publish-app-deployment-${args.appName}"` +
+          ` ${dockerImage}` +
+          ` app:publish` +
+          ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${accessToken} --target ${args.registry.target}` +
+          ` --name ${args.appName} --version ${args.version.commit}`,
+      ),
     },
     {
       dependsOn: createCommand,

--- a/deployment/utils/publish-app-deployment.ts
+++ b/deployment/utils/publish-app-deployment.ts
@@ -9,7 +9,7 @@ const dockerImage = 'ghcr.io/graphql-hive/cli:0.44.4';
 /** Publish API GraphQL schema to Hive schema registry. */
 export function publishAppDeployment(args: {
   appName: string;
-  registry: { accessToken: string; endpoint: string };
+  registry: { accessToken: string; endpoint: string; target: string };
   version: {
     commit: string;
   };
@@ -54,7 +54,7 @@ export function publishAppDeployment(args: {
         ` --rm -v ${args.persistedDocumentsPath}:/usr/src/app/persisted-documents.json` +
         ` ${dockerImage}` +
         ` app:create` +
-        ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken}` +
+        ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken} --target ${args.registry.target}` +
         ` --name ${args.appName} --version ${args.version.commit} ./persisted-documents.json`,
     },
     {
@@ -70,7 +70,7 @@ export function publishAppDeployment(args: {
         `docker run --rm --name "publish-app-deployment-${args.appName}"` +
         ` ${dockerImage}` +
         ` app:publish` +
-        ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken}` +
+        ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken} --target ${args.registry.target}` +
         ` --name ${args.appName} --version ${args.version.commit}`,
     },
     {

--- a/deployment/utils/publish-graphql-schema.ts
+++ b/deployment/utils/publish-graphql-schema.ts
@@ -7,23 +7,25 @@ const dockerImage = 'ghcr.io/graphql-hive/cli:0.44.4';
 /** Publish API GraphQL schema to Hive schema registry. */
 export function publishGraphQLSchema(args: {
   graphql: GraphQL;
-  registry: { accessToken: string; endpoint: string; target: string };
+  registry: { accessToken: pulumi.Output<string>; endpoint: string; target: string };
   version: {
     commit: string;
   };
   schemaPath: string;
 }) {
-  const command =
+  const command = (accessToken: string) =>
     `schema:publish` +
-    ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken} --target ${args.registry.target}` +
+    ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${accessToken} --target ${args.registry.target}` +
     ` --commit ${args.version.commit} --author "Hive CD" ./schema.graphqls`;
 
   return new local.Command(
     'publish-graphql-schema',
     {
-      create:
-        `docker run --name "publish-graphql-schema" -v ${args.schemaPath}:/usr/src/app/schema.graphqls ${dockerImage} ` +
-        command,
+      create: args.registry.accessToken.apply(
+        accessToken =>
+          `docker run --name "publish-graphql-schema" -v ${args.schemaPath}:/usr/src/app/schema.graphqls ${dockerImage} ` +
+          command(accessToken),
+      ),
     },
     {
       dependsOn: [args.graphql.deployment, args.graphql.service],

--- a/deployment/utils/publish-graphql-schema.ts
+++ b/deployment/utils/publish-graphql-schema.ts
@@ -1,4 +1,5 @@
 import { local } from '@pulumi/command';
+import * as pulumi from '@pulumi/pulumi';
 import type { GraphQL } from '../services/graphql';
 
 const dockerImage = 'ghcr.io/graphql-hive/cli:0.44.4';
@@ -6,7 +7,7 @@ const dockerImage = 'ghcr.io/graphql-hive/cli:0.44.4';
 /** Publish API GraphQL schema to Hive schema registry. */
 export function publishGraphQLSchema(args: {
   graphql: GraphQL;
-  registry: { accessToken: string; endpoint: string };
+  registry: { accessToken: string; endpoint: string; target: string };
   version: {
     commit: string;
   };
@@ -14,7 +15,7 @@ export function publishGraphQLSchema(args: {
 }) {
   const command =
     `schema:publish` +
-    ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken}` +
+    ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken} --target ${args.registry.target}` +
     ` --commit ${args.version.commit} --author "Hive CD" ./schema.graphqls`;
 
   return new local.Command(

--- a/deployment/utils/publish-graphql-schema.ts
+++ b/deployment/utils/publish-graphql-schema.ts
@@ -2,7 +2,7 @@ import { local } from '@pulumi/command';
 import * as pulumi from '@pulumi/pulumi';
 import type { GraphQL } from '../services/graphql';
 
-const dockerImage = 'ghcr.io/graphql-hive/cli:0.44.4';
+const dockerImage = 'ghcr.io/graphql-hive/cli:0.49.0';
 
 /** Publish API GraphQL schema to Hive schema registry. */
 export function publishGraphQLSchema(args: {

--- a/deployment/utils/service-deployment.ts
+++ b/deployment/utils/service-deployment.ts
@@ -62,7 +62,7 @@ export class ServiceDeployment {
         };
       };
       availabilityOnEveryNode?: boolean;
-      command?: string[];
+      command?: pulumi.Input<pulumi.Input<string>[]>;
     },
     protected dependencies?: Array<pulumi.Resource | undefined | null>,
     protected parent?: pulumi.Resource | null,

--- a/packages/services/server/README.md
+++ b/packages/services/server/README.md
@@ -29,7 +29,7 @@ The GraphQL API for GraphQL Hive.
 | `CLICKHOUSE_REQUEST_TIMEOUT`                | No                                                   | Force a request timeout value for ClickHouse operations (in ms)                                          | `30000`                                              |
 | `REDIS_HOST`                                | **Yes**                                              | The host of your redis instance.                                                                         | `"127.0.0.1"`                                        |
 | `REDIS_PORT`                                | **Yes**                                              | The port of your redis instance.                                                                         | `6379`                                               |
-| `REDIS_PASSWORD`                            | **Yes**                                              | The password of your redis instance.                                                                     | `"apollorocks"`                                      |
+| `REDIS_PASSWORD`                            | **Yes**                                              | The password of your redis instance.                                                                     | `"password"`                                         |
 | `REDIS_TLS_ENABLED`                         | **No**                                               | Enable TLS for redis connection (rediss://).                                                             | `"0"`                                                |
 | `S3_ENDPOINT`                               | **Yes**                                              | The S3 endpoint.                                                                                         | `http://localhost:9000`                              |
 | `S3_ACCESS_KEY_ID`                          | **Yes**                                              | The S3 access key id.                                                                                    | `minioadmin`                                         |
@@ -89,14 +89,12 @@ The GraphQL API for GraphQL Hive.
 If you are self-hosting GraphQL Hive, you can ignore this section. It is only required for the Cloud
 version.
 
-| Name                      | Required                      | Description                            | Example Value                   |
-| ------------------------- | ----------------------------- | -------------------------------------- | ------------------------------- |
-| `COMMERCE_ENDPOINT`       | **Yes**                       | The endpoint of the commerce service.  | `http://127.0.0.1:4012`         |
-| `CDN_CF`                  | No                            | Whether the CDN is enabled.            | `1` (enabled) or `0` (disabled) |
-| `CDN_CF_BASE_URL`         | No (**Yes** if `CDN` is `1`)  | The base URL of the cdn.               | `https://cdn.graphql-hive.com`  |
-| `HIVE`                    | No                            | The internal endpoint key.             | `iliketurtles`                  |
-| `HIVE_API_TOKEN`          | No (**Yes** if `HIVE` is set) | The internal endpoint key.             | `iliketurtles`                  |
-| `HIVE_USAGE`              | No                            | The internal endpoint key.             | `1` (enabled) or `0` (disabled) |
-| `HIVE_USAGE_ENDPOINT`     | No                            | The endpoint used for usage reporting. | `http://127.0.0.1:4001`         |
-| `HIVE_REPORTING`          | No                            | The internal endpoint key.             | `iliketurtles`                  |
-| `HIVE_REPORTING_ENDPOINT` | No                            | The internal endpoint key.             | `http://127.0.0.1:4000/graphql` |
+| Name                      | Required                             | Description                                                    | Example Value                                       |
+| ------------------------- | ------------------------------------ | -------------------------------------------------------------- | --------------------------------------------------- |
+| `COMMERCE_ENDPOINT`       | **Yes**                              | The endpoint of the commerce service.                          | `http://127.0.0.1:4012`                             |
+| `CDN_CF`                  | No                                   | Whether the CDN is enabled.                                    | `1` (enabled) or `0` (disabled)                     |
+| `CDN_CF_BASE_URL`         | No (**Yes** if `CDN` is `1`)         | The base URL of the cdn.                                       | `https://cdn.graphql-hive.com`                      |
+| `HIVE_USAGE`              | No                                   | Whether usage reporting for the GraphQL API to Hive is enabled | `1` (enabled) or `0` (disabled)                     |
+| `HIVE_USAGE_TARGET`       | No (**Yes** if `HIVE` is set to `1`) | The target to which the usage data should be reported          | `the-guild/graphql-hive/development`                |
+| `HIVE_USAGE_ACCESS_TOKEN` | No (**Yes** if `HIVE` is set to `1`) | The internal endpoint key.                                     | `iliketurtles`                                      |
+| `HIVE_USAGE_ENDPOINT`     | No                                   | The endpoint used for usage reporting.                         | `http://app.graphql-hive.com/usage` (default value) |

--- a/packages/services/server/src/environment.ts
+++ b/packages/services/server/src/environment.ts
@@ -132,15 +132,12 @@ const CdnApiModel = zod.union([
 ]);
 
 const HiveModel = zod.union([
-  zod.object({ HIVE: emptyString(zod.literal('0').optional()) }),
+  zod.object({ HIVE_USAGE: emptyString(zod.literal('0').optional()) }),
   zod.object({
-    HIVE: zod.literal('1'),
-    HIVE_API_TOKEN: zod.string(),
-    HIVE_USAGE: zod.union([zod.literal('0'), zod.literal('1')]).optional(),
+    HIVE_USAGE: zod.literal('1'),
     HIVE_USAGE_ENDPOINT: zod.string().url().optional(),
-    HIVE_USAGE_DATA_RETENTION_PURGE_INTERVAL_MINUTES: emptyString(NumberFromString.optional()),
-    HIVE_REPORTING: zod.union([zod.literal('0'), zod.literal('1')]).optional(),
-    HIVE_REPORTING_ENDPOINT: zod.string().url().optional(),
+    HIVE_USAGE_TARGET: zod.string(),
+    HIVE_USAGE_ACCESS_TOKEN: zod.string(),
   }),
 ]);
 
@@ -330,18 +327,12 @@ const zendeskSupport = extractConfig(configs.zendeskSupport);
 const tracing = extractConfig(configs.tracing);
 const hivePersistedDocuments = extractConfig(configs.hivePersistedDocuments);
 
-const hiveConfig =
-  hive.HIVE === '1'
+const hiveUsageConfig =
+  hive.HIVE_USAGE === '1'
     ? {
-        token: hive.HIVE_API_TOKEN,
-        reporting:
-          hive.HIVE_REPORTING === '1' ? { endpoint: hive.HIVE_REPORTING_ENDPOINT ?? null } : null,
-        usage:
-          hive.HIVE_USAGE === '1'
-            ? {
-                endpoint: hive.HIVE_USAGE_ENDPOINT ?? null,
-              }
-            : null,
+        target: hive.HIVE_USAGE_TARGET,
+        token: hive.HIVE_USAGE_ACCESS_TOKEN,
+        endpoint: hive.HIVE_USAGE_ENDPOINT ?? null,
       }
     : null;
 
@@ -353,7 +344,7 @@ const hivePersistedDocumentsConfig =
       }
     : null;
 
-export type HiveConfig = typeof hiveConfig;
+export type HiveUsageConfig = typeof hiveUsageConfig;
 export type HivePersistedDocumentsConfig = typeof hivePersistedDocumentsConfig;
 
 export const env = {
@@ -511,7 +502,7 @@ export const env = {
           port: prometheus.PROMETHEUS_METRICS_PORT ?? 10_254,
         }
       : null,
-  hive: hiveConfig,
+  hive: hiveUsageConfig,
   hivePersistedDocuments: hivePersistedDocumentsConfig,
   graphql: {
     origin: base.GRAPHQL_PUBLIC_ORIGIN,

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -445,7 +445,7 @@ export async function main() {
       },
       isProduction: env.environment !== 'development',
       release: env.release,
-      hiveConfig: env.hive,
+      hiveUsageConfig: env.hive,
       hivePersistedDocumentsConfig: env.hivePersistedDocuments,
       tracing,
       logger: logger as any,


### PR DESCRIPTION
### Description

Changes the deployment configuration to use organization access tokens instead of target access tokens.

Small cleanup of environment variables.

Requires https://github.com/graphql-hive/deployment/pull/1439

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
