### PR TITLE
fix: retain `@oneOf` in public api

### DIFF
--- a/packages/services/api/src/modules/shared/module.graphql.ts
+++ b/packages/services/api/src/modules/shared/module.graphql.ts
@@ -1,7 +1,19 @@
 import { gql } from 'graphql-modules';
 
 export default gql`
-  scalar DateTime @tag(name: "public")
+  """
+  A date-time string at UTC, such as \`2007-12-03T10:15:30Z\`, is compliant with the date-time format outlined
+  in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
+
+  This scalar is a description of an exact instant on the timeline such as the instant that a user account was created.
+
+  This scalar ignores leap seconds (thereby assuming that a minute constitutes 59 seconds). In this respect, it diverges from the RFC 3339 profile.
+
+  Where an RFC 3339 compliant date-time string has a time-zone other than UTC, it is shifted to UTC. For example, the date-time string \`2016-01-01T14:10:20+01:00\` is shifted to \`2016-01-01T13:10:20Z\`.
+  """
+  scalar DateTime
+    @tag(name: "public")
+    @specifiedBy(url: "https://the-guild.dev/graphql/scalars/docs/scalars/date-time")
   scalar Date
   scalar JSON
   scalar JSONSchemaObject

--- a/packages/services/api/src/modules/shared/module.graphql.ts
+++ b/packages/services/api/src/modules/shared/module.graphql.ts
@@ -21,9 +21,14 @@ export default gql`
 
   extend schema
     @link(url: "https://specs.apollo.dev/link/v1.0")
-    @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"])
+    @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@tag", "@composeDirective"])
+    @link(url: "https://github.com/graphql/graphql-spec/pull/825/v0.1", import: ["@oneOf"])
+    @composeDirective(name: "@oneOf")
+
+  directive @oneOf on INPUT_OBJECT
 
   directive @link(url: String!, import: [String!]) repeatable on SCHEMA
+  directive @composeDirective(name: String!) repeatable on SCHEMA
 
   directive @tag(
     name: String!

--- a/packages/services/server/src/public-graphql-handler.ts
+++ b/packages/services/server/src/public-graphql-handler.ts
@@ -26,12 +26,21 @@ type CreatePublicGraphQLHandlerArgs = {
   tracing?: TracingInstance;
 };
 
+const defaultQuery = `#
+# Welcome to the Hive Console GraphQL API.
+#
+`;
+
 export const createPublicGraphQLHandler = (
   args: CreatePublicGraphQLHandlerArgs,
 ): RouteHandlerMethod => {
   const publicSchema = createPublicGraphQLSchema<Context>(args.registry);
   const server = createYoga<Context>({
     logging: args.logger,
+    graphiql: {
+      title: 'Hive Console - GraphQL API',
+      defaultQuery,
+    },
     plugins: [
       useArmor(),
       useHiveSentry(),


### PR DESCRIPTION
### Description

The `@oneOf` directive was stripped out of the public API definitions, as it was not retained in the federation composition.
