### PR TITLE
fix: ensure file is written in temp dir

### DIFF
--- a/.changeset/happy-wasps-vanish.md
+++ b/.changeset/happy-wasps-vanish.md
@@ -1,0 +1,5 @@
+---
+'hive-apollo-router-plugin': patch
+---
+
+fix tmp dir filename

--- a/packages/libraries/router/src/registry.rs
+++ b/packages/libraries/router/src/registry.rs
@@ -124,7 +124,7 @@ impl HiveRegistry {
         // It also enables hot-reloading to makes sure Apollo Router watches the file.
         let file_name = config.schema_file_path.unwrap_or(
             env::temp_dir()
-                .with_file_name("supergraph-schema.graphql")
+                .join("supergraph-schema.graphql")
                 .to_string_lossy()
                 .to_string(),
         );


### PR DESCRIPTION
### Background

```
use std::env;

fn main() {
    let file_name = env::temp_dir()
                .with_file_name("supergraph-schema.graphql")
                .to_string_lossy()
                .to_string();
                
    assert_eq!(file_name, "/tmp/supergraph-schema.graphql")
}
```

results in:

```
thread 'main' panicked at src/main.rs:9:5:
assertion `left == right` failed
  left: "/supergraph-schema.graphql"
 right: "/tmp/supergraph-schema.graphql"
```

If the file is written to root, it is problematic when configuring the container to run as non-root user

### Description

Concat filename to temp directory

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
