### PR TITLE
fix: support ticket user lookup

### DIFF
--- a/packages/services/api/src/modules/support/providers/support-manager.ts
+++ b/packages/services/api/src/modules/support/providers/support-manager.ts
@@ -218,7 +218,7 @@ export class SupportManager {
 
       // Before attempting to create the user we need to check whether an user with that email might already exist.
       let userZendeskId = await this.httpClient
-        .get(`https://${this.config.subdomain}.zendesk.com/api/v2/users`, {
+        .get(`https://${this.config.subdomain}.zendesk.com/api/v2/users/search`, {
           searchParams: {
             query: email,
           },
@@ -242,9 +242,9 @@ export class SupportManager {
             })
             .parse(res);
 
-          const user = data.users.at(0) ?? null;
+          const user = data.users.find(u => u.email === email) ?? null;
 
-          if (user?.email === email) {
+          if (user) {
             this.logger.info(
               'User found on Zendesk. (organizationID: %s, userId: %s)',
               input.organizationId,


### PR DESCRIPTION
### Background

https://linear.app/the-guild/issue/CONSOLE-1232/support-ticket-failed-with-internal-server-error

A customer was unable to submit a support ticket and retried 3x. Each time failing the user lookup.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

The current URL is to get a list of users, but is not searching that list. We should be using: https://developer.zendesk.com/api-reference/ticketing/users/users/#search-users

And this returns a list of users that match. And on the off chance that users have an email that is a partial match to another email in our system, we should find the email in the returned list instead of checking the first.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
