### PR TITLE
Extend timeout for schema check using cli from 20s to 65s

### DIFF
--- a/.changeset/twelve-cycles-lick.md
+++ b/.changeset/twelve-cycles-lick.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+Increase schema check client timeout from 20s to 65s

--- a/packages/libraries/cli/src/commands/schema/check.ts
+++ b/packages/libraries/cli/src/commands/schema/check.ts
@@ -265,6 +265,8 @@ export default class SchemaCheck extends Command<typeof SchemaCheck> {
             url: flags.url,
           },
         },
+        // extend timeout from 20s to 65s for checks since they can take longer for massive schema
+        timeout: 65_000,
       });
 
       if (flags.experimentalJsonFile) {


### PR DESCRIPTION
### Background

We had an issue where a schema check was being aborted after 20s and not hitting our service. Hive's global timeout is 60s. Therefore, it's possible for these schema checks to succeed, but be aborted by clients after 20s. Instead, we should allow the service to process the schema fully before giving up.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

Sets the client timeout to slightly longer than the server in order to minimize the possibility of the schema check being aborted early while it's still being processed.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
