### PR TITLE
fix: adjust query depth

### DIFF
--- a/packages/services/server/src/use-armor.ts
+++ b/packages/services/server/src/use-armor.ts
@@ -87,6 +87,8 @@ export function useArmor<
       ctx.addValidationRule(
         maxDepthRule({
           n: 22,
+          flattenFragments: true,
+          ignoreIntrospection: true,
           onReject: [
             (_, error) => {
               rejectedRequests.inc({


### PR DESCRIPTION
### Background

Follow up for https://github.com/graphql-hive/console/pull/6686

### Description

Setting `flattenFragments` to `false` makes the query depth limit plugin behave the same as our `graphql-inspector validate` command.

### Links

- https://github.com/graphql-hive/graphql-inspector/issues/2878
