### PR TITLE
Coordinate insights metadata

### DIFF
--- a/.changeset/brave-lobsters-raise.md
+++ b/.changeset/brave-lobsters-raise.md
@@ -1,0 +1,5 @@
+---
+'hive': minor
+---
+
+Add meta and subgraph data to coordinate insights page; Fix SubgraphChip service link

--- a/packages/services/api/src/modules/operations/resolvers/SchemaCoordinateStats.ts
+++ b/packages/services/api/src/modules/operations/resolvers/SchemaCoordinateStats.ts
@@ -2,7 +2,10 @@ import { hash } from '../../../shared/helpers';
 import { OperationsManager } from '../providers/operations-manager';
 import type { SchemaCoordinateStatsResolvers } from './../../../__generated__/types';
 
-export const SchemaCoordinateStats: SchemaCoordinateStatsResolvers = {
+export const SchemaCoordinateStats: Pick<
+  SchemaCoordinateStatsResolvers,
+  'clients' | 'operations' | 'requestsOverTime' | 'totalRequests' | '__isTypeOf'
+> = {
   totalRequests: ({ organization, project, target, period, schemaCoordinate }, _, { injector }) => {
     return injector.get(OperationsManager).countRequestsWithSchemaCoordinate({
       organizationId: organization,

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -857,6 +857,11 @@ export default gql`
     subscription: GraphQLObjectType
   }
 
+  extend type SchemaCoordinateStats {
+    # If associated with a federated project, this contains the metadata for this coordinate.
+    supergraphMetadata: SupergraphMetadata
+  }
+
   type UnusedSchemaExplorer {
     types: [GraphQLNamedType!]!
   }

--- a/packages/services/api/src/modules/schema/resolvers/SchemaCoordinateStats.ts
+++ b/packages/services/api/src/modules/schema/resolvers/SchemaCoordinateStats.ts
@@ -1,0 +1,31 @@
+import { extractSuperGraphInformation } from '../lib/federation-super-graph';
+import { SchemaManager } from '../providers/schema-manager';
+import { SchemaVersionHelper } from '../providers/schema-version-helper';
+import type { SchemaCoordinateStatsResolvers } from './../../../__generated__/types';
+
+export const SchemaCoordinateStats: Pick<
+  SchemaCoordinateStatsResolvers,
+  'supergraphMetadata' | '__isTypeOf'
+> = {
+  supergraphMetadata: async ({ organization, project, target, schemaCoordinate }, _, { injector }) => {
+    // @note: SchemaManager.getLatestValidVersion uses DataLoader to avoid multiple fetches per operation
+    const latestVersion = await injector.get(SchemaManager).getLatestValidVersion({
+      targetId: target,
+      projectId: project,
+      organizationId: organization,
+    });
+    // @note: `SchemaVersionHelper.getSupergraphAst` is cached
+    const supergraphAst = await injector.get(SchemaVersionHelper).getSupergraphAst(latestVersion);
+    const supergraph = supergraphAst ? extractSuperGraphInformation(supergraphAst) : null;
+        supergraph?.schemaCoordinateServicesMappings
+
+    return {
+      __typename: 'SupergraphMetadata',
+      metadata: latestVersion.schemaMetadata?.[schemaCoordinate]?.map(m => ({
+        ...m,
+        __typename: 'SchemaMetadata',
+      })),
+      ownedByServiceNames: supergraph?.schemaCoordinateServicesMappings.get(schemaCoordinate),
+    };
+  },
+};

--- a/packages/services/api/src/modules/schema/resolvers/SchemaCoordinateStats.ts
+++ b/packages/services/api/src/modules/schema/resolvers/SchemaCoordinateStats.ts
@@ -7,7 +7,11 @@ export const SchemaCoordinateStats: Pick<
   SchemaCoordinateStatsResolvers,
   'supergraphMetadata' | '__isTypeOf'
 > = {
-  supergraphMetadata: async ({ organization, project, target, schemaCoordinate }, _, { injector }) => {
+  supergraphMetadata: async (
+    { organization, project, target, schemaCoordinate },
+    _,
+    { injector },
+  ) => {
     // @note: SchemaManager.getLatestValidVersion uses DataLoader to avoid multiple fetches per operation
     const latestVersion = await injector.get(SchemaManager).getLatestValidVersion({
       targetId: target,
@@ -17,7 +21,7 @@ export const SchemaCoordinateStats: Pick<
     // @note: `SchemaVersionHelper.getSupergraphAst` is cached
     const supergraphAst = await injector.get(SchemaVersionHelper).getSupergraphAst(latestVersion);
     const supergraph = supergraphAst ? extractSuperGraphInformation(supergraphAst) : null;
-        supergraph?.schemaCoordinateServicesMappings
+    supergraph?.schemaCoordinateServicesMappings;
 
     return {
       __typename: 'SupergraphMetadata',

--- a/packages/web/app/src/components/target/explorer/super-graph-metadata.tsx
+++ b/packages/web/app/src/components/target/explorer/super-graph-metadata.tsx
@@ -52,8 +52,9 @@ function SubgraphChip(props: {
         projectSlug: props.projectSlug,
         targetSlug: props.targetSlug,
       }}
-      // TODO(router)
-      hash={`service-${props.text}`}
+      search={{
+        service: props.text,
+      }}
       style={{ backgroundColor: stringToHslColor(props.text) }}
       className="my-[2px] ml-[6px] inline-block h-[22px] max-w-[100px] cursor-pointer items-center justify-between truncate rounded-[16px] py-0 pl-[8px] pr-[6px] text-[10px] font-normal normal-case leading-loose text-[#4f4f4f] drop-shadow-md"
     >
@@ -98,14 +99,16 @@ const SupergraphMetadataList_SupergraphMetadataFragment = graphql(`
 `);
 
 const tooltipColor = 'rgb(36, 39, 46)';
-const previewThreshold = 3;
+const DEFAULT_PREVIEW_THRESHOLD = 3;
 
 export function SupergraphMetadataList(props: {
   organizationSlug: string;
   projectSlug: string;
   targetSlug: string;
   supergraphMetadata: FragmentType<typeof SupergraphMetadataList_SupergraphMetadataFragment>;
+  previewThreshold?: number;
 }) {
+  const previewThreshold = props.previewThreshold ?? DEFAULT_PREVIEW_THRESHOLD;
   const supergraphMetadata = useFragment(
     SupergraphMetadataList_SupergraphMetadataFragment,
     props.supergraphMetadata,

--- a/packages/web/app/src/pages/target-insights-coordinate.tsx
+++ b/packages/web/app/src/pages/target-insights-coordinate.tsx
@@ -27,6 +27,8 @@ import { formatNumber, formatThroughput, toDecimal } from '@/lib/hooks';
 import { useDateRangeController } from '@/lib/hooks/use-date-range-controller';
 import { useChartStyles } from '@/utils';
 import { Link } from '@tanstack/react-router';
+import { SupergraphMetadataList } from '@/components/target/explorer/super-graph-metadata';
+
 
 const SchemaCoordinateView_SchemaCoordinateStatsQuery = graphql(`
   query SchemaCoordinateView_SchemaCoordinateStatsQuery(
@@ -35,6 +37,9 @@ const SchemaCoordinateView_SchemaCoordinateStatsQuery = graphql(`
     $resolution: Int!
   ) {
     schemaCoordinateStats(selector: $selector) {
+      supergraphMetadata {
+        ...SupergraphMetadataList_SupergraphMetadataFragment
+      }
       requestsOverTime(resolution: $resolution) {
         date
         value
@@ -113,6 +118,8 @@ function SchemaCoordinateView(props: {
   const totalOperations = query.data?.schemaCoordinateStats?.operations.nodes.length ?? 0;
   const totalClients = query.data?.schemaCoordinateStats?.clients.nodes.length ?? 0;
 
+  const supergraphMetadata = query.data?.schemaCoordinateStats?.supergraphMetadata;
+
   if (query.error) {
     return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
@@ -121,7 +128,16 @@ function SchemaCoordinateView(props: {
     <>
       <div className="flex flex-row items-center justify-between py-6">
         <div>
-          <Title>{props.coordinate}</Title>
+          <div className="flex flex-row items-center justify-between">
+            <Title className="pr-8">{props.coordinate}</Title>
+            {supergraphMetadata ? <SupergraphMetadataList
+              organizationSlug={props.organizationSlug}
+              projectSlug={props.projectSlug}
+              targetSlug={props.targetSlug}
+              supergraphMetadata={supergraphMetadata}
+              previewThreshold={5}
+            /> : null}
+          </div>
           <Subtitle>Schema coordinate insights</Subtitle>
         </div>
         <div className="flex justify-end gap-x-2">
@@ -185,12 +201,12 @@ function SchemaCoordinateView(props: {
                     {isLoading
                       ? '-'
                       : formatThroughput(
-                          totalRequests,
-                          differenceInMilliseconds(
-                            new Date(dateRangeController.resolvedRange.to),
-                            new Date(dateRangeController.resolvedRange.from),
-                          ),
-                        )}
+                        totalRequests,
+                        differenceInMilliseconds(
+                          new Date(dateRangeController.resolvedRange.to),
+                          new Date(dateRangeController.resolvedRange.from),
+                        ),
+                      )}
                   </div>
                   <p className="text-muted-foreground text-xs">
                     RPM in {dateRangeController.selectedPreset.label.toLowerCase()}
@@ -310,30 +326,30 @@ function SchemaCoordinateView(props: {
                 {isLoading
                   ? null
                   : query.data?.schemaCoordinateStats.operations.nodes.map(operation => (
-                      <div key={operation.id} className="flex items-center">
-                        <p className="truncate text-sm font-medium">
-                          <Link
-                            className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
-                            to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
-                            params={{
-                              organizationSlug: props.organizationSlug,
-                              projectSlug: props.projectSlug,
-                              targetSlug: props.targetSlug,
-                              operationName: operation.name,
-                              operationHash: operation.operationHash ?? '_',
-                            }}
-                          >
-                            {operation.name}
-                          </Link>
-                        </p>
-                        <div className="ml-auto flex min-w-[150px] flex-row items-center justify-end text-sm font-light">
-                          <div>{formatNumber(operation.count)}</div>{' '}
-                          <div className="min-w-[70px] text-right">
-                            {toDecimal((operation.count * 100) / totalRequests)}%
-                          </div>
+                    <div key={operation.id} className="flex items-center">
+                      <p className="truncate text-sm font-medium">
+                        <Link
+                          className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
+                          to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
+                          params={{
+                            organizationSlug: props.organizationSlug,
+                            projectSlug: props.projectSlug,
+                            targetSlug: props.targetSlug,
+                            operationName: operation.name,
+                            operationHash: operation.operationHash ?? '_',
+                          }}
+                        >
+                          {operation.name}
+                        </Link>
+                      </p>
+                      <div className="ml-auto flex min-w-[150px] flex-row items-center justify-end text-sm font-light">
+                        <div>{formatNumber(operation.count)}</div>{' '}
+                        <div className="min-w-[70px] text-right">
+                          {toDecimal((operation.count * 100) / totalRequests)}%
                         </div>
                       </div>
-                    ))}
+                    </div>
+                  ))}
               </div>
             </CardContent>
           </Card>
@@ -352,29 +368,29 @@ function SchemaCoordinateView(props: {
                 {isLoading
                   ? null
                   : query.data?.schemaCoordinateStats.clients.nodes.map(client => (
-                      <div key={client.name} className="flex items-center">
-                        <p className="truncate text-sm font-medium">
-                          <Link
-                            className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
-                            to="/$organizationSlug/$projectSlug/$targetSlug/insights/client/$name"
-                            params={{
-                              organizationSlug: props.organizationSlug,
-                              projectSlug: props.projectSlug,
-                              targetSlug: props.targetSlug,
-                              name: client.name,
-                            }}
-                          >
-                            {client.name}
-                          </Link>
-                        </p>
-                        <div className="ml-auto flex min-w-[150px] flex-row items-center justify-end text-sm font-light">
-                          <div>{formatNumber(client.count)}</div>
-                          <div className="min-w-[70px] text-right">
-                            {toDecimal((client.count * 100) / totalRequests)}%
-                          </div>
+                    <div key={client.name} className="flex items-center">
+                      <p className="truncate text-sm font-medium">
+                        <Link
+                          className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
+                          to="/$organizationSlug/$projectSlug/$targetSlug/insights/client/$name"
+                          params={{
+                            organizationSlug: props.organizationSlug,
+                            projectSlug: props.projectSlug,
+                            targetSlug: props.targetSlug,
+                            name: client.name,
+                          }}
+                        >
+                          {client.name}
+                        </Link>
+                      </p>
+                      <div className="ml-auto flex min-w-[150px] flex-row items-center justify-end text-sm font-light">
+                        <div>{formatNumber(client.count)}</div>
+                        <div className="min-w-[70px] text-right">
+                          {toDecimal((client.count * 100) / totalRequests)}%
                         </div>
                       </div>
-                    ))}
+                    </div>
+                  ))}
               </div>
             </CardContent>
           </Card>

--- a/packages/web/app/src/pages/target-insights-coordinate.tsx
+++ b/packages/web/app/src/pages/target-insights-coordinate.tsx
@@ -12,6 +12,7 @@ import {
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { useQuery } from 'urql';
 import { Page, TargetLayout } from '@/components/layouts/target';
+import { SupergraphMetadataList } from '@/components/target/explorer/super-graph-metadata';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -27,8 +28,6 @@ import { formatNumber, formatThroughput, toDecimal } from '@/lib/hooks';
 import { useDateRangeController } from '@/lib/hooks/use-date-range-controller';
 import { useChartStyles } from '@/utils';
 import { Link } from '@tanstack/react-router';
-import { SupergraphMetadataList } from '@/components/target/explorer/super-graph-metadata';
-
 
 const SchemaCoordinateView_SchemaCoordinateStatsQuery = graphql(`
   query SchemaCoordinateView_SchemaCoordinateStatsQuery(
@@ -130,13 +129,15 @@ function SchemaCoordinateView(props: {
         <div>
           <div className="flex flex-row items-center justify-between">
             <Title className="pr-8">{props.coordinate}</Title>
-            {supergraphMetadata ? <SupergraphMetadataList
-              organizationSlug={props.organizationSlug}
-              projectSlug={props.projectSlug}
-              targetSlug={props.targetSlug}
-              supergraphMetadata={supergraphMetadata}
-              previewThreshold={5}
-            /> : null}
+            {supergraphMetadata ? (
+              <SupergraphMetadataList
+                organizationSlug={props.organizationSlug}
+                projectSlug={props.projectSlug}
+                targetSlug={props.targetSlug}
+                supergraphMetadata={supergraphMetadata}
+                previewThreshold={5}
+              />
+            ) : null}
           </div>
           <Subtitle>Schema coordinate insights</Subtitle>
         </div>
@@ -201,12 +202,12 @@ function SchemaCoordinateView(props: {
                     {isLoading
                       ? '-'
                       : formatThroughput(
-                        totalRequests,
-                        differenceInMilliseconds(
-                          new Date(dateRangeController.resolvedRange.to),
-                          new Date(dateRangeController.resolvedRange.from),
-                        ),
-                      )}
+                          totalRequests,
+                          differenceInMilliseconds(
+                            new Date(dateRangeController.resolvedRange.to),
+                            new Date(dateRangeController.resolvedRange.from),
+                          ),
+                        )}
                   </div>
                   <p className="text-muted-foreground text-xs">
                     RPM in {dateRangeController.selectedPreset.label.toLowerCase()}
@@ -326,30 +327,30 @@ function SchemaCoordinateView(props: {
                 {isLoading
                   ? null
                   : query.data?.schemaCoordinateStats.operations.nodes.map(operation => (
-                    <div key={operation.id} className="flex items-center">
-                      <p className="truncate text-sm font-medium">
-                        <Link
-                          className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
-                          to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
-                          params={{
-                            organizationSlug: props.organizationSlug,
-                            projectSlug: props.projectSlug,
-                            targetSlug: props.targetSlug,
-                            operationName: operation.name,
-                            operationHash: operation.operationHash ?? '_',
-                          }}
-                        >
-                          {operation.name}
-                        </Link>
-                      </p>
-                      <div className="ml-auto flex min-w-[150px] flex-row items-center justify-end text-sm font-light">
-                        <div>{formatNumber(operation.count)}</div>{' '}
-                        <div className="min-w-[70px] text-right">
-                          {toDecimal((operation.count * 100) / totalRequests)}%
+                      <div key={operation.id} className="flex items-center">
+                        <p className="truncate text-sm font-medium">
+                          <Link
+                            className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
+                            to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
+                            params={{
+                              organizationSlug: props.organizationSlug,
+                              projectSlug: props.projectSlug,
+                              targetSlug: props.targetSlug,
+                              operationName: operation.name,
+                              operationHash: operation.operationHash ?? '_',
+                            }}
+                          >
+                            {operation.name}
+                          </Link>
+                        </p>
+                        <div className="ml-auto flex min-w-[150px] flex-row items-center justify-end text-sm font-light">
+                          <div>{formatNumber(operation.count)}</div>{' '}
+                          <div className="min-w-[70px] text-right">
+                            {toDecimal((operation.count * 100) / totalRequests)}%
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  ))}
+                    ))}
               </div>
             </CardContent>
           </Card>
@@ -368,29 +369,29 @@ function SchemaCoordinateView(props: {
                 {isLoading
                   ? null
                   : query.data?.schemaCoordinateStats.clients.nodes.map(client => (
-                    <div key={client.name} className="flex items-center">
-                      <p className="truncate text-sm font-medium">
-                        <Link
-                          className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
-                          to="/$organizationSlug/$projectSlug/$targetSlug/insights/client/$name"
-                          params={{
-                            organizationSlug: props.organizationSlug,
-                            projectSlug: props.projectSlug,
-                            targetSlug: props.targetSlug,
-                            name: client.name,
-                          }}
-                        >
-                          {client.name}
-                        </Link>
-                      </p>
-                      <div className="ml-auto flex min-w-[150px] flex-row items-center justify-end text-sm font-light">
-                        <div>{formatNumber(client.count)}</div>
-                        <div className="min-w-[70px] text-right">
-                          {toDecimal((client.count * 100) / totalRequests)}%
+                      <div key={client.name} className="flex items-center">
+                        <p className="truncate text-sm font-medium">
+                          <Link
+                            className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
+                            to="/$organizationSlug/$projectSlug/$targetSlug/insights/client/$name"
+                            params={{
+                              organizationSlug: props.organizationSlug,
+                              projectSlug: props.projectSlug,
+                              targetSlug: props.targetSlug,
+                              name: client.name,
+                            }}
+                          >
+                            {client.name}
+                          </Link>
+                        </p>
+                        <div className="ml-auto flex min-w-[150px] flex-row items-center justify-end text-sm font-light">
+                          <div>{formatNumber(client.count)}</div>
+                          <div className="min-w-[70px] text-right">
+                            {toDecimal((client.count * 100) / totalRequests)}%
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  ))}
+                    ))}
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
### Background

Relates to https://github.com/graphql-hive/console/issues/2818
We have metadata and subgraph data being shown on the explorer, but the insights page for a schema coordinate doesn't include this information. This makes for a poor experience when needing to lookup details about a schema coordinate.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

This change adds the subgraph owner and metadata for a schema coordinate to the insights page. The visualization matches the explorer for consistency and familiarity.

I also fixed the link to use search parameters instead of a hash.

<img width="857" alt="Screenshot 2025-05-09 at 3 52 14 PM" src="https://github.com/user-attachments/assets/afab9c13-8037-4705-880e-59c2c995cd8a" />



<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->