### PR TITLE
fix: normalize token alias display with consistent masking symbols

### DIFF
--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -54,6 +54,17 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { RadioGroupIndicator } from '@radix-ui/react-radio-group';
 import { Link, useRouter } from '@tanstack/react-router';
 
+/**
+ * We previously used a different character for token masking.
+ * This function standardizes it by replacing all non-alphanumeric characters
+ * with bullet points (•) to ensure consistent formatting.
+ * @param tokenAlias 553••***•••&*******••••••••••••7ab
+ * @returns 553••••••••••••••••••7ab
+ */
+function normalizeTokenAlias(tokenAlias: string): string {
+  return tokenAlias.replaceAll(/[^a-z0-9]/g, '•');
+}
+
 export const DeleteTokensDocument = graphql(`
   mutation deleteTokens($input: DeleteTokensInput!) {
     deleteTokens(input: $input) {
@@ -166,7 +177,7 @@ function RegistryAccessTokens(props: {
                   checked={checked.includes(token.id)}
                 />
               </Td>
-              <Td>{token.alias}</Td>
+              <Td className="font-mono">{normalizeTokenAlias(token.alias)}</Td>
               <Td>{token.name}</Td>
               <Td align="right">
                 {token.lastUsedAt ? (


### PR DESCRIPTION
We previously used a different character for token masking. The function I added standardizes it by replacing all non-alphanumeric characters with bullet points (•) to ensure consistent formatting.

I also added font-mono class to better display the token alias. Previously at some point of the string the line was broken and some characters were displayed higher than the rest.

| Before | After |
|--------|-------|
| ![Screenshot 2025-05-16 at 09 03 53](https://github.com/user-attachments/assets/bede245c-e53c-404a-abbb-119622020960) | ![Screenshot 2025-05-16 at 09 03 41](https://github.com/user-attachments/assets/b9150b87-33ca-4681-bc89-56fb8742a16f) |
