### PR TITLE
feat(sdk): better handling of token info and usage configuration

### DIFF
--- a/.changeset/tiny-glasses-talk.md
+++ b/.changeset/tiny-glasses-talk.md
@@ -1,0 +1,11 @@
+---
+'@graphql-hive/core': minor
+'@graphql-hive/apollo': minor
+'@graphql-hive/envelop': minor
+'@graphql-hive/yoga': minor
+---
+
+Add error logging for invalid combinations of the `target` and `token` configuration.
+
+- Please make sure to provide the `target` option for usage reporting when using a token that starts with `hvo1/`.
+- Please make sure to **not** provide a `target` option for usage reporting when a token does **not** start with `hvo1/`

--- a/packages/libraries/core/src/client/client.ts
+++ b/packages/libraries/core/src/client/client.ts
@@ -53,10 +53,16 @@ export function createHive(options: HivePluginOptions): HiveClient {
     await Promise.all([schemaReporter.dispose(), usage.dispose()]);
   }
 
+  const isOrganizationAccessToken = options.token?.startsWith('hvo1/') === true;
+
   // enabledOnly when `printTokenInfo` is `true` or `debug` is true and `printTokenInfo` is not `false`
-  const printTokenInfo = enabled
-    ? options.printTokenInfo === true || (!!options.debug && options.printTokenInfo !== false)
-    : false;
+  const printTokenInfo =
+    enabled &&
+    /** Access tokens using the `hvo1/` prefix cannot print any token information. */
+    isOrganizationAccessToken === false
+      ? options.printTokenInfo === true || (!!options.debug && options.printTokenInfo !== false)
+      : false;
+
   const infoLogger = createHiveLogger(logger, '[info]');
 
   const info = printTokenInfo

--- a/packages/libraries/core/src/client/types.ts
+++ b/packages/libraries/core/src/client/types.ts
@@ -234,6 +234,10 @@ export type HivePluginOptions = OptionalWhenFalse<
     /**
      * Print info about the token.
      * Disabled by default (enabled by default only in debug mode)
+     *
+     * **Note:** The new access tokens do not support printing the token info. For every access token starting with `hvo1/`
+     * no information will be printed.
+     * @deprecated This option will be removed in the future.
      */
     printTokenInfo?: boolean;
     /**

--- a/packages/libraries/core/tests/usage.spec.ts
+++ b/packages/libraries/core/tests/usage.spec.ts
@@ -750,7 +750,7 @@ test('retry on non-200', async () => {
 
 test('constructs URL with usage.target', async ({ expect }) => {
   const logger = createHiveTestingLogger();
-  const token = 'Token';
+  const token = 'hvo1/brrrrt';
   const dUrl = Promise.withResolvers<string>();
 
   const hive = createHive({


### PR DESCRIPTION
### Background

This adds a bit more context when using any combinations of the `target` and `token` config option.
Not sure if it is really needed, but it could potentially help people figure out what is wrong with their configuration.