### PR TITLE
fix(docs): update max body size for usage service

### DIFF
--- a/packages/web/docs/src/content/specs/usage-reports.mdx
+++ b/packages/web/docs/src/content/specs/usage-reports.mdx
@@ -11,7 +11,7 @@ import usageReportV2Schema from '../../../../../services/usage/usage-report-v2.s
 The official JavaScript Hive Client (`@graphql-hive/core`) collects executed operations and sends
 them in batches (as a single report, when a buffer is full or every few seconds) over HTTP.
 
-> It's recommended to send a report for more than 1 operation. The maximum payload size is 1 MB.
+> It's recommended to send a report for more than 1 operation. The maximum payload size is 15 MB.
 
 | Name                 | Value                                                                                                                      |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
The default body size 15MB: https://github.com/graphql-hive/console/blob/70bc7a862a20a65550ccdafbd1fac6950955e3c4/packages/services/service-common/src/fastify.ts#L21 , and we do no override it for usage service. 