### PR TITLE
Remove redundant indices

### DIFF
--- a/.changeset/nine-timers-complain.md
+++ b/.changeset/nine-timers-complain.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Remove redundant pg indices

--- a/packages/migrations/src/actions/2025.05.15T00-00-00.redundant-indices.ts
+++ b/packages/migrations/src/actions/2025.05.15T00-00-00.redundant-indices.ts
@@ -36,12 +36,5 @@ export default {
         DROP INDEX CONCURRENTLY IF EXISTS "schema_version_to_log_version_id"
       `,
     },
-    // redundant with document_preflight_scripts_target_id_key
-    {
-      name: 'drop index unique_target_id',
-      query: sql`
-        DROP INDEX CONCURRENTLY IF EXISTS "unique_target_id"
-      `,
-    },
   ],
 } satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2025.05.15T00-00-00.redundant-indices.ts
+++ b/packages/migrations/src/actions/2025.05.15T00-00-00.redundant-indices.ts
@@ -1,0 +1,47 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+/**
+ * This migration removes indices that are covered by other btree indices.
+ * This should have no impact on performance while lowering our db footprint.
+ */
+export default {
+  name: '2025.05.15T00-00-00.redundant-indices.ts',
+  noTransaction: true,
+  run: ({ sql }) => [
+    // redundant with schema_versions_cursor_pagination
+    {
+      name: 'drop index schema_versions_target_id',
+      query: sql`
+        DROP INDEX CONCURRENTLY IF EXISTS "schema_versions_target_id"
+      `,
+    },
+    // redundant with organization_member_pkey
+    {
+      name: 'drop index organization_member_organization_id',
+      query: sql`
+        DROP INDEX CONCURRENTLY IF EXISTS "organization_member_organization_id"
+      `,
+    },
+    // redundant with schema_checks_connection_pagination
+    {
+      name: 'drop index schema_checks_target_id',
+      query: sql`
+        DROP INDEX CONCURRENTLY IF EXISTS "schema_checks_target_id"
+      `,
+    },
+    // redundant with schema_version_to_log_pkey
+    {
+      name: 'drop index schema_version_to_log_version_id',
+      query: sql`
+        DROP INDEX CONCURRENTLY IF EXISTS "schema_version_to_log_version_id"
+      `,
+    },
+    // redundant with document_preflight_scripts_target_id_key
+    {
+      name: 'drop index unique_target_id',
+      query: sql`
+        DROP INDEX CONCURRENTLY IF EXISTS "unique_target_id"
+      `,
+    },
+  ],
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -163,5 +163,6 @@ export const runPGMigrations = async (args: { slonik: DatabasePool; runTo?: stri
       await import('./actions/2025.02.21T00-00-00.schema-versions-metadata-attributes'),
       await import('./actions/2025.03.20T00-00-00.dangerous_breaking'),
       await import('./actions/2025.05.14T00-00-00.cascade-deletion-indices-2'),
+      await import('./actions/2025.05.15T00-00-00.redundant-indices'),
     ],
   });


### PR DESCRIPTION
### Background

As part of finding missing indices for cascading deletes, I discovered some btree indices that are already covered by multi column btree indices.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

This removes these single column btree indices in favor of letting pg use the multi column. This should have no performance impact and reduce pg footprint.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
