### PR TITLE
fix(api): improve emtpy value assertion

### DIFF
--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -765,7 +765,7 @@ export function detectUrlChanges(
     const before = nameToCompositeSchemaMap.get(schema.service_name);
 
     if (before && before.service_url !== schema.service_url) {
-      if (before.service_url && schema.service_url) {
+      if (before.service_url != null && schema.service_url != null) {
         changes.push({
           type: 'REGISTRY_SERVICE_URL_CHANGED',
           meta: {
@@ -776,7 +776,7 @@ export function detectUrlChanges(
             },
           },
         });
-      } else if (before.service_url && schema.service_url == null) {
+      } else if (before.service_url != null && schema.service_url == null) {
         changes.push({
           type: 'REGISTRY_SERVICE_URL_CHANGED',
           meta: {
@@ -787,7 +787,7 @@ export function detectUrlChanges(
             },
           },
         });
-      } else if (before.service_url == null && schema.service_url) {
+      } else if (before.service_url == null && schema.service_url != null) {
         changes.push({
           type: 'REGISTRY_SERVICE_URL_CHANGED',
           meta: {
@@ -799,7 +799,9 @@ export function detectUrlChanges(
           },
         });
       } else {
-        throw new Error("This shouldn't happen.");
+        throw new Error(
+          `This shouldn't happen (before.service_url=${JSON.stringify(before.service_url)}, schema.service_url=${JSON.stringify(schema.service_url)}).`,
+        );
       }
     }
   }


### PR DESCRIPTION
### Background

Someone managed to publish an empty service url to a federation project, which resulted in a runtime exception as `""` is treated as falsy by default.


### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
