### PR TITLE
Contract root types

### DIFF
--- a/.changeset/fifty-deers-shake.md
+++ b/.changeset/fifty-deers-shake.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Adjust contract logic to allow removing mutation and subscription types

--- a/packages/services/schema/src/api.ts
+++ b/packages/services/schema/src/api.ts
@@ -123,7 +123,6 @@ export const schemaBuilderApiRouter = t.router({
             native: 'native' in input && input.native ? true : false,
             contracts: 'contracts' in input && input.contracts ? input.contracts : undefined,
             requestId: ctx.req.id,
-            // @todo pass the base schema in so that it's factored into the cache key.
           });
         }
 

--- a/packages/services/schema/src/api.ts
+++ b/packages/services/schema/src/api.ts
@@ -123,6 +123,7 @@ export const schemaBuilderApiRouter = t.router({
             native: 'native' in input && input.native ? true : false,
             contracts: 'contracts' in input && input.contracts ? input.contracts : undefined,
             requestId: ctx.req.id,
+            // @todo pass the base schema in so that it's factored into the cache key.
           });
         }
 

--- a/packages/services/schema/src/lib/__tests__/federation-tag-extraction.spec.ts
+++ b/packages/services/schema/src/lib/__tests__/federation-tag-extraction.spec.ts
@@ -392,7 +392,9 @@ describe('applyTagFilterToInaccessibleTransformOnSubgraphSchema', () => {
 
       const output = applyTagFilterToInaccessibleTransformOnSubgraphSchema(sdl, filter);
 
-      expect(output.typesWithAllFieldsInaccessible.entries().toArray()).toEqual([['Mutation', true]]);
+      expect(output.typesWithAllFieldsInaccessible.entries().toArray()).toEqual([
+        ['Mutation', true],
+      ]);
 
       expect(print(output.typeDefs)).toMatchInlineSnapshot(`
         schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"]) {

--- a/packages/services/schema/src/lib/__tests__/federation-tag-extraction.spec.ts
+++ b/packages/services/schema/src/lib/__tests__/federation-tag-extraction.spec.ts
@@ -3,7 +3,7 @@ import {
   applyTagFilterOnSubgraphs,
   applyTagFilterToInaccessibleTransformOnSubgraphSchema,
   type Federation2SubgraphDocumentNodeByTagsFilter,
-} from './federation-tag-extraction';
+} from '../federation-tag-extraction';
 
 describe('applyTagFilterToInaccessibleTransformOnSubgraphSchema', () => {
   describe('correct @inaccessible directive usage based on subgraph version/imports', () => {
@@ -369,6 +369,44 @@ describe('applyTagFilterToInaccessibleTransformOnSubgraphSchema', () => {
         field1: ID!
       }
     `);
+    });
+
+    test('mutation object type is returned in "typesWithAllFieldsInaccessible" if all its fields are excluded', () => {
+      const filter: Federation2SubgraphDocumentNodeByTagsFilter = {
+        include: new Set(),
+        exclude: new Set(['exclude']),
+      };
+      const sdl = parse(/* GraphQL */ `
+        schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"]) {
+          query: Query
+        }
+
+        type Query {
+          field1: String!
+        }
+
+        type Mutation {
+          field1: ID! @tag(name: "exclude")
+        }
+      `);
+
+      const output = applyTagFilterToInaccessibleTransformOnSubgraphSchema(sdl, filter);
+
+      expect(output.typesWithAllFieldsInaccessible.entries().toArray()).toEqual([['Mutation', true]]);
+
+      expect(print(output.typeDefs)).toMatchInlineSnapshot(`
+        schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"]) {
+          query: Query
+        }
+
+        type Query {
+          field1: String!
+        }
+
+        type Mutation {
+          field1: ID! @federation__inaccessible
+        }
+      `);
     });
   });
 

--- a/packages/services/schema/src/lib/__tests__/reachable-type-filter.spec.ts
+++ b/packages/services/schema/src/lib/__tests__/reachable-type-filter.spec.ts
@@ -1,5 +1,5 @@
 import { parse, print } from 'graphql';
-import { addDirectiveOnTypes, getReachableTypes } from './reachable-type-filter';
+import { addDirectiveOnTypes, getReachableTypes } from '../reachable-type-filter';
 
 describe('getReachableTypes', () => {
   it('includes the query type', () => {

--- a/packages/services/schema/src/lib/federation-tag-extraction.ts
+++ b/packages/services/schema/src/lib/federation-tag-extraction.ts
@@ -63,10 +63,8 @@ function hasIntersection<T>(a: Set<T>, b: Set<T>): boolean {
   return false;
 }
 
-function getRootTypeNamesFromDocumentNode(document: DocumentNode) {
+function getRootQueryTypeNameFromDocumentNode(document: DocumentNode) {
   let queryName: string | null = 'Query';
-  let mutationName: string | null = 'Mutation';
-  let subscriptionName: string | null = 'Subscription';
 
   for (const definition of document.definitions) {
     if (definition.kind === Kind.SCHEMA_DEFINITION || definition.kind === Kind.SCHEMA_EXTENSION) {
@@ -74,23 +72,11 @@ function getRootTypeNamesFromDocumentNode(document: DocumentNode) {
         if (operationTypeDefinition.operation === 'query') {
           queryName = operationTypeDefinition.type.name.value;
         }
-        if (operationTypeDefinition.operation === 'mutation') {
-          mutationName = operationTypeDefinition.type.name.value;
-        }
-        if (operationTypeDefinition.operation === 'subscription') {
-          subscriptionName = operationTypeDefinition.type.name.value;
-        }
       }
     }
   }
 
-  const names = new Set<string>();
-
-  names.add(queryName);
-  names.add(mutationName);
-  names.add(subscriptionName);
-
-  return names;
+  return queryName;
 }
 
 type ObjectLikeNode =
@@ -127,7 +113,7 @@ export function applyTagFilterToInaccessibleTransformOnSubgraphSchema(
     tagDirectiveName,
     inaccessibleDirectiveName,
   );
-  const rootTypeNames = getRootTypeNamesFromDocumentNode(documentNode);
+  const rootQueryTypeName = getRootQueryTypeNameFromDocumentNode(documentNode);
 
   const typesWithAllFieldsInaccessibleTracker = new Map<string, boolean>();
 
@@ -355,9 +341,7 @@ export function applyTagFilterToInaccessibleTransformOnSubgraphSchema(
     [Kind.UNION_TYPE_DEFINITION]: scalarAndUnionHandler,
   });
 
-  for (const rootTypeName of rootTypeNames) {
-    typesWithAllFieldsInaccessibleTracker.delete(rootTypeName);
-  }
+  typesWithAllFieldsInaccessibleTracker.delete(rootQueryTypeName);
 
   return {
     typeDefs,


### PR DESCRIPTION
### Background

https://linear.app/the-guild/issue/CONSOLE-1239/adjust-contract-logic-to-allow-empty-mutations

Contract behavior is to remove types that have all inaccessible fields. However, currently all root types are kept. This causes issues because per graphql, only the Query type needs to be defined in a schema.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

This change adjusts the contracts logic so that only the root query type is kept no matter what.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [x] Testing
