### PR TITLE
Adjust date selector ui

### DIFF
--- a/.changeset/wild-walls-pump.md
+++ b/.changeset/wild-walls-pump.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Adjust date range selector ui

--- a/packages/web/app/src/components/ui/date-range-picker.tsx
+++ b/packages/web/app/src/components/ui/date-range-picker.tsx
@@ -314,7 +314,7 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
         <div className="flex flex-col py-4">
           <div className="flex flex-col items-center justify-end gap-2 lg:flex-row lg:items-start">
             <div className="flex flex-col gap-1 pl-3">
-              <div className="mb-2 font-bold">Absolute time range</div>
+              <div className="mb-2 font-bold">Absolute date range</div>
               <div className="space-y-2">
                 <div className="grid w-full max-w-sm items-center gap-1.5">
                   <Label htmlFor="from">From</Label>
@@ -327,7 +327,7 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
                         setFromValue(ev.target.value);
                       }}
                     />
-                    <Button size="icon" variant="ghost" onClick={() => setShowCalendar(true)}>
+                    <Button size="icon" variant="outline" onClick={() => setShowCalendar(true)}>
                       <CalendarDays className="size-4" />
                     </Button>
                   </div>
@@ -350,7 +350,7 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
                         setToValue(ev.target.value);
                       }}
                     />
-                    <Button size="icon" variant="ghost" onClick={() => setShowCalendar(true)}>
+                    <Button size="icon" variant="outline" onClick={() => setShowCalendar(true)}>
                       <CalendarDays className="size-4" />
                     </Button>
                   </div>
@@ -366,7 +366,7 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
                 </div>
 
                 <Button
-                  size="sm"
+                  className="w-full text-center"
                   onClick={() => {
                     const fromWithoutWhitespace = fromValue.trim();
                     const toWithoutWhitespace = toValue.trim();


### PR DESCRIPTION
### Background

The date selector is slightly unclear. The calendar buttons are not obvious that they are buttons because the background is so faint. And its title indicates it can select time, not just date.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

Before:
<img width="1093" alt="Screenshot 2025-05-14 at 4 08 37 PM" src="https://github.com/user-attachments/assets/f3d290a8-88dd-420e-b36a-bfc7dbf52e10" />

After:
<img width="1097" alt="Screenshot 2025-05-14 at 4 04 32 PM" src="https://github.com/user-attachments/assets/06c2981a-8d3f-4cec-b17d-0ad03438a043" />

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
