### PR TITLE
Update the link to go to Hive blog

### DIFF
--- a/packages/web/docs/src/app/layout.tsx
+++ b/packages/web/docs/src/app/layout.tsx
@@ -97,7 +97,11 @@ export default async function HiveDocsLayout({ children }: { children: ReactNode
               icon: <AccountBox />,
               children: 'Case Studies',
             },
-            { href: 'https://the-guild.dev/blog', icon: <PencilIcon />, children: 'Blog' },
+            {
+              href: 'https://the-guild.dev/graphql/hive/blog',
+              icon: <PencilIcon />,
+              children: 'Blog',
+            },
             {
               href: 'https://github.com/graphql-hive/console',
               icon: <GitHubIcon />,


### PR DESCRIPTION
### Description

Fixed the link. We now go to the new blog in the Hive website.

