### PR TITLE
fix(docs): updated usage example of apollo-router plugin as a rs lib

### DIFF
--- a/packages/libraries/router/README.md
+++ b/packages/libraries/router/README.md
@@ -30,7 +30,7 @@ integration to Apollo-Router.
 
 [Please follow this guide and documentation for integrating Hive with Apollo Router](https://the-guild.dev/graphql/hive/docs/other-integrations/apollo-router)
 
-### Library
+### As a Library
 
 If you are
 [building a custom Apollo-Router with your own native plugins](https://www.apollographql.com/docs/graphos/routing/customization/native-plugins),
@@ -44,14 +44,21 @@ hive-apollo-router-plugin = "..."
 And then in your codebase, make sure to import and register the Hive plugin:
 
 ```rs
+use apollo_router::register_plugin;
 // import the registry instance and the plugin registration function
 use hive_apollo_router_plugin::registry::HiveRegistry;
-use hive_apollo_router_plugin::usage::register;
+// Import the usage plugin
+use hive_apollo_router_plugin::usage::UsagePlugin;
+// Import persisted documents plugin, if needed
+use persisted_documents::PersistedDocumentsPlugin;
+
 
 // In your main function, make sure to register the plugin before you create or initialize Apollo-Router
 fn main() {
     // Register the Hive usage_reporting plugin
-    register();
+    register_plugin!("hive", "usage", UsagePlugin);
+    // Register the persisted documents plugin, if needed
+    register_plugin!("hive", "persisted_documents", PersistedDocumentsPlugin);
 
     // Initialize the Hive Registry instance and start the Apollo Router
     match HiveRegistry::new(None).and(apollo_router::main()) {

--- a/packages/web/docs/src/content/other-integrations/apollo-router.mdx
+++ b/packages/web/docs/src/content/other-integrations/apollo-router.mdx
@@ -246,12 +246,16 @@ You can send usage reporting to Hive registry by enabling `hive.usage` plugin in
       mod plugins;
 
       use anyhow::Result;
+    + use apollo_router::register_plugin;
     + use hive_apollo_router_plugin::registry;
-    + use hive_apollo_router_plugin::usage;
+    + use hive_apollo_router_plugin::usage::UsagePlugin;
 
       fn main() -> Result<()> {
     -   apollo_router::main()
-    +   usage::register();
+
+    + // Register the Hive usage_reporting plugin
+    + register_plugin!("hive", "usage", UsagePlugin);
+
     +   match registry::HiveRegistry::new(None).and(apollo_router::main()) {
     +     Ok(_) => {}
     +     Err(e) => {
@@ -366,6 +370,45 @@ plugins:
     # Default: 1000
     cache_size: 1000
 ```
+
+### Use as library
+
+You may also add the persisted-documents plugin:
+
+```toml filename="Cargo.toml"
+[dependencies]
+# You can use a "branch", or commit id with "rev" key
+hive_apollo_router_plugin = { git = "https://github.com/graphql-hive/console", branch = "main" }
+```
+
+Next, update `src/main.rs` file with the following content to add GraphQL Hive:
+
+```diff filename="src/main.rs"
+  mod plugins;
+
+  use anyhow::Result;
++ use apollo_router::register_plugin;
++ use hive_apollo_router_plugin::registry;
++ use hive_apollo_router_plugin::persisted_documents::PersistedDocumentsPlugin;
+
+  fn main() -> Result<()> {
+-   apollo_router::main()
+
++ // Register the persisted documents plugin, if needed
++ register_plugin!("hive", "persisted_documents", PersistedDocumentsPlugin);
+
++   match registry::HiveRegistry::new(None).and(apollo_router::main()) {
++     Ok(_) => {}
++     Err(e) => {
++         eprintln!("{}", e);
++         std::process::exit(1);
++     }
++   }
+  }
+```
+
+If you are using both plugins (usage and persisted operations), you'll need to have a
+`register_plugin!` call to both plugins.
 
 ## Additional Resources
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1861,7 +1861,7 @@ importers:
         version: 4.3.4(vite@6.1.5(@types/node@22.10.5)(jiti@2.3.3)(less@4.2.0)(lightningcss@1.28.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.5.0))
       autoprefixer:
         specifier: 10.4.20
-        version: 10.4.20(postcss@8.4.49)
+        version: 10.4.20(postcss@8.5.2)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -25168,14 +25168,14 @@ snapshots:
 
   auto-bind@4.0.0: {}
 
-  autoprefixer@10.4.20(postcss@8.4.49):
+  autoprefixer@10.4.20(postcss@8.5.2):
     dependencies:
       browserslist: 4.24.0
       caniuse-lite: 1.0.30001669
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.4.49
+      postcss: 8.5.2
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.5: {}


### PR DESCRIPTION
- [x] Updated example snippets to use `register_plugin!` instead of legacy `::register` fn. 
- [x] Added docs for using persisted-documents plugin as a library. 
- [x] Also updated README