### PR TITLE
Reduce retry counts; adjust usage producer fallback logic

### DIFF
--- a/.changeset/tender-flowers-refuse.md
+++ b/.changeset/tender-flowers-refuse.md
@@ -2,4 +2,4 @@
 'hive': patch
 ---
 
-Do not rethrow kafka messages that have been added to fallback queue
+Correctly set usage service state to Ready after processing all of the fallback queue.

--- a/.changeset/tender-flowers-refuse.md
+++ b/.changeset/tender-flowers-refuse.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Do not rethrow kafka messages that have been added to fallback queue

--- a/packages/services/usage/src/usage.ts
+++ b/packages/services/usage/src/usage.ts
@@ -35,7 +35,7 @@ const retryOptions = {
   initialRetryTime: 500,
   factor: 0.2,
   multiplier: 2,
-  retries: 10,
+  retries: 5,
 } satisfies RetryOptions; // why satisfies? To be able to use `retryOptions.retries` and get `number` instead of `number | undefined`
 
 export function splitReport(report: RawReport, numOfChunks: number) {
@@ -165,7 +165,7 @@ export function createUsage(config: {
       return Object.keys(report.map).length;
     },
     split(report, numOfChunks) {
-      logger.info('Splitting into %s', numOfChunks);
+      logger.info('Splitting report into %s (id=%s)', numOfChunks, report.id);
       return splitReport(report, numOfChunks);
     },
     onRetry(reports) {
@@ -186,6 +186,7 @@ export function createUsage(config: {
       try {
         bufferFlushes.inc();
         const stopTimer = kafkaDuration.startTimer();
+
         const meta = await producer
           .send({
             topic: config.kafka.topic,
@@ -212,21 +213,11 @@ export function createUsage(config: {
           rawOperationWrites.inc(numOfOperations);
           logger.info(`Flushed (id=%s, operations=%s)`, batchId, numOfOperations);
         }
-
-        changeStatus(Status.Ready);
       } catch (error: any) {
         rawOperationFailures.inc(numOfOperations);
 
         changeStatus(Status.Unhealthy);
-        logger.error(`Failed to flush (id=%s, error=%s)`, batchId, error.message);
-        Sentry.setTags({
-          batchId,
-          message: error.message,
-          numOfOperations,
-        });
-        Sentry.captureException(error);
-
-        logger.info('Adding to fallback queue (id=%s)', batchId);
+        logger.error(`Failed to flush. Adding to fallback queue (id=%s, error=%s)`, batchId, error.message);
         fallback.add(value, numOfOperations);
 
         throw error;
@@ -254,6 +245,11 @@ export function createUsage(config: {
         throw error;
       } finally {
         stopTimer();
+      }
+
+      if (fallback.size() === 0) {
+        logger.info('Fallback queue flushed')
+        changeStatus(Status.Ready);
       }
     },
     logger: logger.child({ component: 'fallback' }),
@@ -306,7 +302,7 @@ export function createUsage(config: {
       },
     ),
     readiness() {
-      return status === Status.Ready && fallback.size() === 0;
+      return status === Status.Ready;
     },
     async start() {
       logger.info('Starting Kafka producer');

--- a/packages/services/usage/src/usage.ts
+++ b/packages/services/usage/src/usage.ts
@@ -186,7 +186,6 @@ export function createUsage(config: {
       try {
         bufferFlushes.inc();
         const stopTimer = kafkaDuration.startTimer();
-
         const meta = await producer
           .send({
             topic: config.kafka.topic,

--- a/packages/services/usage/src/usage.ts
+++ b/packages/services/usage/src/usage.ts
@@ -216,7 +216,11 @@ export function createUsage(config: {
         rawOperationFailures.inc(numOfOperations);
 
         changeStatus(Status.Unhealthy);
-        logger.error(`Failed to flush. Adding to fallback queue (id=%s, error=%s)`, batchId, error.message);
+        logger.error(
+          `Failed to flush. Adding to fallback queue (id=%s, error=%s)`,
+          batchId,
+          error.message,
+        );
         fallback.add(value, numOfOperations);
 
         throw error;
@@ -247,7 +251,7 @@ export function createUsage(config: {
       }
 
       if (fallback.size() === 0) {
-        logger.info('Fallback queue flushed')
+        logger.info('Fallback queue flushed');
         changeStatus(Status.Ready);
       }
     },


### PR DESCRIPTION
### Background

The short form is that when we push the the fallback producer queue, our buffer is never set back to the `Ready` status.

And the pod is killed after the grace period -- `terminationGracePeriodSeconds: 60,`

The most recent case when this happend looked like this:
<img width="563" alt="Screenshot 2025-04-25 at 1 15 34 PM" src="https://github.com/user-attachments/assets/c4b26f9e-2e03-4a09-a890-436c3c3cad97" />
<img width="714" alt="Screenshot 2025-04-25 at 1 15 37 PM" src="https://github.com/user-attachments/assets/276c0677-e899-422f-8b5a-9d4d999dc3cd" />
which supports this theory.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

This change addresses the readiness logic to make sure after the fallback queue is processed, that the state is changed back to Ready.

The one thing I am not entirely sure about is why the memory shows such a dramatic spike. All other metrics make sense (503s, kafka latency ... ).

