### PR TITLE
Add maxmemory policy volatile-ttl

### DIFF
--- a/deployment/utils/redis.ts
+++ b/deployment/utils/redis.ts
@@ -108,7 +108,11 @@ export class Redis {
           // Note: this is needed, otherwise local config is not loaded at all
           command: ['/opt/bitnami/scripts/redis/entrypoint.sh'],
           // This is where we can pass actual flags to the bitnami/redis runtime
-          args: ['/opt/bitnami/scripts/redis/run.sh', `--maxmemory ${memoryInMegabytes}mb`],
+          args: [
+            '/opt/bitnami/scripts/redis/run.sh',
+            `--maxmemory ${memoryInMegabytes}mb`,
+            '--maxmemory-policy volatile-ttl',
+          ],
           readinessProbe: {
             initialDelaySeconds: 5,
             periodSeconds: 8,


### PR DESCRIPTION
### Background

Recent outage of webhooks caused by redis filling up and emitting an unhandled error because of maxmemory set here https://github.com/graphql-hive/console/pull/6737

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

Currently, the maxmemory policy is `noeviction` which is causing memory to fill up past its limit.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

