### PR TITLE
Specify oclif exitcode in cli errors

### DIFF
--- a/.changeset/weak-crabs-approve.md
+++ b/.changeset/weak-crabs-approve.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+Correct error exit codes

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -92,7 +92,7 @@ test.concurrent(
       },
     ]);
     expect(collectResult.status).toEqual(200);
-    await waitFor(8000);
+    await waitFor(10_000);
 
     // should be breaking because the field is used now
     const usedCheckResult = await readToken
@@ -123,6 +123,9 @@ test.concurrent(
     expect(op.name).toMatch('ping');
     expect(op.percentage).toBeGreaterThan(99);
   },
+  {
+    timeout: 15_000,
+  }
 );
 
 test.concurrent(

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -125,7 +125,7 @@ test.concurrent(
   },
   {
     timeout: 15_000,
-  }
+  },
 );
 
 test.concurrent(

--- a/integration-tests/tests/cli/__snapshots__/schema.spec.ts.snap
+++ b/integration-tests/tests/cli/__snapshots__/schema.spec.ts.snap
@@ -156,7 +156,7 @@ http://__URL__
 exports[`FEDERATION > publish validates the service name > onlyNumbers 1`] = `
 :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
 exitCode------------------------------------------:
-2
+1
 stderr--------------------------------------------:
  ›   Error: Schema publish failed.  [300]
  ›   > See https://__URL__ for
@@ -173,7 +173,7 @@ stdout--------------------------------------------:
 exports[`FEDERATION > publish validates the service name > specialCharacters 1`] = `
 :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
 exitCode------------------------------------------:
-2
+1
 stderr--------------------------------------------:
  ›   Error: Schema publish failed.  [300]
  ›   > See https://__URL__ for
@@ -198,7 +198,7 @@ stdout--------------------------------------------:
 exports[`FEDERATION > publishing invalid schema SDL provides meaningful feedback for the user. > schemaPublish 1`] = `
 :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
 exitCode------------------------------------------:
-2
+3
 stderr--------------------------------------------:
  ›   Error: The SDL is not valid at line 1, column 1:
  ›    Syntax Error: Unexpected Name "iliketurtles".  [301]
@@ -274,7 +274,7 @@ stdout--------------------------------------------:
 exports[`FEDERATION > schema:publish should see Invalid Token error when token is invalid > schemaPublish 1`] = `
 :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
 exitCode------------------------------------------:
-2
+1
 stderr--------------------------------------------:
  ›   Error: A valid registry token is required to perform the action. The
  ›   registry token used does not exist or has been revoked.  [106]
@@ -461,7 +461,7 @@ stdout--------------------------------------------:
 exports[`SINGLE > publishing invalid schema SDL provides meaningful feedback for the user. > schemaPublish 1`] = `
 :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
 exitCode------------------------------------------:
-2
+3
 stderr--------------------------------------------:
  ›   Error: The SDL is not valid at line 1, column 1:
  ›    Syntax Error: Unexpected Name "iliketurtles".  [301]
@@ -542,7 +542,7 @@ stdout--------------------------------------------:
 exports[`SINGLE > schema:publish should see Invalid Token error when token is invalid > schemaPublish 1`] = `
 :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
 exitCode------------------------------------------:
-2
+1
 stderr--------------------------------------------:
  ›   Error: A valid registry token is required to perform the action. The
  ›   registry token used does not exist or has been revoked.  [106]
@@ -703,7 +703,7 @@ http://__URL__
 exports[`STITCHING > publish validates the service name > onlyNumbers 1`] = `
 :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
 exitCode------------------------------------------:
-2
+1
 stderr--------------------------------------------:
  ›   Error: Schema publish failed.  [300]
  ›   > See https://__URL__ for
@@ -720,7 +720,7 @@ stdout--------------------------------------------:
 exports[`STITCHING > publish validates the service name > specialCharacters 1`] = `
 :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
 exitCode------------------------------------------:
-2
+1
 stderr--------------------------------------------:
  ›   Error: Schema publish failed.  [300]
  ›   > See https://__URL__ for
@@ -745,7 +745,7 @@ stdout--------------------------------------------:
 exports[`STITCHING > publishing invalid schema SDL provides meaningful feedback for the user. > schemaPublish 1`] = `
 :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
 exitCode------------------------------------------:
-2
+3
 stderr--------------------------------------------:
  ›   Error: The SDL is not valid at line 1, column 1:
  ›    Syntax Error: Unexpected Name "iliketurtles".  [301]
@@ -823,7 +823,7 @@ stdout--------------------------------------------:
 exports[`STITCHING > schema:publish should see Invalid Token error when token is invalid > schemaPublish 1`] = `
 :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
 exitCode------------------------------------------:
-2
+1
 stderr--------------------------------------------:
  ›   Error: A valid registry token is required to perform the action. The
  ›   registry token used does not exist or has been revoked.  [106]

--- a/integration-tests/tests/cli/schema.spec.ts
+++ b/integration-tests/tests/cli/schema.spec.ts
@@ -704,7 +704,7 @@ test.concurrent(
     ).rejects.toMatchInlineSnapshot(`
       :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
       exitCode------------------------------------------:
-      2
+      1
       stderr--------------------------------------------:
        ›   Error: No access (reason: "Missing permission for performing
        ›   'schemaVersion:publish' on resource")  (Request ID: __REQUEST_ID__)  [115]
@@ -785,7 +785,7 @@ test('schema:check without `--target` flag fails for organization access token',
   ).rejects.toMatchInlineSnapshot(`
     :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
     exitCode------------------------------------------:
-    2
+    3
     stderr--------------------------------------------:
      ›   Error: Missing 1 required argument:
      ›   TARGET 	The target on which the action is performed. This can either be a
@@ -857,7 +857,7 @@ test('schema:publish without `--target` flag fails for organization access token
   ).rejects.toMatchInlineSnapshot(`
     :::::::::::::::: CLI FAILURE OUTPUT :::::::::::::::
     exitCode------------------------------------------:
-    2
+    3
     stderr--------------------------------------------:
      ›   Error: Missing 1 required argument:
      ›   TARGET 	The target on which the action is performed. This can either be a

--- a/packages/libraries/cli/src/helpers/errors.ts
+++ b/packages/libraries/cli/src/helpers/errors.ts
@@ -30,7 +30,9 @@ export class HiveCLIError extends CLIError {
   ) {
     const tip = `> See https://the-guild.dev/graphql/hive/docs/api-reference/cli#errors for a complete list of error codes and recommended fixes.
 To disable this message set HIVE_NO_ERROR_TIP=1`;
-    super(`${message}  [${code}]${env.HIVE_NO_ERROR_TIP === '1' ? '' : `\n${tip}`}`);
+    super(`${message}  [${code}]${env.HIVE_NO_ERROR_TIP === '1' ? '' : `\n${tip}`}`, {
+      exit: exitCode,
+    });
   }
 }
 


### PR DESCRIPTION
### Background

https://linear.app/the-guild/issue/CONSOLE-1098/cli-add-optional-flag-to-exit-with-1-if-composition-fails
We got a report that composition failures were not exiting with code(1) on error.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

OCLIF was not being passed the exit code. This fixes the exitcode passing so that we can control what the exit code is based on the error we throw.

After fix:
```
➜  cli git:(main) ✗ pnpm start dev \
  --registry.accessToken "25eb3969ecfca640645d6f50e7ef9bc2" \
  --target "82804777-0061-49d0-8bb0-201668f079d4" \
  --service reviews --url http://localhost:3001/graphql --schema examples/federation.reviews.graphql \
  --service products --url http://localhost:3002/graphql --schema examples/federation.products.graphql

> @graphql-hive/cli@0.49.1 start /Users/jdolle/guild/console/packages/libraries/cli
> ./bin/dev dev --registry.accessToken 25eb3969ecfca640645d6f50e7ef9bc2 --target 82804777-0061-49d0-8bb0-201668f079d4 --service reviews --url http\://localhost\:3001/graphql --schema examples/federation.reviews.graphql --service products --url http\://localhost\:3002/graphql --schema examples/federation.products.graphql

Error: Local composition failed:
✖ Detected 2 errors

   - Non-shareable field Query.product is resolved from multiple subgraphs: it is resolved from subgraphs products and reviews and defined as non-shareable in all of them
   - Argument Query.product(id:) is required in some subgraphs but does not appear in all subgraphs: it is required in subgraph products but does not appear in subgraph reviews
  [601]
> See https://the-guild.dev/graphql/hive/docs/api-reference/cli#errors for a complete list of error codes and recommended fixes.
To disable this message set HIVE_NO_ERROR_TIP=1
    at Dev.composeLocally (/Users/jdolle/guild/console/packages/libraries/cli/src/commands/dev.ts:355:21)
 ELIFECYCLE  Command failed with exit code 1.
```
