### PR TITLE
chore: fix docker image publish (?)

### DIFF
--- a/.github/workflows/build-and-dockerize.yaml
+++ b/.github/workflows/build-and-dockerize.yaml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      # Reference to checkout
+      ref:
+        default: ''
+        type: string
       dockerize:
         default: true
         type: boolean
@@ -54,6 +58,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 2
+          ref: ${{ inputs.ref }}
 
       - name: setup environment
         if: ${{ inputs.build }}
@@ -185,7 +190,7 @@ jobs:
 
             <details>
               <summary>Docker Bake metadata</summary>
-              
+
               ```json
               ${{ steps.docker-bake.outputs.metadata }}
               ```
@@ -211,6 +216,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 2
+          ref: ${{ inputs.ref }}
 
       - name: configure docker buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -1,12 +1,13 @@
 name: 'Release Docker Images'
 
-# When a tag is pushed, it means a new release is being made.
+# When the workflow is invoked with a tag, we are releaseing the version.
 on:
-  push:
-    tags:
-      # "hive@1.2.3" is an example tag that will trigger this workflow.
-      # "hive" represents the docker images needed for self-hosting.
-      - hive@*
+  workflow_call:
+    inputs:
+      tag:
+        default: false
+        type: string
+        required: true
 
 jobs:
   version:
@@ -21,7 +22,7 @@ jobs:
         id: version
         run: |
           # hive@1.0.0
-          VERSION=${{ github.ref_name }}
+          VERSION=${{ inputs.tag }}
           # 1.0.0
           VERSION_NUMBER=$(echo $VERSION | sed 's/[^0-9.]*//g')
           echo "number=$VERSION_NUMBER" >> $GITHUB_OUTPUT
@@ -31,6 +32,7 @@ jobs:
     if: ${{ contains(needs.version.outputs.number, '.') }}
     uses: ./.github/workflows/build-and-dockerize.yaml
     with:
+      ref: refs/tags/${{ inputs.tag }}
       imageTag: ${{ needs.version.outputs.number }}
       publishLatest: true
       publishSourceMaps: true

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -90,6 +90,12 @@ jobs:
           echo "hiveVersion=$VERSION" >> $GITHUB_OUTPUT
           echo "hivePublish=true" >> $GITHUB_OUTPUT
 
+      - name: publish stable hive docker images
+        uses: ./.github/workflows/release-docker.yaml
+        if: steps.hive.outputs.hivePublish
+        with:
+          tag: hive@${{ steps.hive.outputs.hiveVersion }}
+
       # Needed for `oclif pack win`
       - name: Install NSIS
         run: |

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -90,12 +90,6 @@ jobs:
           echo "hiveVersion=$VERSION" >> $GITHUB_OUTPUT
           echo "hivePublish=true" >> $GITHUB_OUTPUT
 
-      - name: publish stable hive docker images
-        uses: ./.github/workflows/release-docker.yaml
-        if: steps.hive.outputs.hivePublish
-        with:
-          tag: hive@${{ steps.hive.outputs.hiveVersion }}
-
       # Needed for `oclif pack win`
       - name: Install NSIS
         run: |
@@ -135,3 +129,13 @@ jobs:
           cd packages/libraries/router
           cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish --allow-dirty --no-verify
+
+  # Release the stable docker images
+  release-docker:
+    uses: ./.github/workflows/release-docker.yaml
+    secrets: inherit
+    needs:
+      - publish
+    with:
+      tag: hive@${{ needs.publish.outputs.hivePublish }}
+    if: ${{ needs.package.outputs.hivePublish == 'true' }}


### PR DESCRIPTION
### Background

The workflow tag push trigger was [not invoked since the push is made with the github token](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), leading to no docker images being tagged with the version number

### Description

I changed the workflow for pushing the docker images to be invoked by the `release-stable.yml` workflow instead.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
