### PR TITLE
Exit the worker thread correctly instead of hanging

### DIFF
--- a/packages/services/schema/src/composition-scheduler.ts
+++ b/packages/services/schema/src/composition-scheduler.ts
@@ -102,8 +102,8 @@ export class CompositionScheduler {
       });
     };
 
+    // catch uncaught exception from worker thread. Worker thread gets terminated.
     worker.on('error', error => {
-      console.error(error);
       this.logger.error('Worker error %s', error);
       Sentry.captureException(error, {
         extra: {

--- a/packages/services/schema/src/composition-worker.ts
+++ b/packages/services/schema/src/composition-worker.ts
@@ -22,21 +22,7 @@ export function createCompositionWorker(args: {
 
   process.on('unhandledRejection', function (err) {
     console.error('unhandledRejection', err);
-    console.error(err);
-    args.port.postMessage({
-      code: 'ERROR',
-      err,
-    });
-    process.exit(1);
-  });
-
-  process.on('uncaughtException', function (err) {
-    console.error('uncaughtException', err);
-    args.port.postMessage({
-      code: 'ERROR',
-      err,
-    });
-    process.exit(1);
+    throw err;
   });
 
   args.port.on('message', async (message: CompositionEvent) => {


### PR DESCRIPTION
### Background

If the worker thread throws an uncaught exception, the worker thread stops receiving messages and `postMessage` from the main thread will hang.

This is because when the worker thread calls process.exit, it does not report the error to the main process

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

To resolve this, we should not capture this error and should instead allow the main thread to capture and handle the error.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
