### PR TITLE
feat(api): add `SeverityLevelType`

### DIFF
--- a/.changeset/rotten-roses-sip.md
+++ b/.changeset/rotten-roses-sip.md
@@ -1,0 +1,5 @@
+---
+'hive': minor
+---
+
+Deprecate `CriticalityLevel` scalar and fields referencing it in favor of the `SeverityLevelType` scalar. Expose `SchemaChange.severityLevel` and `SchemaChange.severityReason` via the public API endpoint.

--- a/packages/libraries/cli/src/commands/schema/check.ts
+++ b/packages/libraries/cli/src/commands/schema/check.ts
@@ -43,17 +43,7 @@ const schemaCheckMutation = graphql(/* GraphQL */ `
         }
         changes {
           edges {
-            node {
-              message(withSafeBasedOnUsageNote: false)
-              criticality
-              isSafeBasedOnUsage
-              approval {
-                approvedBy {
-                  id
-                  displayName
-                }
-              }
-            }
+            __typename
           }
           ...RenderChanges_schemaChanges
         }
@@ -65,11 +55,7 @@ const schemaCheckMutation = graphql(/* GraphQL */ `
         valid
         changes {
           edges {
-            node {
-              message(withSafeBasedOnUsageNote: false)
-              criticality
-              isSafeBasedOnUsage
-            }
+            __typename
           }
           ...RenderChanges_schemaChanges
         }

--- a/packages/libraries/cli/src/commands/schema/delete.ts
+++ b/packages/libraries/cli/src/commands/schema/delete.ts
@@ -19,14 +19,6 @@ const schemaDeleteMutation = graphql(/* GraphQL */ `
       __typename
       ... on SchemaDeleteSuccess {
         valid
-        changes {
-          edges {
-            node {
-              criticality
-              message
-            }
-          }
-        }
         errors {
           ...RenderErrors_SchemaErrorConnectionFragment
         }

--- a/packages/libraries/cli/src/commands/schema/fetch.ts
+++ b/packages/libraries/cli/src/commands/schema/fetch.ts
@@ -26,7 +26,7 @@ const SchemaVersionForActionIdQuery = graphql(/* GraphQL */ `
   ) {
     schemaVersionForActionId(actionId: $actionId, target: $target) {
       id
-      valid
+      isValid
       sdl @include(if: $includeSDL)
       supergraph @include(if: $includeSupergraph)
       schemas @include(if: $includeSubgraphs) {
@@ -59,7 +59,7 @@ const LatestSchemaVersionQuery = graphql(/* GraphQL */ `
   ) {
     latestValidVersion(target: $target) {
       id
-      valid
+      isValid
       sdl @include(if: $includeSDL)
       supergraph @include(if: $includeSupergraph)
       schemas @include(if: $includeSubgraphs) {
@@ -214,7 +214,7 @@ export default class SchemaFetch extends Command<typeof SchemaFetch> {
       throw new SchemaNotFoundError(actionId);
     }
 
-    if (schemaVersion.valid === false) {
+    if (schemaVersion.isValid === false) {
       throw new InvalidSchemaError(actionId);
     }
 

--- a/packages/libraries/cli/src/helpers/schema.ts
+++ b/packages/libraries/cli/src/helpers/schema.ts
@@ -5,13 +5,13 @@ import { JsonFileLoader } from '@graphql-tools/json-file-loader';
 import { loadTypedefs } from '@graphql-tools/load';
 import { UrlLoader } from '@graphql-tools/url-loader';
 import { FragmentType, graphql, useFragment as unmaskFragment, useFragment } from '../gql';
-import { CriticalityLevel, SchemaWarningConnection } from '../gql/graphql';
+import { SchemaWarningConnection, SeverityLevelType } from '../gql/graphql';
 import { Texture } from './texture/texture';
 
-const criticalityMap: Record<CriticalityLevel, string> = {
-  [CriticalityLevel.Breaking]: Texture.colors.red('-'),
-  [CriticalityLevel.Safe]: Texture.colors.green('-'),
-  [CriticalityLevel.Dangerous]: Texture.colors.green('-'),
+const severityLevelMap: Record<SeverityLevelType, string> = {
+  [SeverityLevelType.Breaking]: Texture.colors.red('-'),
+  [SeverityLevelType.Safe]: Texture.colors.green('-'),
+  [SeverityLevelType.Dangerous]: Texture.colors.green('-'),
 };
 
 export const RenderErrors_SchemaErrorConnectionFragment = graphql(`
@@ -41,7 +41,7 @@ const RenderChanges_SchemaChanges = graphql(`
   fragment RenderChanges_schemaChanges on SchemaChangeConnection {
     edges {
       node {
-        criticality
+        severityLevel
         isSafeBasedOnUsage
         message(withSafeBasedOnUsageNote: false)
         approval {
@@ -62,7 +62,7 @@ export const renderChanges = (maskedChanges: FragmentType<typeof RenderChanges_S
   const writeChanges = (changes: ChangeType[]) => {
     changes.forEach(change => {
       const messageParts = [
-        criticalityMap[change.isSafeBasedOnUsage ? CriticalityLevel.Safe : change.criticality],
+        severityLevelMap[change.isSafeBasedOnUsage ? SeverityLevelType.Safe : change.severityLevel],
         Texture.boldQuotedWords(change.message),
       ];
 
@@ -85,15 +85,17 @@ export const renderChanges = (maskedChanges: FragmentType<typeof RenderChanges_S
   t.line();
 
   const breakingChanges = changes.edges.filter(
-    edge => edge.node.criticality === CriticalityLevel.Breaking,
+    edge => edge.node.severityLevel === SeverityLevelType.Breaking,
   );
   const dangerousChanges = changes.edges.filter(
-    edge => edge.node.criticality === CriticalityLevel.Dangerous,
+    edge => edge.node.severityLevel === SeverityLevelType.Dangerous,
   );
-  const safeChanges = changes.edges.filter(edge => edge.node.criticality === CriticalityLevel.Safe);
+  const safeChanges = changes.edges.filter(
+    edge => edge.node.severityLevel === SeverityLevelType.Safe,
+  );
 
   const otherChanges = changes.edges.filter(
-    edge => !Object.keys(CriticalityLevel).includes(edge.node.criticality),
+    edge => !Object.keys(SeverityLevelType).includes(edge.node.severityLevel),
   );
 
   if (breakingChanges.length) {
@@ -111,10 +113,10 @@ export const renderChanges = (maskedChanges: FragmentType<typeof RenderChanges_S
     writeChanges(safeChanges.map(edge => edge.node));
   }
 
-  // For backwards compatibility in case more criticality levels are added.
+  // For backwards compatibility in case more severity levels are added.
   // This is unlikely to happen.
   if (otherChanges.length) {
-    t.indent(`Other changes: (Current CLI version does not support these CriticalityLevels)`);
+    t.indent(`Other changes: (Current CLI version does not support these SeverityLevels)`);
     writeChanges(otherChanges.map(edge => edge.node));
   }
 

--- a/packages/libraries/cli/src/helpers/schema.ts
+++ b/packages/libraries/cli/src/helpers/schema.ts
@@ -95,7 +95,7 @@ export const renderChanges = (maskedChanges: FragmentType<typeof RenderChanges_S
   );
 
   const otherChanges = changes.edges.filter(
-    edge => !Object.keys(SeverityLevelType).includes(edge.node.severityLevel),
+    edge => !Object.values(SeverityLevelType).includes(edge.node.severityLevel),
   );
 
   if (breakingChanges.length) {

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -375,9 +375,18 @@ export default gql`
   }
 
   enum CriticalityLevel {
-    Breaking @deprecated(reason: "Use 'SeverityLevelType' instead.")
-    Dangerous @deprecated(reason: "Use 'SeverityLevelType' instead.")
-    Safe @deprecated(reason: "Use 'SeverityLevelType' instead.")
+    Breaking
+      @deprecated(
+        reason: "Use 'SeverityLevelType' instead. This field will be removed once it is no longer in use by a client."
+      )
+    Dangerous
+      @deprecated(
+        reason: "Use 'SeverityLevelType' instead. This field will be removed once it is no longer in use by a client."
+      )
+    Safe
+      @deprecated(
+        reason: "Use 'SeverityLevelType' instead. This field will be removed once it is no longer in use by a client."
+      )
   }
 
   """
@@ -403,8 +412,14 @@ export default gql`
   Describes a schema change for either a schema version (\`SchemaVersion\`) or schema check (\`SchemaCheck\`).
   """
   type SchemaChange {
-    criticality: CriticalityLevel! @deprecated(reason: "Use 'SchemaChange.severityLevel' instead.")
-    criticalityReason: String @deprecated(reason: "Use 'SchemaChange.severityReason' instead.")
+    criticality: CriticalityLevel!
+      @deprecated(
+        reason: "Use 'SchemaChange.severityLevel' instead. This field will be removed once it is no longer in use by a client."
+      )
+    criticalityReason: String
+      @deprecated(
+        reason: "Use 'SchemaChange.severityReason' instead. This field will be removed once it is no longer in use by a client."
+      )
     """
     The severity level of this schema change.
     Note: A schema change with the impact \`SeverityLevelType.BREAKING\` can still be safe based on the usage (\`SchemaChange.isSafeBasedOnUsage\`).

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -375,14 +375,48 @@ export default gql`
   }
 
   enum CriticalityLevel {
-    Breaking
-    Dangerous
-    Safe
+    Breaking @deprecated(reason: "Use 'SeverityLevelType' instead.")
+    Dangerous @deprecated(reason: "Use 'SeverityLevelType' instead.")
+    Safe @deprecated(reason: "Use 'SeverityLevelType' instead.")
   }
 
+  """
+  Describes the impact of a schema change.
+  """
+  enum SeverityLevelType {
+    """
+    The change is safe and does not break existing clients.
+    """
+    SAFE @tag(name: "public")
+    """
+    The change might break existing clients that do not follow
+    best-practises such as future-proof enums or future-proof interface/union type usages.
+    """
+    DANGEROUS @tag(name: "public")
+    """
+    The change will definetly break GraphQL client users.
+    """
+    BREAKING @tag(name: "public")
+  }
+
+  """
+  Describes a schema change for either a schema version (\`SchemaVersion\`) or schema check (\`SchemaCheck\`).
+  """
   type SchemaChange {
-    criticality: CriticalityLevel!
-    criticalityReason: String
+    criticality: CriticalityLevel! @deprecated(reason: "Use 'SchemaChange.severityLevel' instead.")
+    criticalityReason: String @deprecated(reason: "Use 'SchemaChange.severityReason' instead.")
+    """
+    The severity level of this schema change.
+    Note: A schema change with the impact \`SeverityLevelType.BREAKING\` can still be safe based on the usage (\`SchemaChange.isSafeBasedOnUsage\`).
+    """
+    severityLevel: SeverityLevelType! @tag(name: "public")
+    """
+    The reason for the schema changes severity level (\`SchemaChange.severityLevel\`)
+    """
+    severityReason: String @tag(name: "public")
+    """
+    Message describing the schema change.
+    """
     message(
       """
       Whether to include a note about the safety of the change based on usage data within the message.

--- a/packages/services/api/src/modules/schema/resolvers/SchemaChange.ts
+++ b/packages/services/api/src/modules/schema/resolvers/SchemaChange.ts
@@ -1,11 +1,21 @@
 import { CriticalityLevel as CriticalityLevelEnum } from '@graphql-inspector/core';
 import { BreakingSchemaChangeUsageHelper } from '../providers/breaking-schema-changes-helper';
-import type { CriticalityLevel, SchemaChangeResolvers } from './../../../__generated__/types';
+import type {
+  CriticalityLevel,
+  SchemaChangeResolvers,
+  SeverityLevelType,
+} from './../../../__generated__/types';
 
 const criticalityMap: Record<CriticalityLevelEnum, CriticalityLevel> = {
   [CriticalityLevelEnum.Breaking]: 'Breaking',
   [CriticalityLevelEnum.NonBreaking]: 'Safe',
   [CriticalityLevelEnum.Dangerous]: 'Dangerous',
+};
+
+const severityMap: Record<CriticalityLevelEnum, SeverityLevelType> = {
+  [CriticalityLevelEnum.NonBreaking]: 'SAFE',
+  [CriticalityLevelEnum.Dangerous]: 'DANGEROUS',
+  [CriticalityLevelEnum.Breaking]: 'BREAKING',
 };
 
 export const SchemaChange: SchemaChangeResolvers = {
@@ -21,4 +31,6 @@ export const SchemaChange: SchemaChangeResolvers = {
   isSafeBasedOnUsage: change => change.isSafeBasedOnUsage,
   usageStatistics: (change, _, { injector }) =>
     injector.get(BreakingSchemaChangeUsageHelper).getUsageDataForBreakingSchemaChange(change),
+  severityLevel: change => severityMap[change.criticality],
+  severityReason: change => change.reason,
 };

--- a/packages/web/app/src/components/target/history/errors-and-changes.tsx
+++ b/packages/web/app/src/components/target/history/errors-and-changes.tsx
@@ -26,7 +26,7 @@ import {
 } from '@/components/ui/table';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { FragmentType, graphql, useFragment } from '@/gql';
-import { CriticalityLevel } from '@/gql/graphql';
+import { SeverityLevelType } from '@/gql/graphql';
 import { CheckCircledIcon, InfoCircledIcon } from '@radix-ui/react-icons';
 import { Link } from '@tanstack/react-router';
 
@@ -38,10 +38,10 @@ export function labelize(message: string) {
   });
 }
 
-const criticalityLevelMapping = {
-  [CriticalityLevel.Safe]: clsx('text-emerald-400'),
-  [CriticalityLevel.Dangerous]: clsx('text-yellow-400'),
-} as Record<CriticalityLevel, string>;
+const severityLevelMapping = {
+  [SeverityLevelType.Safe]: clsx('text-emerald-400'),
+  [SeverityLevelType.Dangerous]: clsx('text-yellow-400'),
+} as Record<SeverityLevelType, string>;
 
 const ChangesBlock_SchemaCheckConditionalBreakingChangeMetadataFragment = graphql(`
   fragment ChangesBlock_SchemaCheckConditionalBreakingChangeMetadataFragment on SchemaCheckConditionalBreakingChangeMetadata {
@@ -73,8 +73,8 @@ const ChangesBlock_SchemaChangeWithUsageFragment = graphql(`
   fragment ChangesBlock_SchemaChangeWithUsageFragment on SchemaChange {
     path
     message(withSafeBasedOnUsageNote: false)
-    criticality
-    criticalityReason
+    severityLevel
+    severityReason
     approval {
       ...ChangesBlock_SchemaChangeApprovalFragment
     }
@@ -99,8 +99,8 @@ const ChangesBlock_SchemaChangeFragment = graphql(`
   fragment ChangesBlock_SchemaChangeFragment on SchemaChange {
     path
     message(withSafeBasedOnUsageNote: false)
-    criticality
-    criticalityReason
+    severityLevel
+    severityReason
     approval {
       ...ChangesBlock_SchemaChangeApprovalFragment
     }
@@ -111,7 +111,7 @@ const ChangesBlock_SchemaChangeFragment = graphql(`
 export function ChangesBlock(
   props: {
     title: string | React.ReactElement;
-    criticality: CriticalityLevel;
+    severityLevel: SeverityLevelType;
     organizationSlug: string;
     projectSlug: string;
     targetSlug: string;
@@ -192,7 +192,7 @@ function ChangeItem(props: {
             <div
               className={clsx(
                 (change.approval && 'text-orange-500') ||
-                  (criticalityLevelMapping[change.criticality] ?? 'text-red-400'),
+                  (severityLevelMapping[change.severityLevel] ?? 'text-red-400'),
               )}
             >
               <div className="inline-flex justify-start space-x-2">
@@ -361,8 +361,8 @@ function ChangeItem(props: {
                 )}
               </div>
             </div>
-          ) : change.criticality === CriticalityLevel.Breaking ? (
-            <>{change.criticalityReason ?? 'No details available for this breaking change.'}</>
+          ) : change.severityLevel === SeverityLevelType.Breaking ? (
+            <>{change.severityReason ?? 'No details available for this breaking change.'}</>
           ) : (
             <>No details available for this change.</>
           )}

--- a/packages/web/app/src/pages/target-checks-single.tsx
+++ b/packages/web/app/src/pages/target-checks-single.tsx
@@ -26,7 +26,7 @@ import { TimeAgo } from '@/components/ui/time-ago';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { DiffEditor } from '@/components/v2/diff-editor';
 import { FragmentType, graphql, useFragment } from '@/gql';
-import { CriticalityLevel, ProjectType } from '@/gql/graphql';
+import { ProjectType, SeverityLevelType } from '@/gql/graphql';
 import { cn } from '@/lib/utils';
 import {
   CheckIcon,
@@ -505,7 +505,7 @@ function DefaultSchemaView(props: {
                   targetSlug={props.targetSlug}
                   schemaCheckId={schemaCheck.id}
                   title={<BreakingChangesTitle />}
-                  criticality={CriticalityLevel.Breaking}
+                  severityLevel={SeverityLevelType.Breaking}
                   changesWithUsage={schemaCheck.breakingSchemaChanges.edges.map(edge => edge.node)}
                   conditionBreakingChangeMetadata={schemaCheck.conditionalBreakingChangeMetadata}
                 />
@@ -519,7 +519,7 @@ function DefaultSchemaView(props: {
                   targetSlug={props.targetSlug}
                   schemaCheckId={schemaCheck.id}
                   title="Safe Changes"
-                  criticality={CriticalityLevel.Safe}
+                  severityLevel={SeverityLevelType.Safe}
                   changes={schemaCheck.safeSchemaChanges.edges.map(edge => edge.node)}
                 />
               </div>
@@ -704,7 +704,7 @@ function ContractCheckView(props: {
                   targetSlug={props.targetSlug}
                   schemaCheckId={schemaCheck.id}
                   title={<BreakingChangesTitle />}
-                  criticality={CriticalityLevel.Breaking}
+                  severityLevel={SeverityLevelType.Breaking}
                   changesWithUsage={contractCheck.breakingSchemaChanges.edges.map(
                     edge => edge.node,
                   )}
@@ -720,7 +720,7 @@ function ContractCheckView(props: {
                   targetSlug={props.targetSlug}
                   schemaCheckId={schemaCheck.id}
                   title="Safe Changes"
-                  criticality={CriticalityLevel.Safe}
+                  severityLevel={SeverityLevelType.Safe}
                   changes={contractCheck.safeSchemaChanges.edges.map(edge => edge.node)}
                 />
               </div>

--- a/packages/web/app/src/pages/target-history-version.tsx
+++ b/packages/web/app/src/pages/target-history-version.tsx
@@ -13,7 +13,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { DiffEditor } from '@/components/v2';
 import { FragmentType, graphql, useFragment } from '@/gql';
-import { CriticalityLevel, ProjectType } from '@/gql/graphql';
+import { ProjectType, SeverityLevelType } from '@/gql/graphql';
 import { cn } from '@/lib/utils';
 import {
   CheckCircledIcon,
@@ -335,7 +335,7 @@ function DefaultSchemaVersionView(props: {
                   targetSlug={props.targetSlug}
                   schemaCheckId=""
                   title="Breaking Changes"
-                  criticality={CriticalityLevel.Breaking}
+                  severityLevel={SeverityLevelType.Breaking}
                   changes={schemaVersion.breakingSchemaChanges.edges.map(edge => edge.node)}
                 />
               </div>
@@ -348,7 +348,7 @@ function DefaultSchemaVersionView(props: {
                   targetSlug={props.targetSlug}
                   schemaCheckId=""
                   title="Safe Changes"
-                  criticality={CriticalityLevel.Safe}
+                  severityLevel={SeverityLevelType.Safe}
                   changes={schemaVersion.safeSchemaChanges.edges.map(edge => edge.node)}
                 />
               </div>
@@ -513,7 +513,7 @@ function ContractVersionView(props: {
                   targetSlug={props.targetSlug}
                   schemaCheckId=""
                   title="Breaking Changes"
-                  criticality={CriticalityLevel.Breaking}
+                  severityLevel={SeverityLevelType.Breaking}
                   changes={contractVersion.breakingSchemaChanges.edges.map(edge => edge.node)}
                 />
               </div>
@@ -526,7 +526,7 @@ function ContractVersionView(props: {
                   targetSlug={props.targetSlug}
                   schemaCheckId=""
                   title="Safe Changes"
-                  criticality={CriticalityLevel.Safe}
+                  severityLevel={SeverityLevelType.Safe}
                   changes={contractVersion.safeSchemaChanges.edges.map(edge => edge.node)}
                 />
               </div>


### PR DESCRIPTION
### Description

`CriticalityLevel` does not follow our specified conventions.

- Enum types should end with `Type`
- Enum type fields should be in upper snake case

`SeverityLevelType` replaces `CriticalityLevel` and follows the specified criteria.

This PR also adjusts both CLI and our App to use these new fields.