### PR TITLE
chore: ensure no schema version is created for external composition error

### DIFF
--- a/integration-tests/tests/api/schema/external-composition.spec.ts
+++ b/integration-tests/tests/api/schema/external-composition.spec.ts
@@ -92,9 +92,8 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg, ownerToken } = await initSeed().createOwner();
     const { createProject, organization } = await createOrg();
-    const { createTargetAccessToken, project, setNativeFederation } = await createProject(
-      ProjectType.Federation,
-    );
+    const { createTargetAccessToken, project, setNativeFederation, fetchVersions } =
+      await createProject(ProjectType.Federation);
 
     // Create a token with write rights
     const writeToken = await createTargetAccessToken({});
@@ -180,6 +179,10 @@ test.concurrent(
         },
       }),
     );
+
+    // ensure no new schema version is created for failed external composition
+    const versions = await fetchVersions(20);
+    expect(versions.length).toEqual(1);
   },
 );
 
@@ -188,9 +191,8 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg, ownerToken } = await initSeed().createOwner();
     const { createProject, organization } = await createOrg();
-    const { createTargetAccessToken, project, setNativeFederation } = await createProject(
-      ProjectType.Federation,
-    );
+    const { createTargetAccessToken, project, setNativeFederation, fetchVersions } =
+      await createProject(ProjectType.Federation);
 
     // Create a token with write rights
     const writeToken = await createTargetAccessToken({});
@@ -275,15 +277,18 @@ test.concurrent(
         },
       }),
     );
+
+    // ensure no new schema version is created for failed external composition
+    const versions = await fetchVersions(20);
+    expect(versions.length).toEqual(1);
   },
 );
 
 test.concurrent('a timeout error should be visible to the user', async ({ expect }) => {
   const { createOrg, ownerToken } = await initSeed().createOwner();
   const { createProject, organization } = await createOrg();
-  const { createTargetAccessToken, project, setNativeFederation } = await createProject(
-    ProjectType.Federation,
-  );
+  const { createTargetAccessToken, project, setNativeFederation, fetchVersions } =
+    await createProject(ProjectType.Federation);
 
   // Create a token with write rights
   const writeToken = await createTargetAccessToken({});
@@ -370,4 +375,8 @@ test.concurrent('a timeout error should be visible to the user', async ({ expect
       valid: false,
     }),
   );
+
+  // ensure no new schema version is created for failed external composition
+  const versions = await fetchVersions(20);
+  expect(versions.length).toEqual(1);
 });


### PR DESCRIPTION
### Background

Make sure no schema version is created for external composition errors

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [x] Testing
