### PR TITLE
feat(deployment): add public graphql api route

### DIFF
--- a/deployment/services/environment.ts
+++ b/deployment/services/environment.ts
@@ -22,6 +22,7 @@ export function prepareEnvironment(input: {
       : input.environment;
 
   const appDns = `app.${input.rootDns}`;
+  const apiDns = `api.${input.rootDns}`;
 
   return {
     envVars: {
@@ -38,6 +39,7 @@ export function prepareEnvironment(input: {
     encryptionSecret,
     release: input.release,
     appDns,
+    apiDns,
     rootDns: input.rootDns,
   };
 }

--- a/deployment/services/proxy.ts
+++ b/deployment/services/proxy.ts
@@ -100,5 +100,15 @@ export function deployProxy({
         service: usage.service,
         retriable: true,
       },
+    ])
+    .registerService({ record: environment.apiDns }, [
+      {
+        name: 'graphql-api',
+        path: '/graphql',
+        customRewrite: '/graphql-public',
+        service: graphql.service,
+        requestTimeout: '60s',
+        retriable: true,
+      },
     ]);
 }


### PR DESCRIPTION
### Description

Adjust the proxy configuration to redirect

```
https://api.graphql-hive.com/graphql
https://api.dev.graphql-hive.com/graphql
https://api.staging.graphql-hive.com/graphql
```

to `graphql-api/graphql-public`

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
