### PR TITLE
feat(api): refactor Query.organization + expose via public API

### DIFF
--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -87,18 +87,16 @@ export function getOrganization(organizationSlug: string, authToken: string) {
   return execute({
     document: graphql(`
       query getOrganization($organizationSlug: String!) {
-        organization(selector: { organizationSlug: $organizationSlug }) {
-          organization {
-            id
-            slug
-            getStarted {
-              creatingProject
-              publishingSchema
-              checkingSchema
-              invitingMembers
-              reportingOperations
-              enablingUsageBasedBreakingChanges
-            }
+        organization(reference: { bySelector: { organizationSlug: $organizationSlug } }) {
+          id
+          slug
+          getStarted {
+            creatingProject
+            publishingSchema
+            checkingSchema
+            invitingMembers
+            reportingOperations
+            enablingUsageBasedBreakingChanges
           }
         }
       }
@@ -205,20 +203,18 @@ export function getOrganizationMembers(selector: OrganizationSelectorInput, auth
   return execute({
     document: graphql(`
       query getOrganizationMembers($selector: OrganizationSelectorInput!) {
-        organization(selector: $selector) {
-          organization {
-            members {
-              nodes {
+        organization(reference: { bySelector: $selector }) {
+          members {
+            nodes {
+              id
+              user {
                 id
-                user {
-                  id
-                  email
-                }
-                role {
-                  id
-                  name
-                  permissions
-                }
+                email
+              }
+              role {
+                id
+                name
+                permissions
               }
             }
           }
@@ -236,14 +232,12 @@ export function getOrganizationProjects(selector: OrganizationSelectorInput, aut
   return execute({
     document: graphql(`
       query getOrganizationProjects($selector: OrganizationSelectorInput!) {
-        organization(selector: $selector) {
-          organization {
-            projects {
-              nodes {
-                id
-                slug
-                name
-              }
+        organization(reference: { bySelector: $selector }) {
+          projects {
+            nodes {
+              id
+              slug
+              name
             }
           }
         }
@@ -590,11 +584,9 @@ export function readOrganizationInfo(
   return execute({
     document: graphql(`
       query readOrganizationInfo($selector: OrganizationSelectorInput!) {
-        organization(selector: $selector) {
-          organization {
-            id
-            slug
-          }
+        organization(reference: { bySelector: $selector }) {
+          id
+          slug
         }
       }
     `),

--- a/integration-tests/testkit/schema-policy.ts
+++ b/integration-tests/testkit/schema-policy.ts
@@ -3,18 +3,16 @@ import { RuleInstanceSeverityLevel, SchemaPolicyInput } from './gql/graphql';
 
 export const OrganizationAndProjectsWithSchemaPolicy = graphql(`
   query OrganizationAndProjectsWithSchemaPolicy($organization: String!) {
-    organization(selector: { organizationSlug: $organization }) {
-      organization {
+    organization(reference: { bySelector: { organizationSlug: $organization } }) {
+      id
+      schemaPolicy {
         id
-        schemaPolicy {
+      }
+      projects {
+        nodes {
           id
-        }
-        projects {
-          nodes {
+          schemaPolicy {
             id
-            schemaPolicy {
-              id
-            }
           }
         }
       }

--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -175,7 +175,7 @@ export function initSeed() {
                 r.expectNoGraphQLErrors(),
               );
 
-              return result.organization!.organization;
+              return result.organization!;
             },
             async inviteMember(
               email = 'some@email.com',
@@ -202,7 +202,7 @@ export function initSeed() {
                 ownerToken,
               ).then(r => r.expectNoGraphQLErrors());
 
-              const members = membersResult.organization?.organization.members?.nodes;
+              const members = membersResult.organization?.members?.nodes;
 
               if (!members) {
                 throw new Error(`Could not get members for org ${organization.slug}`);
@@ -216,7 +216,7 @@ export function initSeed() {
                 token,
               ).then(r => r.expectNoGraphQLErrors());
 
-              const projects = projectsResult.organization?.organization.projects.nodes;
+              const projects = projectsResult.organization?.projects.nodes;
 
               if (!projects) {
                 throw new Error(`Could not get projects for org ${organization.slug}`);

--- a/integration-tests/tests/api/oidc-integrations/crud.spec.ts
+++ b/integration-tests/tests/api/oidc-integrations/crud.spec.ts
@@ -5,13 +5,11 @@ import { initSeed } from '../../../testkit/seed';
 
 const OrganizationWithOIDCIntegration = graphql(`
   query OrganizationWithOIDCIntegration($organizationSlug: String!) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
+    organization(reference: { bySelector: { organizationSlug: $organizationSlug } }) {
+      id
+      oidcIntegration {
         id
-        oidcIntegration {
-          id
-          oidcUserAccessOnly
-        }
+        oidcUserAccessOnly
       }
     }
   }
@@ -19,10 +17,8 @@ const OrganizationWithOIDCIntegration = graphql(`
 
 const OrganizationReadTest = graphql(`
   query OrganizationReadTest($organizationSlug: String!) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-      }
+    organization(reference: { bySelector: { organizationSlug: $organizationSlug } }) {
+      id
     }
   }
 `);
@@ -805,9 +801,7 @@ describe('restrictions', () => {
       authToken: ownerToken,
     }).then(r => r.expectNoGraphQLErrors());
 
-    expect(refetchedOrg.organization?.organization.oidcIntegration?.oidcUserAccessOnly).toEqual(
-      true,
-    );
+    expect(refetchedOrg.organization?.oidcIntegration?.oidcUserAccessOnly).toEqual(true);
 
     const invitation = await inviteMember('example@example.com');
     const invitationCode = invitation.ok?.code;
@@ -847,9 +841,7 @@ describe('restrictions', () => {
       authToken: ownerToken,
     }).then(r => r.expectNoGraphQLErrors());
 
-    expect(orgAfterOidc.organization?.organization.oidcIntegration?.oidcUserAccessOnly).toEqual(
-      true,
-    );
+    expect(orgAfterOidc.organization?.oidcIntegration?.oidcUserAccessOnly).toEqual(true);
 
     const restrictionsUpdateResult = await execute({
       document: UpdateOIDCRestrictionsMutation,
@@ -875,8 +867,7 @@ describe('restrictions', () => {
     }).then(r => r.expectNoGraphQLErrors());
 
     expect(
-      orgAfterDisablingOidcRestrictions.organization?.organization.oidcIntegration
-        ?.oidcUserAccessOnly,
+      orgAfterDisablingOidcRestrictions.organization?.oidcIntegration?.oidcUserAccessOnly,
     ).toEqual(false);
 
     const invitation = await inviteMember('example@example.com');
@@ -929,7 +920,7 @@ describe('restrictions', () => {
         authToken: ownerToken,
       }).then(r => r.expectNoGraphQLErrors());
 
-      expect(readAccessCheck.organization?.organization.id).toEqual(organization.id);
+      expect(readAccessCheck.organization?.id).toEqual(organization.id);
     },
   );
 });
@@ -969,7 +960,7 @@ test.concurrent(
       authToken: memberToken,
     }).then(r => r.expectNoGraphQLErrors());
 
-    expect(result.organization!.organization.oidcIntegration).toEqual(null);
+    expect(result.organization!.oidcIntegration).toEqual(null);
 
     await updateMemberRole(role, ['oidc:modify']);
 
@@ -981,6 +972,6 @@ test.concurrent(
       authToken: memberToken,
     }).then(r => r.expectNoGraphQLErrors());
 
-    expect(result.organization!.organization.oidcIntegration).not.toEqual(null);
+    expect(result.organization!.oidcIntegration).not.toEqual(null);
   },
 );

--- a/integration-tests/tests/api/oidc-integrations/crud.spec.ts
+++ b/integration-tests/tests/api/oidc-integrations/crud.spec.ts
@@ -115,12 +115,10 @@ describe('create', () => {
 
       expect(refetchedOrg).toEqual({
         organization: {
-          organization: {
-            id: organization.id,
-            oidcIntegration: {
-              id: result.createOIDCIntegration.ok!.createdOIDCIntegration.id,
-              oidcUserAccessOnly: true,
-            },
+          id: organization.id,
+          oidcIntegration: {
+            id: result.createOIDCIntegration.ok!.createdOIDCIntegration.id,
+            oidcUserAccessOnly: true,
           },
         },
       });
@@ -458,12 +456,10 @@ describe('delete', () => {
 
       expect(refetchedOrg).toEqual({
         organization: {
-          organization: {
-            id: organization.id,
-            oidcIntegration: {
-              id: oidcIntegrationId,
-              oidcUserAccessOnly: true,
-            },
+          id: organization.id,
+          oidcIntegration: {
+            id: oidcIntegrationId,
+            oidcUserAccessOnly: true,
           },
         },
       });
@@ -497,10 +493,8 @@ describe('delete', () => {
 
       expect(refetchedOrg).toEqual({
         organization: {
-          organization: {
-            id: organization.id,
-            oidcIntegration: null,
-          },
+          id: organization.id,
+          oidcIntegration: null,
         },
       });
     });

--- a/integration-tests/tests/api/policy/policy-access.spec.ts
+++ b/integration-tests/tests/api/policy/policy-access.spec.ts
@@ -134,11 +134,9 @@ describe('Policy Access', () => {
   describe('Organization', () => {
     const query = graphql(`
       query OrganizationSchemaPolicyAccess($selector: OrganizationSelectorInput!) {
-        organization(selector: $selector) {
-          organization {
-            schemaPolicy {
-              id
-            }
+        organization(reference: { bySelector: $selector }) {
+          schemaPolicy {
+            id
           }
         }
       }
@@ -259,7 +257,7 @@ describe('Policy Access', () => {
           },
           authToken: memberToken,
         }).then(r => r.expectNoGraphQLErrors());
-        expect(result.organization?.organization.schemaPolicy?.id).not.toBeNull();
+        expect(result.organization?.schemaPolicy?.id).not.toBeNull();
       },
     );
   });

--- a/integration-tests/tests/api/policy/policy-crud.spec.ts
+++ b/integration-tests/tests/api/policy/policy-crud.spec.ts
@@ -27,9 +27,9 @@ describe('Policy CRUD', () => {
           authToken: ownerToken,
         }).then(r => r.expectNoGraphQLErrors());
 
-        expect(result.organization?.organization.schemaPolicy).toBe(null);
-        expect(result.organization?.organization.projects.nodes).toHaveLength(1);
-        expect(result.organization?.organization.projects.nodes[0].schemaPolicy).toBeNull();
+        expect(result.organization?.schemaPolicy).toBe(null);
+        expect(result.organization?.projects.nodes).toHaveLength(1);
+        expect(result.organization?.projects.nodes[0].schemaPolicy).toBeNull();
       },
     );
 
@@ -123,8 +123,8 @@ describe('Policy CRUD', () => {
           authToken: ownerToken,
         }).then(r => r.expectNoGraphQLErrors());
 
-        expect(result.organization?.organization.projects.nodes).toHaveLength(1);
-        expect(result.organization?.organization.projects.nodes[0].schemaPolicy).toBeNull();
+        expect(result.organization?.projects.nodes).toHaveLength(1);
+        expect(result.organization?.projects.nodes[0].schemaPolicy).toBeNull();
       },
     );
 
@@ -178,9 +178,9 @@ describe('Policy CRUD', () => {
         authToken: ownerToken,
       }).then(r => r.expectNoGraphQLErrors());
 
-      expect(result.organization?.organization.schemaPolicy).toBe(null);
-      expect(result.organization?.organization.projects.nodes).toHaveLength(1);
-      expect(result.organization?.organization.projects.nodes[0].schemaPolicy).toBeNull();
+      expect(result.organization?.schemaPolicy).toBe(null);
+      expect(result.organization?.projects.nodes).toHaveLength(1);
+      expect(result.organization?.projects.nodes[0].schemaPolicy).toBeNull();
 
       const upsertResult = await setOrganizationSchemaPolicy(VALID_POLICY, true);
 

--- a/integration-tests/tests/api/target/tokens.spec.ts
+++ b/integration-tests/tests/api/target/tokens.spec.ts
@@ -130,9 +130,7 @@ test.concurrent(
     await expect(organizationResult.expectNoGraphQLErrors()).resolves.toEqual(
       expect.objectContaining({
         organization: expect.objectContaining({
-          organization: expect.objectContaining({
-            slug: organizationSlug,
-          }),
+          slug: organizationSlug,
         }),
       }),
     );
@@ -206,9 +204,7 @@ test.concurrent(
     await expect(organizationResult.expectNoGraphQLErrors()).resolves.toEqual(
       expect.objectContaining({
         organization: expect.objectContaining({
-          organization: expect.objectContaining({
-            slug: organizationSlug,
-          }),
+          slug: organizationSlug,
         }),
       }),
     );

--- a/packages/services/api/src/modules/organization/module.graphql.ts
+++ b/packages/services/api/src/modules/organization/module.graphql.ts
@@ -2,7 +2,12 @@ import { gql } from 'graphql-modules';
 
 export default gql`
   extend type Query {
-    organization(selector: OrganizationSelectorInput!): OrganizationPayload
+    organization(
+      """
+      Reference to the organization that should be fetched.
+      """
+      reference: OrganizationReferenceInput! @tag(name: "public")
+    ): Organization @tag(name: "public")
     organizationByInviteCode(code: String!): OrganizationByInviteCodePayload
     organizations: OrganizationConnection!
     organizationTransferRequest(
@@ -44,8 +49,8 @@ export default gql`
   }
 
   input OrganizationReferenceInput @oneOf {
-    bySelector: OrganizationSelectorInput
-    byId: ID
+    bySelector: OrganizationSelectorInput @tag(name: "public")
+    byId: ID @tag(name: "public")
   }
 
   input CreateOrganizationAccessTokenInput {
@@ -204,7 +209,7 @@ export default gql`
   }
 
   input OrganizationSelectorInput {
-    organizationSlug: String!
+    organizationSlug: String! @tag(name: "public")
   }
 
   type OrganizationSelector {
@@ -266,8 +271,14 @@ export default gql`
   }
 
   type Organization {
-    id: ID!
-    slug: String!
+    """
+    Unique UUID of the organization
+    """
+    id: ID! @tag(name: "public")
+    """
+    The slug of the organization.
+    """
+    slug: String! @tag(name: "public")
     cleanId: ID! @deprecated(reason: "Use the 'slug' field instead.")
     name: String! @deprecated(reason: "Use the 'slug' field instead.")
     owner: Member!

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
+import { OrganizationReferenceInput } from 'packages/libraries/core/src/client/__generated__/types';
 import * as GraphQLSchema from '../../../__generated__/types';
 import { Organization } from '../../../shared/entities';
 import { HiveError } from '../../../shared/errors';
@@ -49,6 +50,17 @@ export class OrganizationManager {
     private idTranslator: IdTranslator,
   ) {
     this.logger = logger.child({ source: 'OrganizationManager' });
+  }
+
+  async getOrganizationByReference(reference: OrganizationReferenceInput): Promise<Organization> {
+    const selector = await this.idTranslator.resolveOrganizationReference({
+      reference,
+      onError: () => {
+        this.session.raise('organization:describe');
+      },
+    });
+
+    return this.getOrganization(selector);
   }
 
   async getOrganization(selector: OrganizationSelector): Promise<Organization> {

--- a/packages/services/api/src/modules/organization/resolvers/Query/organization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Query/organization.ts
@@ -1,18 +1,10 @@
-import { IdTranslator } from '../../../shared/providers/id-translator';
 import { OrganizationManager } from '../../providers/organization-manager';
 import type { QueryResolvers } from './../../../../__generated__/types';
 
 export const organization: NonNullable<QueryResolvers['organization']> = async (
   _,
-  { selector },
+  { reference },
   { injector },
 ) => {
-  const organization = await injector.get(IdTranslator).translateOrganizationId(selector);
-
-  return {
-    selector,
-    organization: await injector.get(OrganizationManager).getOrganization({
-      organizationId: organization,
-    }),
-  };
+  return await injector.get(OrganizationManager).getOrganizationByReference(reference);
 };

--- a/packages/web/app/src/components/v2/modals/transfer-organization-ownership.tsx
+++ b/packages/web/app/src/components/v2/modals/transfer-organization-ownership.tsx
@@ -29,24 +29,22 @@ const TransferOrganizationOwnership_Request = graphql(`
 
 const TransferOrganizationOwnership_Members = graphql(`
   query TransferOrganizationOwnership_Members($selector: OrganizationSelectorInput!) {
-    organization(selector: $selector) {
-      organization {
-        id
-        slug
-        members {
-          nodes {
+    organization(reference: { bySelector: $selector }) {
+      id
+      slug
+      members {
+        nodes {
+          id
+          isOwner
+          ...MemberFields
+          user {
             id
-            isOwner
-            ...MemberFields
-            user {
-              id
-              fullName
-              displayName
-              email
-            }
+            fullName
+            displayName
+            email
           }
-          total
         }
+        total
       }
     }
   }
@@ -161,7 +159,7 @@ export const TransferOrganizationOwnershipModal = ({
     [setSelected, setFieldValue],
   );
 
-  const members = (query.data?.organization?.organization.members?.nodes ?? []).filter(
+  const members = (query.data?.organization?.members?.nodes ?? []).filter(
     member => !member.isOwner,
   );
 

--- a/packages/web/app/src/pages/organization-members.tsx
+++ b/packages/web/app/src/pages/organization-members.tsx
@@ -106,12 +106,10 @@ function PageContent(props: {
 }
 
 const OrganizationMembersPageQuery = graphql(`
-  query OrganizationMembersPageQuery($selector: OrganizationSelectorInput!) {
-    organization(selector: $selector) {
-      organization {
-        ...OrganizationMembersPage_OrganizationFragment
-        viewerCanSeeMembers
-      }
+  query OrganizationMembersPageQuery($organizationSlug: String!) {
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      ...OrganizationMembersPage_OrganizationFragment
+      viewerCanSeeMembers
     }
   }
 `);
@@ -124,13 +122,11 @@ function OrganizationMembersPageContent(props: {
   const [query, refetch] = useQuery({
     query: OrganizationMembersPageQuery,
     variables: {
-      selector: {
-        organizationSlug: props.organizationSlug,
-      },
+      organizationSlug: props.organizationSlug,
     },
   });
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
 
   useRedirect({
     canAccess: currentOrganization?.viewerCanSeeMembers === true,

--- a/packages/web/app/src/pages/organization-policy.tsx
+++ b/packages/web/app/src/pages/organization-policy.tsx
@@ -12,23 +12,21 @@ import { useToast } from '@/components/ui/use-toast';
 import { graphql } from '@/gql';
 
 const OrganizationPolicyPageQuery = graphql(`
-  query OrganizationPolicyPageQuery($selector: OrganizationSelectorInput!) {
-    organization(selector: $selector) {
-      organization {
-        id
-        projects {
-          nodes {
-            id
-            slug
-          }
-        }
-        schemaPolicy {
+  query OrganizationPolicyPageQuery($organizationSlug: String!) {
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      projects {
+        nodes {
           id
-          updatedAt
-          ...PolicySettings_SchemaPolicyFragment
+          slug
         }
-        viewerCanModifySchemaPolicy
       }
+      schemaPolicy {
+        id
+        updatedAt
+        ...PolicySettings_SchemaPolicyFragment
+      }
+      viewerCanModifySchemaPolicy
     }
   }
 `);
@@ -66,15 +64,13 @@ function PolicyPageContent(props: { organizationSlug: string }) {
   const [query] = useQuery({
     query: OrganizationPolicyPageQuery,
     variables: {
-      selector: {
-        organizationSlug: props.organizationSlug,
-      },
+      organizationSlug: props.organizationSlug,
     },
   });
   const [mutation, mutate] = useMutation(UpdateSchemaPolicyForOrganization);
   const { toast } = useToast();
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
 
   if (query.error) {
     return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;

--- a/packages/web/app/src/pages/organization-settings.tsx
+++ b/packages/web/app/src/pages/organization-settings.tsx
@@ -471,13 +471,11 @@ const SettingsPageRenderer = (props: {
 };
 
 const OrganizationSettingsPageQuery = graphql(`
-  query OrganizationSettingsPageQuery($selector: OrganizationSelectorInput!) {
-    organization(selector: $selector) {
-      organization {
-        ...SettingsPageRenderer_OrganizationFragment
-        viewerCanAccessSettings
-        viewerCanManageAccessTokens
-      }
+  query OrganizationSettingsPageQuery($organizationSlug: String!) {
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      ...SettingsPageRenderer_OrganizationFragment
+      viewerCanAccessSettings
+      viewerCanManageAccessTokens
     }
   }
 `);
@@ -493,13 +491,11 @@ function SettingsPageContent(props: {
   const [query] = useQuery({
     query: OrganizationSettingsPageQuery,
     variables: {
-      selector: {
-        organizationSlug: props.organizationSlug,
-      },
+      organizationSlug: props.organizationSlug,
     },
   });
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
 
   const subPages = useMemo(() => {
     const pages: Array<{

--- a/packages/web/app/src/pages/organization-subscription-manage.tsx
+++ b/packages/web/app/src/pages/organization-subscription-manage.tsx
@@ -413,12 +413,11 @@ function Inner(props: {
 }
 
 const ManageSubscriptionPageQuery = graphql(`
-  query ManageSubscriptionPageQuery($selector: OrganizationSelectorInput!) {
-    organization(selector: $selector) {
-      organization {
-        slug
-        ...ManageSubscriptionInner_OrganizationFragment
-      }
+  query ManageSubscriptionPageQuery($organizationSlug: String!) {
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      slug
+      ...ManageSubscriptionInner_OrganizationFragment
     }
     billingPlans {
       ...ManageSubscriptionInner_BillingPlansFragment
@@ -430,13 +429,11 @@ function ManageSubscriptionPageContent(props: { organizationSlug: string }) {
   const [query] = useQuery({
     query: ManageSubscriptionPageQuery,
     variables: {
-      selector: {
-        organizationSlug: props.organizationSlug,
-      },
+      organizationSlug: props.organizationSlug,
     },
   });
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
   const billingPlans = query.data?.billingPlans;
 
   if (query.error) {

--- a/packages/web/app/src/pages/organization-subscription.tsx
+++ b/packages/web/app/src/pages/organization-subscription.tsx
@@ -60,15 +60,14 @@ const SubscriptionPage_QueryFragment = graphql(`
 `);
 
 const SubscriptionPageQuery = graphql(`
-  query SubscriptionPageQuery($selector: OrganizationSelectorInput!) {
-    organization(selector: $selector) {
-      organization {
-        slug
-        ...SubscriptionPage_OrganizationFragment
-      }
+  query SubscriptionPageQuery($organizationSlug: String!) {
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      slug
+      ...SubscriptionPage_OrganizationFragment
     }
     ...SubscriptionPage_QueryFragment
-    monthlyUsage(selector: $selector) {
+    monthlyUsage(selector: { organizationSlug: $organizationSlug }) {
       date
       total
     }
@@ -79,13 +78,11 @@ function SubscriptionPageContent(props: { organizationSlug: string }) {
   const [query] = useQuery({
     query: SubscriptionPageQuery,
     variables: {
-      selector: {
-        organizationSlug: props.organizationSlug,
-      },
+      organizationSlug: props.organizationSlug,
     },
   });
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
 
   const organization = useFragment(SubscriptionPage_OrganizationFragment, currentOrganization);
   const queryForBilling = useFragment(SubscriptionPage_QueryFragment, query.data);

--- a/packages/web/app/src/pages/organization-support-ticket.tsx
+++ b/packages/web/app/src/pages/organization-support-ticket.tsx
@@ -270,13 +270,11 @@ const SupportTicket_OrganizationFragment = graphql(`
 `);
 
 const SupportTicketPageQuery = graphql(`
-  query SupportTicketPageQuery($selector: OrganizationSelectorInput!, $ticketId: ID!) {
-    organization(selector: $selector) {
-      organization {
-        ...SupportTicket_OrganizationFragment
-        supportTicket(id: $ticketId) {
-          ...SupportTicket_SupportTicketFragment
-        }
+  query SupportTicketPageQuery($organizationSlug: String!, $ticketId: ID!) {
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      ...SupportTicket_OrganizationFragment
+      supportTicket(id: $ticketId) {
+        ...SupportTicket_SupportTicketFragment
       }
     }
   }
@@ -287,9 +285,7 @@ function SupportTicketPageContent(props: { ticketId: string; organizationSlug: s
   const [query, refetchQuery] = useQuery({
     query: SupportTicketPageQuery,
     variables: {
-      selector: {
-        organizationSlug: props.organizationSlug,
-      },
+      organizationSlug: props.organizationSlug,
       ticketId,
     },
     requestPolicy: 'cache-first',
@@ -303,8 +299,8 @@ function SupportTicketPageContent(props: { ticketId: string; organizationSlug: s
     return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
-  const currentOrganization = query.data?.organization?.organization;
-  const ticket = query.data?.organization?.organization.supportTicket;
+  const currentOrganization = query.data?.organization;
+  const ticket = currentOrganization?.supportTicket;
 
   return (
     <OrganizationLayout

--- a/packages/web/app/src/pages/organization-support.tsx
+++ b/packages/web/app/src/pages/organization-support.tsx
@@ -376,11 +376,9 @@ function Support(props: {
 }
 
 const SupportPageQuery = graphql(`
-  query SupportPageQuery($selector: OrganizationSelectorInput!) {
-    organization(selector: $selector) {
-      organization {
-        ...Support_OrganizationFragment
-      }
+  query SupportPageQuery($organizationSlug: String!) {
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      ...Support_OrganizationFragment
     }
   }
 `);
@@ -389,9 +387,7 @@ function SupportPageContent(props: { organizationSlug: string }) {
   const [query, refetchQuery] = useQuery({
     query: SupportPageQuery,
     variables: {
-      selector: {
-        organizationSlug: props.organizationSlug,
-      },
+      organizationSlug: props.organizationSlug,
     },
     requestPolicy: 'cache-first',
   });
@@ -404,7 +400,7 @@ function SupportPageContent(props: { organizationSlug: string }) {
     return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
 
   return (
     <OrganizationLayout

--- a/packages/web/app/src/pages/organization.tsx
+++ b/packages/web/app/src/pages/organization.tsx
@@ -229,11 +229,9 @@ const OrganizationProjectsPageQuery = graphql(`
     $chartResolution: Int!
     $period: DateRangeInput!
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-        slug
-      }
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      slug
     }
     projects(selector: { organizationSlug: $organizationSlug }) {
       total
@@ -295,7 +293,7 @@ function OrganizationPageContent(
     requestPolicy: 'cache-and-network',
   });
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
   const projectsConnection = query.data?.projects;
 
   const highestNumberOfRequests = useMemo(() => {

--- a/packages/web/app/src/pages/project-policy.tsx
+++ b/packages/web/app/src/pages/project-policy.tsx
@@ -11,10 +11,8 @@ import { graphql } from '@/gql';
 
 const ProjectPolicyPageQuery = graphql(`
   query ProjectPolicyPageQuery($organizationSlug: String!, $projectSlug: String!) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-      }
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
     }
     project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
       id
@@ -73,7 +71,7 @@ function ProjectPolicyContent(props: { organizationSlug: string; projectSlug: st
   });
   const { toast } = useToast();
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
   const currentProject = query.data?.project;
 
   if (query.error) {

--- a/packages/web/app/src/pages/project-settings.tsx
+++ b/packages/web/app/src/pages/project-settings.tsx
@@ -42,14 +42,12 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from '@tanstack/react-router';
 
 const GithubIntegration_GithubIntegrationDetailsQuery = graphql(`
-  query getGitHubIntegrationDetails($selector: OrganizationSelectorInput!) {
-    organization(selector: $selector) {
-      organization {
-        id
-        gitHubIntegration {
-          repositories {
-            nameWithOwner
-          }
+  query getGitHubIntegrationDetails($organizationSlug: String!) {
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      gitHubIntegration {
+        repositories {
+          nameWithOwner
         }
       }
     }
@@ -75,9 +73,7 @@ function GitHubIntegration(props: {
   const [integrationQuery] = useQuery({
     query: GithubIntegration_GithubIntegrationDetailsQuery,
     variables: {
-      selector: {
-        organizationSlug: props.organizationSlug,
-      },
+      organizationSlug: props.organizationSlug,
     },
   });
 
@@ -89,7 +85,7 @@ function GitHubIntegration(props: {
     return null;
   }
 
-  const githubIntegration = integrationQuery.data?.organization?.organization.gitHubIntegration;
+  const githubIntegration = integrationQuery.data?.organization?.gitHubIntegration;
 
   if (!githubIntegration) {
     return null;
@@ -333,10 +329,8 @@ const ProjectSettingsPage_ProjectFragment = graphql(`
 
 const ProjectSettingsPageQuery = graphql(`
   query ProjectSettingsPageQuery($organizationSlug: String!, $projectSlug: String!) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        ...ProjectSettingsPage_OrganizationFragment
-      }
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      ...ProjectSettingsPage_OrganizationFragment
     }
     project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
       ...ProjectSettingsPage_ProjectFragment
@@ -356,7 +350,7 @@ function ProjectSettingsContent(props: { organizationSlug: string; projectSlug: 
     requestPolicy: 'cache-and-network',
   });
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
   const currentProject = query.data?.project;
 
   const organization = useFragment(ProjectSettingsPage_OrganizationFragment, currentOrganization);

--- a/packages/web/app/src/pages/target-apps.tsx
+++ b/packages/web/app/src/pages/target-apps.tsx
@@ -44,10 +44,8 @@ const TargetAppsViewQuery = graphql(`
     $targetSlug: String!
     $after: String
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-      }
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
     }
     target(
       selector: {

--- a/packages/web/app/src/pages/target-checks.tsx
+++ b/packages/web/app/src/pages/target-checks.tsx
@@ -180,12 +180,10 @@ const ChecksPageQuery = graphql(`
     $targetSlug: String!
     $filters: SchemaChecksFilter
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-        rateLimit {
-          retentionInDays
-        }
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      rateLimit {
+        retentionInDays
       }
     }
     target(

--- a/packages/web/app/src/pages/target-explorer-deprecated.tsx
+++ b/packages/web/app/src/pages/target-explorer-deprecated.tsx
@@ -324,14 +324,12 @@ const TargetExplorerDeprecatedSchemaPageQuery = graphql(`
     $projectSlug: String!
     $targetSlug: String!
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-        rateLimit {
-          retentionInDays
-        }
-        slug
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      rateLimit {
+        retentionInDays
       }
+      slug
     }
     hasCollectedOperations(
       selector: {
@@ -367,7 +365,7 @@ function ExplorerDeprecatedSchemaPageContent(props: {
     );
   }
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
 
   if (!currentOrganization) {
     return null;

--- a/packages/web/app/src/pages/target-explorer-type.tsx
+++ b/packages/web/app/src/pages/target-explorer-type.tsx
@@ -130,13 +130,11 @@ const TargetExplorerTypenamePageQuery = graphql(`
     $period: DateRangeInput!
     $typename: String!
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-        slug
-        rateLimit {
-          retentionInDays
-        }
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      slug
+      rateLimit {
+        retentionInDays
       }
     }
     target(
@@ -199,7 +197,7 @@ function TypeExplorerPageContent(props: {
     },
   });
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
   const retentionInDays = currentOrganization?.rateLimit.retentionInDays;
 
   useEffect(() => {

--- a/packages/web/app/src/pages/target-explorer-unused.tsx
+++ b/packages/web/app/src/pages/target-explorer-unused.tsx
@@ -376,14 +376,12 @@ const TargetExplorerUnusedSchemaPageQuery = graphql(`
     $projectSlug: String!
     $targetSlug: String!
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-        rateLimit {
-          retentionInDays
-        }
-        slug
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      rateLimit {
+        retentionInDays
       }
+      slug
     }
     hasCollectedOperations(
       selector: {
@@ -419,7 +417,7 @@ function ExplorerUnusedSchemaPageContent(props: {
     );
   }
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
   const hasCollectedOperations = query.data?.hasCollectedOperations === true;
 
   if (!currentOrganization) {

--- a/packages/web/app/src/pages/target-explorer.tsx
+++ b/packages/web/app/src/pages/target-explorer.tsx
@@ -102,14 +102,12 @@ const TargetExplorerPageQuery = graphql(`
     $targetSlug: String!
     $period: DateRangeInput!
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-        rateLimit {
-          retentionInDays
-        }
-        slug
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      rateLimit {
+        retentionInDays
       }
+      slug
     }
     target(
       selector: {
@@ -170,7 +168,7 @@ function ExplorerPageContent(props: {
     },
   });
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
   const retentionInDays = currentOrganization?.rateLimit.retentionInDays;
 
   useEffect(() => {

--- a/packages/web/app/src/pages/target-insights-client.tsx
+++ b/packages/web/app/src/pages/target-insights-client.tsx
@@ -346,13 +346,11 @@ const ClientInsightsPageQuery = graphql(`
     $projectSlug: String!
     $targetSlug: String!
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-        slug
-        rateLimit {
-          retentionInDays
-        }
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      slug
+      rateLimit {
+        retentionInDays
       }
     }
     hasCollectedOperations(
@@ -390,7 +388,7 @@ function ClientInsightsPageContent(props: {
     );
   }
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
 
   if (!currentOrganization) {
     return null;

--- a/packages/web/app/src/pages/target-insights-coordinate.tsx
+++ b/packages/web/app/src/pages/target-insights-coordinate.tsx
@@ -390,13 +390,11 @@ const TargetSchemaCoordinatePageQuery = graphql(`
     $projectSlug: String!
     $targetSlug: String!
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-        slug
-        rateLimit {
-          retentionInDays
-        }
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      slug
+      rateLimit {
+        retentionInDays
       }
     }
     hasCollectedOperations(
@@ -434,7 +432,7 @@ function TargetSchemaCoordinatePageContent(props: {
     );
   }
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
 
   if (!currentOrganization) {
     return null;

--- a/packages/web/app/src/pages/target-insights-operation.tsx
+++ b/packages/web/app/src/pages/target-insights-operation.tsx
@@ -163,13 +163,11 @@ const OperationInsightsPageQuery = graphql(`
     $projectSlug: String!
     $targetSlug: String!
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-        slug
-        rateLimit {
-          retentionInDays
-        }
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      slug
+      rateLimit {
+        retentionInDays
       }
     }
     hasCollectedOperations(
@@ -208,7 +206,7 @@ function OperationInsightsContent(props: {
     );
   }
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
 
   if (!currentOrganization) {
     return null;

--- a/packages/web/app/src/pages/target-insights.tsx
+++ b/packages/web/app/src/pages/target-insights.tsx
@@ -106,13 +106,11 @@ const TargetOperationsPageQuery = graphql(`
     $projectSlug: String!
     $targetSlug: String!
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-        slug
-        rateLimit {
-          retentionInDays
-        }
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
+      id
+      slug
+      rateLimit {
+        retentionInDays
       }
     }
     hasCollectedOperations(
@@ -149,7 +147,7 @@ function TargetOperationsPageContent(props: {
     );
   }
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
   const hasCollectedOperations = query.data?.hasCollectedOperations === true;
 
   if (!currentOrganization) {

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -403,12 +403,10 @@ const TargetSettingsPage_TargetSettingsQuery = graphql(`
         slug
       }
     }
-    organization(selector: $organizationSelector) {
-      organization {
-        id
-        rateLimit {
-          retentionInDays
-        }
+    organization(reference: { bySelector: $organizationSelector }) {
+      id
+      rateLimit {
+        retentionInDays
       }
     }
   }
@@ -548,7 +546,7 @@ const BreakingChanges = (props: {
       }),
       period: Yup.number()
         .min(1)
-        .max(targetSettings.data?.organization?.organization?.rateLimit.retentionInDays ?? 30)
+        .max(targetSettings.data?.organization?.rateLimit.retentionInDays ?? 30)
         .test('double-precision', 'Invalid precision', num => {
           if (typeof num !== 'number') {
             return false;
@@ -782,9 +780,7 @@ const BreakingChanges = (props: {
                 disabled={isSubmitting}
                 type="number"
                 min="1"
-                max={
-                  targetSettings.data?.organization?.organization?.rateLimit.retentionInDays ?? 30
-                }
+                max={targetSettings.data?.organization?.rateLimit.retentionInDays ?? 30}
                 className="mx-2 !inline-flex w-16"
               />
               days.
@@ -1234,11 +1230,9 @@ const TargetSettingsPageQuery = graphql(`
     $projectSlug: String!
     $targetSlug: String!
   ) {
-    organization(selector: { organizationSlug: $organizationSlug }) {
-      organization {
-        id
-        slug
-      }
+    organization(reference: { bySelector: { organizationSlug: $organizationSlug } }) {
+      id
+      slug
     }
     project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
       id
@@ -1289,7 +1283,7 @@ function TargetSettingsContent(props: {
     },
   });
 
-  const currentOrganization = query.data?.organization?.organization;
+  const currentOrganization = query.data?.organization;
   const currentProject = query.data?.project;
   const currentTarget = query.data?.target;
 


### PR DESCRIPTION
### Description

- Changes `Query.organization` to use our new patterns for resolving a resource. 
- Remove nested `organization { organization { ... } }` selections
- Adds the basic `Organization` type and `Query.organization` to the public GraphQL API.



### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
