### PR TITLE
test: retain service on next schema if url if not in input

### DIFF
--- a/integration-tests/tests/cli/__snapshots__/schema.spec.ts.snap
+++ b/integration-tests/tests/cli/__snapshots__/schema.spec.ts.snap
@@ -84,7 +84,13 @@ stdout--------------------------------------------:
 ℹ Available at http://__URL__
 `;
 
-exports[`FEDERATION > can update a service without providing a url if previously published > schema publish same url 1`] = ``;
+exports[`FEDERATION > can update a service without providing a url if previously published > schema publish same url 1`] = `
+:::::::::::::::: CLI SUCCESS OUTPUT :::::::::::::::::
+
+stdout--------------------------------------------:
+✔ Schema published
+ℹ Available at http://__URL__
+`;
 
 exports[`FEDERATION > can update a service without providing a url if previously published > schemaPublish (initial) 1`] = `
 :::::::::::::::: CLI SUCCESS OUTPUT :::::::::::::::::

--- a/integration-tests/tests/cli/schema.spec.ts
+++ b/integration-tests/tests/cli/schema.spec.ts
@@ -5,6 +5,7 @@ import * as GraphQLSchema from 'testkit/gql/graphql';
 import { createCLI, schemaCheck, schemaPublish } from '../../testkit/cli';
 import { cliOutputSnapshotSerializer } from '../../testkit/cli-snapshot-serializer';
 import { initSeed } from '../../testkit/seed';
+import type { CompositeSchema } from '@hive/api/__generated__/types';
 
 expect.addSnapshotSerializer(cliOutputSnapshotSerializer);
 
@@ -423,25 +424,45 @@ describe.each([ProjectType.Stitching, ProjectType.Federation, ProjectType.Single
             }),
           ).resolves.toMatchSnapshot('schema publish initial');
 
+          const sdl2 = /* GraphQL */ `
+          type Query {
+            users: [User!]
+          }
+
+          type User {
+            id: ID!
+            name: String!
+            email: String!
+            phone: String
+          }
+        `;
+
           await expect(
             cli.publish({
-              sdl,
+              sdl: sdl2,
               commit: 'push2',
               serviceName,
-              expect: 'ignored',
+              serviceUrl: undefined,
+              expect: 'latest-composable',
             }),
           ).resolves.toMatchSnapshot('schema publish same url');
 
           const versions = await fetchVersions(3);
-          expect(versions).toHaveLength(1);
+          expect(versions).toHaveLength(2);
 
           const versionWithNewServiceUrl = versions[0];
+
+          const schema = versionWithNewServiceUrl.schemas.nodes?.[0];
+          expect(schema.__typename).toBe('CompositeSchema');
+          expect((schema as CompositeSchema).url).toBe('http://localhost:4000');
 
           expect(await compareToPreviousVersion(versionWithNewServiceUrl.id)).toEqual(
             expect.objectContaining({
               target: expect.objectContaining({
                 schemaVersion: expect.objectContaining({
-                  safeSchemaChanges: null,
+                  safeSchemaChanges: {
+                    nodes: expect.anything(),
+                  },
                   schemaCompositionErrors: null,
                 }),
               }),

--- a/integration-tests/tests/cli/schema.spec.ts
+++ b/integration-tests/tests/cli/schema.spec.ts
@@ -2,10 +2,10 @@
 import { createHash } from 'node:crypto';
 import { ProjectType } from 'testkit/gql/graphql';
 import * as GraphQLSchema from 'testkit/gql/graphql';
+import type { CompositeSchema } from '@hive/api/__generated__/types';
 import { createCLI, schemaCheck, schemaPublish } from '../../testkit/cli';
 import { cliOutputSnapshotSerializer } from '../../testkit/cli-snapshot-serializer';
 import { initSeed } from '../../testkit/seed';
-import type { CompositeSchema } from '@hive/api/__generated__/types';
 
 expect.addSnapshotSerializer(cliOutputSnapshotSerializer);
 
@@ -425,17 +425,17 @@ describe.each([ProjectType.Stitching, ProjectType.Federation, ProjectType.Single
           ).resolves.toMatchSnapshot('schema publish initial');
 
           const sdl2 = /* GraphQL */ `
-          type Query {
-            users: [User!]
-          }
+            type Query {
+              users: [User!]
+            }
 
-          type User {
-            id: ID!
-            name: String!
-            email: String!
-            phone: String
-          }
-        `;
+            type User {
+              id: ID!
+              name: String!
+              email: String!
+              phone: String
+            }
+          `;
 
           await expect(
             cli.publish({


### PR DESCRIPTION
### Background

Tests https://github.com/graphql-hive/console/pull/6694

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

I wrote this test and ran before the fix PR:

<img width="850" alt="Screenshot 2025-04-02 at 1 03 59 PM" src="https://github.com/user-attachments/assets/0a5d3dbc-0bae-4e28-8b40-5dfb8c43ba8e" />

Then ran against latest:
<img width="351" alt="Screenshot 2025-04-02 at 1 11 40 PM" src="https://github.com/user-attachments/assets/9f4dd9f8-b430-49e7-b096-c5e2877973d8" />


<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
