### PR TITLE
feat(api): refactor Query.project + expose via public API

### DIFF
--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -607,7 +607,7 @@ export function readProjectInfo(
   return execute({
     document: graphql(`
       query readProjectInfo($selector: ProjectSelectorInput!) {
-        project(selector: $selector) {
+        project(reference: { bySelector: $selector }) {
           id
           slug
         }

--- a/integration-tests/tests/api/policy/policy-access.spec.ts
+++ b/integration-tests/tests/api/policy/policy-access.spec.ts
@@ -8,7 +8,7 @@ describe('Policy Access', () => {
   describe('Project', () => {
     const query = graphql(`
       query ProjectSchemaPolicyAccess($selector: ProjectSelectorInput!) {
-        project(selector: $selector) {
+        project(reference: { bySelector: $selector }) {
           schemaPolicy {
             id
           }

--- a/packages/services/api/src/modules/project/module.graphql.ts
+++ b/packages/services/api/src/modules/project/module.graphql.ts
@@ -2,7 +2,7 @@ import { gql } from 'graphql-modules';
 
 export default gql`
   extend type Query {
-    project(selector: ProjectSelectorInput!): Project
+    project(reference: ProjectReferenceInput! @tag(name: "public")): Project @tag(name: "public")
     projects(selector: OrganizationSelectorInput!): ProjectConnection!
   }
 
@@ -66,8 +66,8 @@ export default gql`
   }
 
   input ProjectSelectorInput {
-    organizationSlug: String!
-    projectSlug: String!
+    organizationSlug: String! @tag(name: "public")
+    projectSlug: String! @tag(name: "public")
   }
 
   type ProjectSelector {
@@ -87,9 +87,14 @@ export default gql`
     projectBySlug(projectSlug: String!): Project
   }
 
+  input ProjectReferenceInput @oneOf {
+    byId: ID @tag(name: "public")
+    bySelector: ProjectSelectorInput @tag(name: "public")
+  }
+
   type Project {
-    id: ID!
-    slug: String!
+    id: ID! @tag(name: "public")
+    slug: String! @tag(name: "public")
     cleanId: ID! @deprecated(reason: "Use the 'slug' field instead.")
     name: String! @deprecated(reason: "Use the 'slug' field instead.")
     type: ProjectType!

--- a/packages/services/api/src/modules/project/resolvers/Query/project.ts
+++ b/packages/services/api/src/modules/project/resolvers/Query/project.ts
@@ -1,19 +1,10 @@
-import { IdTranslator } from '../../../shared/providers/id-translator';
 import { ProjectManager } from '../../providers/project-manager';
 import type { QueryResolvers } from './../../../../__generated__/types';
 
 export const project: NonNullable<QueryResolvers['project']> = async (
   _,
-  { selector },
+  { reference },
   { injector },
 ) => {
-  const translator = injector.get(IdTranslator);
-  const [organization, project] = await Promise.all([
-    translator.translateOrganizationId(selector),
-    translator.translateProjectId(selector),
-  ]);
-  return injector.get(ProjectManager).getProject({
-    projectId: project,
-    organizationId: organization,
-  });
+  return await injector.get(ProjectManager).getProjectByRereference(reference);
 };

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -205,6 +205,8 @@ export interface Storage {
 
   getProjects(_: OrganizationSelector): Promise<Project[] | never>;
 
+  getProjectById(projectId: string): Promise<Project | null>;
+
   findProjectsByIds(args: { projectIds: Array<string> }): Promise<Map<string, Project>>;
 
   createProject(_: Pick<Project, 'type'> & { slug: string } & OrganizationSelector): Promise<

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -1430,6 +1430,11 @@ export async function createStorage(
         });
       },
     ),
+    getProjectById(projectId) {
+      return this.findProjectsByIds({ projectIds: [projectId] }).then(
+        map => map.get(projectId) ?? null,
+      );
+    },
     async updateProjectSlug({ slug, organizationId: organization, projectId: project }) {
       return pool.transaction(async t => {
         const projectSlugExists = await t.exists(

--- a/packages/web/app/src/components/project/settings/external-composition.tsx
+++ b/packages/web/app/src/components/project/settings/external-composition.tsx
@@ -307,7 +307,7 @@ const ExternalComposition_DisableMutation = graphql(`
 
 const ExternalComposition_ProjectConfigurationQuery = graphql(`
   query ExternalComposition_ProjectConfigurationQuery($selector: ProjectSelectorInput!) {
-    project(selector: $selector) {
+    project(reference: { bySelector: $selector }) {
       id
       slug
       isNativeFederationEnabled

--- a/packages/web/app/src/components/project/settings/native-composition.tsx
+++ b/packages/web/app/src/components/project/settings/native-composition.tsx
@@ -117,7 +117,7 @@ const NativeCompositionSettings_ProjectFragment = graphql(`
 
 const NativeCompositionSettings_ProjectQuery = graphql(`
   query NativeCompositionSettings_ProjectQuery($selector: ProjectSelectorInput!) {
-    project(selector: $selector) {
+    project(reference: { bySelector: $selector }) {
       id
       nativeFederationCompatibility
       experimental_nativeCompositionPerTarget

--- a/packages/web/app/src/pages/project-alerts.tsx
+++ b/packages/web/app/src/pages/project-alerts.tsx
@@ -165,7 +165,9 @@ function Alerts(props: {
 
 const ProjectAlertsPageQuery = graphql(`
   query ProjectAlertsPageQuery($organizationSlug: String!, $projectSlug: String!) {
-    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
+    project(
+      reference: { bySelector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug } }
+    ) {
       id
       targets {
         nodes {

--- a/packages/web/app/src/pages/project-policy.tsx
+++ b/packages/web/app/src/pages/project-policy.tsx
@@ -13,25 +13,25 @@ const ProjectPolicyPageQuery = graphql(`
   query ProjectPolicyPageQuery($organizationSlug: String!, $projectSlug: String!) {
     organization: organizationBySlug(organizationSlug: $organizationSlug) {
       id
-    }
-    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
-      id
-      schemaPolicy {
+      project: projectBySlug(projectSlug: $projectSlug) {
         id
-        updatedAt
-        ...PolicySettings_SchemaPolicyFragment
-      }
-      parentSchemaPolicy {
-        id
-        updatedAt
-        allowOverrides
-        rules {
-          rule {
-            id
+        schemaPolicy {
+          id
+          updatedAt
+          ...PolicySettings_SchemaPolicyFragment
+        }
+        parentSchemaPolicy {
+          id
+          updatedAt
+          allowOverrides
+          rules {
+            rule {
+              id
+            }
           }
         }
+        viewerCanModifySchemaPolicy
       }
-      viewerCanModifySchemaPolicy
     }
   }
 `);
@@ -72,7 +72,7 @@ function ProjectPolicyContent(props: { organizationSlug: string; projectSlug: st
   const { toast } = useToast();
 
   const currentOrganization = query.data?.organization;
-  const currentProject = query.data?.project;
+  const currentProject = currentOrganization?.project;
 
   if (query.error) {
     return (

--- a/packages/web/app/src/pages/project-settings.tsx
+++ b/packages/web/app/src/pages/project-settings.tsx
@@ -331,9 +331,9 @@ const ProjectSettingsPageQuery = graphql(`
   query ProjectSettingsPageQuery($organizationSlug: String!, $projectSlug: String!) {
     organization: organizationBySlug(organizationSlug: $organizationSlug) {
       ...ProjectSettingsPage_OrganizationFragment
-    }
-    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
-      ...ProjectSettingsPage_ProjectFragment
+      project: projectBySlug(projectSlug: $projectSlug) {
+        ...ProjectSettingsPage_ProjectFragment
+      }
     }
     isGitHubIntegrationFeatureEnabled
   }
@@ -351,7 +351,7 @@ function ProjectSettingsContent(props: { organizationSlug: string; projectSlug: 
   });
 
   const currentOrganization = query.data?.organization;
-  const currentProject = query.data?.project;
+  const currentProject = currentOrganization?.project;
 
   const organization = useFragment(ProjectSettingsPage_OrganizationFragment, currentOrganization);
   const project = useFragment(ProjectSettingsPage_ProjectFragment, currentProject);

--- a/packages/web/app/src/pages/target-checks-single.tsx
+++ b/packages/web/app/src/pages/target-checks-single.tsx
@@ -1008,21 +1008,17 @@ const ActiveSchemaCheckQuery = graphql(`
     $targetSlug: String!
     $schemaCheckId: ID!
   ) {
-    target(
-      selector: {
-        organizationSlug: $organizationSlug
-        projectSlug: $projectSlug
-        targetSlug: $targetSlug
-      }
+    project(
+      reference: { bySelector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug } }
     ) {
       id
-      schemaCheck(id: $schemaCheckId) {
-        ...ActiveSchemaCheck_SchemaCheckFragment
-      }
-    }
-    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
-      id
       type
+      target: targetBySlug(targetSlug: $targetSlug) {
+        id
+        schemaCheck(id: $schemaCheckId) {
+          ...ActiveSchemaCheck_SchemaCheckFragment
+        }
+      }
     }
   }
 `);
@@ -1048,7 +1044,7 @@ const ActiveSchemaCheck = (props: {
 
   const schemaCheck = useFragment(
     ActiveSchemaCheck_SchemaCheckFragment,
-    query.data?.target?.schemaCheck,
+    query.data?.project?.target?.schemaCheck,
   );
 
   if (!schemaCheckId) {

--- a/packages/web/app/src/pages/target-history-version.tsx
+++ b/packages/web/app/src/pages/target-history-version.tsx
@@ -551,22 +551,18 @@ const ActiveSchemaVersion_SchemaVersionQuery = graphql(`
     $targetSlug: String!
     $versionId: ID!
   ) {
-    target(
-      selector: {
-        organizationSlug: $organizationSlug
-        projectSlug: $projectSlug
-        targetSlug: $targetSlug
-      }
+    project(
+      reference: { bySelector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug } }
     ) {
       id
-      schemaVersion(id: $versionId) {
-        id
-        ...SchemaVersionView_SchemaVersionFragment
-      }
-    }
-    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
-      id
       type
+      target: targetBySlug(targetSlug: $targetSlug) {
+        id
+        schemaVersion(id: $versionId) {
+          id
+          ...SchemaVersionView_SchemaVersionFragment
+        }
+      }
     }
   }
 `);
@@ -590,8 +586,9 @@ function ActiveSchemaVersion(props: {
   const { error } = query;
 
   const isLoading = query.fetching || query.stale;
-  const schemaVersion = query?.data?.target?.schemaVersion;
-  const projectType = query?.data?.project?.type;
+  const project = query.data?.project;
+  const schemaVersion = project?.target?.schemaVersion;
+  const projectType = query.data?.project?.type;
 
   if (isLoading || !schemaVersion || !projectType) {
     return (

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -1230,31 +1230,25 @@ const TargetSettingsPageQuery = graphql(`
     $projectSlug: String!
     $targetSlug: String!
   ) {
-    organization(reference: { bySelector: { organizationSlug: $organizationSlug } }) {
+    organization: organizationBySlug(organizationSlug: $organizationSlug) {
       id
       slug
-    }
-    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
-      id
-      slug
-      type
-    }
-    target(
-      selector: {
-        organizationSlug: $organizationSlug
-        projectSlug: $projectSlug
-        targetSlug: $targetSlug
+      project: projectBySlug(projectSlug: $projectSlug) {
+        id
+        slug
+        type
+        target: targetBySlug(targetSlug: $targetSlug) {
+          id
+          slug
+          graphqlEndpointUrl
+          viewerCanAccessSettings
+          baseSchema
+          viewerCanModifySettings
+          viewerCanModifyCDNAccessToken
+          viewerCanModifyTargetAccessToken
+          viewerCanDelete
+        }
       }
-    ) {
-      id
-      slug
-      graphqlEndpointUrl
-      viewerCanAccessSettings
-      baseSchema
-      viewerCanModifySettings
-      viewerCanModifyCDNAccessToken
-      viewerCanModifyTargetAccessToken
-      viewerCanDelete
     }
   }
 `);
@@ -1284,8 +1278,8 @@ function TargetSettingsContent(props: {
   });
 
   const currentOrganization = query.data?.organization;
-  const currentProject = query.data?.project;
-  const currentTarget = query.data?.target;
+  const currentProject = currentOrganization?.project;
+  const currentTarget = currentProject?.target;
 
   useRedirect({
     canAccess: currentTarget?.viewerCanAccessSettings === true,

--- a/packages/web/app/src/pages/target.tsx
+++ b/packages/web/app/src/pages/target.tsx
@@ -254,17 +254,13 @@ const TargetSchemaPageQuery = graphql(`
     $projectSlug: String!
     $targetSlug: String!
   ) {
-    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
-      ...SchemaView_ProjectFragment
-    }
-    target(
-      selector: {
-        organizationSlug: $organizationSlug
-        projectSlug: $projectSlug
-        targetSlug: $targetSlug
-      }
+    project(
+      reference: { bySelector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug } }
     ) {
-      ...SchemaView_TargetFragment
+      ...SchemaView_ProjectFragment
+      target: targetBySlug(targetSlug: $targetSlug) {
+        ...SchemaView_TargetFragment
+      }
     }
   }
 `);
@@ -288,7 +284,7 @@ function TargetSchemaPage(props: {
   }
 
   const currentProject = query.data?.project;
-  const target = query.data?.target;
+  const target = currentProject?.target;
 
   return (
     <TargetLayout


### PR DESCRIPTION
### Description

- Changes `Query.project` to use our new patterns for resolving a resource.
- Adds the basic `Project` type and `Query.project` to the public GraphQL API.

