### PR TITLE
Remove duplicate "Gateway" item in sidebar

### DIFF
--- a/packages/web/docs/src/app/_meta.ts
+++ b/packages/web/docs/src/app/_meta.ts
@@ -41,6 +41,11 @@ const meta: Record<string, DeepPartial<Item | MenuItem | PageItem>> = {
     type: 'page',
     display: 'hidden',
   },
+  gateway: {
+    title: 'Gateway',
+    type: 'page',
+    display: 'hidden',
+  },
   products: {
     title: 'Products',
     type: 'menu',


### PR DESCRIPTION
### Background

I inadvertently added "Hive Gateway" to sidebar, causing a duplicate React key error, because I forgot about adding it to `_meta.ts` as `hidden`, and Nextra added it automatically based on the directory structure.

<img width="244" alt="image" src="https://github.com/user-attachments/assets/ec729dee-06e0-45df-8612-296a78f11b5a" />

### Description

We already have "Gateway" entry in the sidebar that goes to the part of docs about Hive Gateway.
Linking from docs back to landing page feels off, overtly salesy, so this PR removes the newest `href=/gateway` entry.
