### PR TITLE
Improve resource id tooltip interaction

### DIFF
--- a/.changeset/chilly-bobcats-smile.md
+++ b/.changeset/chilly-bobcats-smile.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Improve resource ID tooltip behavior

--- a/packages/web/app/src/components/ui/resource-details.tsx
+++ b/packages/web/app/src/components/ui/resource-details.tsx
@@ -11,10 +11,10 @@ export function ResourceDetails(props: { id: string }): ReactElement {
         Resource ID
       </div>
       <InputCopy value={props.id} className="rounded-l-none" />
-      <TooltipProvider>
+      <TooltipProvider delayDuration={0}>
         <Tooltip>
           <TooltipTrigger>
-            <InfoCircledIcon className="ml-2 size-4" />
+            <InfoCircledIcon className="ml-2 size-4 cursor-default" />
           </TooltipTrigger>
           <TooltipContent className="max-w-sm text-pretty">
             This UUID can be used in API calls or CLI commands to Hive instead of passing the full


### PR DESCRIPTION
### Background

This is something @dotansimha brought to my attention. The icon previously showed a cursor pointer on hover, making you think you needed to click. However, clicking causes the tooltip to hide.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description
This reduces to hover delay to 0 so the tooltip shows instantly on hover, and adjusts the cursor to be the default look.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->