### PR TITLE
Add pg indexes to help with org delete

### DIFF
--- a/.changeset/fluffy-rice-build.md
+++ b/.changeset/fluffy-rice-build.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Add pg indexes to help with org delete

--- a/packages/migrations/src/actions/2025.05.14T00-00-00.cascade-deletion-indices-2.ts
+++ b/packages/migrations/src/actions/2025.05.14T00-00-00.cascade-deletion-indices-2.ts
@@ -1,0 +1,151 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+/**
+ * This migration adds a bunch of indices for columns that have cascade triggers.
+ * Adding these significantly improves the delete performance.
+ */
+export default {
+  name: '2025.05.14T00-00-00.cascade-deletion-indices-2.ts',
+  noTransaction: true,
+  run: ({ sql }) => [
+    {
+      name: 'index schema_versions_action_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "schema_versions_action_id" ON "schema_versions"("action_id")
+      `,
+    },
+    // For cascading delete from "schema_log"
+    {
+      name: 'index versions_commit_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "versions_commit_id" ON "versions"("commit_id")
+      `,
+    },
+    // For cascading delete from "targets"
+    {
+      name: 'index versions_target_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "versions_target_id" ON "versions"("target_id")
+      `,
+    },
+    // For cascading delete from "organizations"
+    {
+      name: 'index tokens_organization_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "tokens_organization_id" ON "tokens"("organization_id")
+      `,
+    },
+    // For cascading delete from "projects"
+    {
+      name: 'index tokens_project_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "tokens_project_id" ON "tokens"("project_id")
+      `,
+    },
+    // For cascading delete from "targets"
+    {
+      name: 'index tokens_target_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "tokens_target_id" ON "tokens"("target_id")
+      `,
+    },
+    // For cascading delete from "targets"
+    {
+      name: 'index target_validation_destination_target_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "target_validation_destination_target_id" ON "target_validation"("destination_target_id")
+      `,
+    },
+    // For cascading delete from "targets"
+    {
+      name: 'index schema_coordinate_status_created_in_version_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "schema_coordinate_status_created_in_version_id" ON "target_validation"("created_in_version_id")
+      `,
+    },
+    // For cascading delete from "targets"
+    {
+      name: 'index schema_coordinate_status_deprecated_in_version_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "schema_coordinate_status_deprecated_in_version_id" ON "schema_coordinate_status"("deprecated_in_version_id")
+      `,
+    },
+    // For cascading set NULL from "users"
+    {
+      name: 'index document_preflight_scripts_created_by_user_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "document_preflight_scripts_created_by_user_id" ON "document_preflight_scripts"("created_by_user_id") WHERE "created_by_user_id" IS NOT NULL
+      `,
+    },
+    // For cascading set NULL from "users"
+    {
+      name: 'index document_collections_created_by_user_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "document_collections_created_by_user_id" ON "document_collections"("created_by_user_id") WHERE "created_by_user_id" IS NOT NULL
+      `,
+    },
+    // For cascading delete from "contract_versions"
+    {
+      name: 'index contract_version_changes_contract_version_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "contract_version_changes_contract_version_id" ON "contract_version_changes"("contract_version_id")
+      `,
+    },
+    // For cascading delete from "contract_versions"
+    {
+      name: 'index contract_checks_compared_contract_version_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "contract_checks_compared_contract_version_id" ON "contract_checks"("compared_contract_version_id")
+      `,
+    },
+    // For cascading delete from "contracts"
+    {
+      name: 'index contracts_contract_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "contracts_contract_id" ON "contract_checks"("contract_id")
+      `,
+    },
+    // For cascading delete from "targets"
+    {
+      name: 'index alerts_target_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "alerts_target_id" ON "alerts"("target_id")
+      `,
+    },
+    // For cascading delete from "projects"
+    {
+      name: 'index alerts_project_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "alerts_project_id" ON "alerts"("project_id")
+      `,
+    },
+    // For cascading delete from "alert_channels"
+    {
+      name: 'index alerts_alert_channel_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "alerts_alert_channel_id" ON "alerts"("alert_channel_id")
+      `,
+    },
+    // For cascading delete from "organizations"
+    {
+      name: 'index tokens_organization_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "tokens_organization_id" ON "tokens"("organization_id")
+      `,
+    },
+    // For cascading delete from "projects"
+    {
+      name: 'index tokens_project_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "tokens_project_id" ON "tokens"("project_id")
+      `,
+    },
+    // For cascading delete from "targets"
+    {
+      name: 'index tokens_target_id',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "tokens_target_id" ON "tokens"("target_id")
+      `,
+    },
+  ],
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2025.05.14T00-00-00.cascade-deletion-indices-2.ts
+++ b/packages/migrations/src/actions/2025.05.14T00-00-00.cascade-deletion-indices-2.ts
@@ -60,7 +60,7 @@ export default {
     {
       name: 'index schema_coordinate_status_created_in_version_id',
       query: sql`
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS "schema_coordinate_status_created_in_version_id" ON "target_validation"("created_in_version_id")
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "schema_coordinate_status_created_in_version_id" ON "schema_coordinate_status"("created_in_version_id")
       `,
     },
     // For cascading delete from "targets"

--- a/packages/migrations/src/actions/2025.05.14T00-00-00.cascade-deletion-indices-2.ts
+++ b/packages/migrations/src/actions/2025.05.14T00-00-00.cascade-deletion-indices-2.ts
@@ -56,14 +56,14 @@ export default {
         CREATE INDEX CONCURRENTLY IF NOT EXISTS "target_validation_destination_target_id" ON "target_validation"("destination_target_id")
       `,
     },
-    // For cascading delete from "targets"
+    // For cascading delete from "schema_versions"
     {
       name: 'index schema_coordinate_status_created_in_version_id',
       query: sql`
         CREATE INDEX CONCURRENTLY IF NOT EXISTS "schema_coordinate_status_created_in_version_id" ON "schema_coordinate_status"("created_in_version_id")
       `,
     },
-    // For cascading delete from "targets"
+    // For cascading delete from "schema_versions"
     {
       name: 'index schema_coordinate_status_deprecated_in_version_id',
       query: sql`

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -162,5 +162,6 @@ export const runPGMigrations = async (args: { slonik: DatabasePool; runTo?: stri
       await import('./actions/2025.02.14T00-00-00.schema-versions-metadata'),
       await import('./actions/2025.02.21T00-00-00.schema-versions-metadata-attributes'),
       await import('./actions/2025.03.20T00-00-00.dangerous_breaking'),
+      await import('./actions/2025.05.14T00-00-00.cascade-deletion-indices-2'),
     ],
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3557,6 +3557,7 @@ packages:
 
   '@fastify/vite@6.0.7':
     resolution: {integrity: sha512-+dRo9KUkvmbqdmBskG02SwigWl06Mwkw8SBDK1zTNH6vd4DyXbRvI7RmJEmBkLouSU81KTzy1+OzwHSffqSD6w==}
+    bundledDependencies: []
 
   '@floating-ui/core@1.2.6':
     resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}


### PR DESCRIPTION
### Background

Large organizations are hitting timeouts when trying to delete their organization.
One such call ran for over 10min.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

To address this performance issue and to allow organizations to self-serve, I've added an index for every foreign key that uses cascading deletes.

This should significantly improve the speed of this operation because when a delete is cascading, it must find those records in the table to perform the delete. Without an index, it must scan through all records.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
