### PR TITLE
Slack error logs

### DIFF
--- a/.changeset/brave-snails-design.md
+++ b/.changeset/brave-snails-design.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Improve slack alert error logs

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -287,8 +287,6 @@ export class RegistryChecks {
       } satisfies CheckResult;
     }
 
-    this.logger.debug('No validation errors');
-
     if (!result.sdl) {
       throw new Error('No SDL, but no errors either');
     }


### PR DESCRIPTION
### Background

When investigating other sentry errors, I noticed that the "channel_not_found" was coming up relatively frequently. This error is due to the channel not existing and is not an error on our end that is worth tracking.
<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

I've adjusted the error level to be a warning, which makes more sense, and have improved the logs to include some details about the error. Currently, the error logs only show `"msg":"Failed to send Slack notification ..."`
