### PR TITLE
fix: correct the schedule a meeting cal link

### DIFF
--- a/.changeset/silent-stingrays-visit.md
+++ b/.changeset/silent-stingrays-visit.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+fix schedule a meeting link

--- a/packages/web/app/src/components/ui/user-menu.tsx
+++ b/packages/web/app/src/components/ui/user-menu.tsx
@@ -186,7 +186,7 @@ export function UserMenu(props: {
               </DropdownMenuSub>
               <DropdownMenuItem asChild>
                 <a
-                  href="https://cal.com/team/the-guild/graphql-hive-15m"
+                  href="https://cal.com/team/the-guild/hive?duration=15"
                   target="_blank"
                   rel="noreferrer"
                 >


### PR DESCRIPTION
### Background
Current link shows:
<img width="1201" alt="Screenshot 2025-03-26 at 2 29 18 PM" src="https://github.com/user-attachments/assets/a995030d-6688-43e9-af6f-892ebdb1aa99" />

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

This corrects the link so that it's valid.