### PR TITLE
tests: Use pollFor logic instead of static wait times in integration tests

### DIFF
--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -58,28 +58,41 @@ function pollInternal(
   /** In milliseconds */
   startTime: number = Date.now(),
 ) {
-  setTimeout(async () => {
-    try {
-      const passes = await check();
-      if (passes) {
-        resolve();
-      } else {
-        const waited = Date.now() - startTime;
-        if (waited > maxWait) {
-          reject(new Error(`Polling failed. Condition was not satisfied within ${maxWait}ms`));
+  setTimeout(
+    async () => {
+      try {
+        const passes = await check();
+        if (passes) {
+          resolve();
         } else {
-          pollInternal(check, pollFrequency, maxWait, jitter, resolve, reject, startTime);
+          const waited = Date.now() - startTime;
+          if (waited > maxWait) {
+            reject(new Error(`Polling failed. Condition was not satisfied within ${maxWait}ms`));
+          } else {
+            pollInternal(check, pollFrequency, maxWait, jitter, resolve, reject, startTime);
+          }
         }
+      } catch (e) {
+        reject(e);
       }
-    } catch (e) {
-      reject(e);
-    }
-  }, Math.round(pollFrequency + Math.random()*jitter));
+    },
+    Math.round(pollFrequency + Math.random() * jitter),
+  );
 }
 
-export function pollFor(check: () => Promise<boolean>, opts?: { pollFrequency?: number, maxWait?: number, jitter?: number }): Promise<void> {
+export function pollFor(
+  check: () => Promise<boolean>,
+  opts?: { pollFrequency?: number; maxWait?: number; jitter?: number },
+): Promise<void> {
   return new Promise((resolve, reject) => {
-    pollInternal(check, opts?.pollFrequency ?? 500, opts?.maxWait ?? 10_000, opts?.jitter ?? 100, resolve, reject);
+    pollInternal(
+      check,
+      opts?.pollFrequency ?? 500,
+      opts?.maxWait ?? 10_000,
+      opts?.jitter ?? 100,
+      resolve,
+      reject,
+    );
   });
 }
 

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -40,9 +40,23 @@ export function waitFor(ms: number) {
 
 function pollInternal(
   check: () => Promise<boolean>,
+
+  /** In milliseconds */
   pollFrequency: number,
+
+  /** In milliseconds */
+  maxWait: number,
+
+  /** In milliseconds. A random number between 0 and Jitter is added to the pollFrequency to add some
+   * noise and prevent test cases where exact durations are required.
+   * */
+  jitter: number,
+
   resolve: (value: void | PromiseLike<void>) => void,
   reject: (reason?: any) => void,
+
+  /** In milliseconds */
+  startTime: number = Date.now(),
 ) {
   setTimeout(async () => {
     try {
@@ -50,17 +64,22 @@ function pollInternal(
       if (passes) {
         resolve();
       } else {
-        pollInternal(check, pollFrequency, resolve, reject);
+        const waited = Date.now() - startTime;
+        if (waited > maxWait) {
+          reject(new Error(`Polling failed. Condition was not satisfied within ${maxWait}ms`));
+        } else {
+          pollInternal(check, pollFrequency, maxWait, jitter, resolve, reject, startTime);
+        }
       }
     } catch (e) {
       reject(e);
     }
-  }, pollFrequency);
+  }, Math.round(pollFrequency + Math.random()*jitter));
 }
 
-export function pollFor(check: () => Promise<boolean>, pollFrequency = 500): Promise<void> {
+export function pollFor(check: () => Promise<boolean>, opts?: { pollFrequency?: number, maxWait?: number, jitter?: number }): Promise<void> {
   return new Promise((resolve, reject) => {
-    pollInternal(check, pollFrequency, resolve, reject);
+    pollInternal(check, opts?.pollFrequency ?? 500, opts?.maxWait ?? 10_000, opts?.jitter ?? 100, resolve, reject);
   });
 }
 

--- a/integration-tests/testkit/graphql.ts
+++ b/integration-tests/testkit/graphql.ts
@@ -66,7 +66,7 @@ export async function execute<TResult, TVariables>(
     rawBody: body,
     status: response.status,
     expectGraphQLErrors() {
-      if (!body.errors?.length) {
+      if (!body?.errors?.length) {
         throw new Error(
           `Expected GraphQL response to have errors, but no errors were found!${detailsDump}`,
         );
@@ -75,7 +75,7 @@ export async function execute<TResult, TVariables>(
       return body.errors!;
     },
     expectNoGraphQLErrors: async () => {
-      if (body.errors?.length) {
+      if (body?.errors?.length) {
         throw new Error(
           `Expected GraphQL response to have no errors, but got ${
             body.errors.length

--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -763,6 +763,35 @@ export function initSeed() {
 
                   return pollFor(check);
                 },
+                async waitForRequestsCollected(
+                  n: number,
+                  opts?: {
+                    from?: number,
+                    to?: number,
+                    target?: TargetOverwrite,
+                  },
+                ) {
+                  const from = formatISO(opts?.from ?? subHours(Date.now(), 1));
+                  const to = formatISO(opts?.to ?? Date.now());
+                  const check = async () => {
+                    const statsResult = await readOperationsStats(
+                      {
+                        organizationSlug: organization.slug,
+                        projectSlug: project.slug,
+                        targetSlug: (opts?.target ?? target).slug,
+                        period: {
+                          from,
+                          to,
+                        },
+                      },
+                      ownerToken,
+                    ).then(r => r.expectNoGraphQLErrors());
+                    const totalRequests = statsResult.operationsStats.operations.nodes.reduce((total, node) => total + node.count, 0);
+                    return totalRequests == n;
+                  };
+
+                  return pollFor(check);
+                },
                 async readOperationsStats(
                   from: string,
                   to: string,

--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -766,9 +766,9 @@ export function initSeed() {
                 async waitForRequestsCollected(
                   n: number,
                   opts?: {
-                    from?: number,
-                    to?: number,
-                    target?: TargetOverwrite,
+                    from?: number;
+                    to?: number;
+                    target?: TargetOverwrite;
                   },
                 ) {
                   const from = formatISO(opts?.from ?? subHours(Date.now(), 1));
@@ -786,7 +786,10 @@ export function initSeed() {
                       },
                       ownerToken,
                     ).then(r => r.expectNoGraphQLErrors());
-                    const totalRequests = statsResult.operationsStats.operations.nodes.reduce((total, node) => total + node.count, 0);
+                    const totalRequests = statsResult.operationsStats.operations.nodes.reduce(
+                      (total, node) => total + node.count,
+                      0,
+                    );
                     return totalRequests == n;
                   };
 

--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -1696,7 +1696,8 @@ test('app deployment usage reporting', async () => {
   const { createOrg, ownerToken } = await initSeed().createOwner();
   const { createProject, setFeatureFlag, organization } = await createOrg();
   await setFeatureFlag('appDeployments', true);
-  const { createTargetAccessToken, project, target, waitForOperationsCollected } = await createProject();
+  const { createTargetAccessToken, project, target, waitForOperationsCollected } =
+    await createProject();
   const token = await createTargetAccessToken({});
 
   const { createAppDeployment } = await execute({

--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -1,6 +1,5 @@
 import { buildASTSchema, parse } from 'graphql';
 import { createLogger } from 'graphql-yoga';
-import { waitFor } from 'testkit/flow';
 import { initSeed } from 'testkit/seed';
 import { getServiceHost } from 'testkit/utils';
 import { createHive } from '@graphql-hive/core';
@@ -1697,7 +1696,7 @@ test('app deployment usage reporting', async () => {
   const { createOrg, ownerToken } = await initSeed().createOwner();
   const { createProject, setFeatureFlag, organization } = await createOrg();
   await setFeatureFlag('appDeployments', true);
-  const { createTargetAccessToken, project, target } = await createProject();
+  const { createTargetAccessToken, project, target, waitForOperationsCollected } = await createProject();
   const token = await createTargetAccessToken({});
 
   const { createAppDeployment } = await execute({
@@ -1806,7 +1805,7 @@ test('app deployment usage reporting', async () => {
     'app-name~app-version~aaa',
   );
 
-  await waitFor(5000);
+  await waitForOperationsCollected(1);
 
   data = await execute({
     document: GetAppDeployment,

--- a/integration-tests/tests/api/legacy-auth.spec.ts
+++ b/integration-tests/tests/api/legacy-auth.spec.ts
@@ -10,7 +10,7 @@ test.concurrent(
     const { createOrg } = await initSeed().createOwner();
     const { inviteAndJoinMember, createProject } = await createOrg();
     await inviteAndJoinMember();
-    const { createTargetAccessToken, readOperationsStats, readOperationBody } = await createProject(
+    const { createTargetAccessToken, readOperationsStats, readOperationBody, waitForOperationsCollected } = await createProject(
       ProjectType.Single,
     );
     const { publishSchema, collectLegacyOperations: collectOperations } =
@@ -40,7 +40,7 @@ test.concurrent(
 
     expect(collectResult.status).toEqual(200);
 
-    await waitFor(5000);
+    await waitForOperationsCollected(1)
 
     const from = formatISO(subHours(Date.now(), 6));
     const to = formatISO(Date.now());

--- a/integration-tests/tests/api/legacy-auth.spec.ts
+++ b/integration-tests/tests/api/legacy-auth.spec.ts
@@ -10,9 +10,12 @@ test.concurrent(
     const { createOrg } = await initSeed().createOwner();
     const { inviteAndJoinMember, createProject } = await createOrg();
     await inviteAndJoinMember();
-    const { createTargetAccessToken, readOperationsStats, readOperationBody, waitForOperationsCollected } = await createProject(
-      ProjectType.Single,
-    );
+    const {
+      createTargetAccessToken,
+      readOperationsStats,
+      readOperationBody,
+      waitForOperationsCollected,
+    } = await createProject(ProjectType.Single);
     const { publishSchema, collectLegacyOperations: collectOperations } =
       await createTargetAccessToken({});
 
@@ -40,7 +43,7 @@ test.concurrent(
 
     expect(collectResult.status).toEqual(200);
 
-    await waitForOperationsCollected(1)
+    await waitForOperationsCollected(1);
 
     const from = formatISO(subHours(Date.now(), 6));
     const to = formatISO(Date.now());

--- a/integration-tests/tests/api/organization/get-started.spec.ts
+++ b/integration-tests/tests/api/organization/get-started.spec.ts
@@ -1,5 +1,4 @@
 import { ProjectType } from 'testkit/gql/graphql';
-import { waitFor } from '../../../testkit/flow';
 import { initSeed } from '../../../testkit/seed';
 
 test.concurrent(
@@ -23,7 +22,7 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { inviteAndJoinMember, fetchOrganizationInfo, createProject } = await createOrg();
-    const { target, project, createTargetAccessToken, toggleTargetValidation } =
+    const { target, project, createTargetAccessToken, toggleTargetValidation, waitForOperationsCollected } =
       await createProject(ProjectType.Single);
 
     const { getStarted: steps } = await fetchOrganizationInfo();
@@ -87,7 +86,7 @@ test.concurrent(
         },
       },
     ]);
-    await waitFor(8000);
+    await waitForOperationsCollected(1);
     const { getStarted: steps5 } = await fetchOrganizationInfo();
     expect(steps5?.creatingProject).toBe(true);
     expect(steps5?.publishingSchema).toBe(true);

--- a/integration-tests/tests/api/organization/get-started.spec.ts
+++ b/integration-tests/tests/api/organization/get-started.spec.ts
@@ -22,8 +22,13 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { inviteAndJoinMember, fetchOrganizationInfo, createProject } = await createOrg();
-    const { target, project, createTargetAccessToken, toggleTargetValidation, waitForOperationsCollected } =
-      await createProject(ProjectType.Single);
+    const {
+      target,
+      project,
+      createTargetAccessToken,
+      toggleTargetValidation,
+      waitForOperationsCollected,
+    } = await createProject(ProjectType.Single);
 
     const { getStarted: steps } = await fetchOrganizationInfo();
     expect(steps?.creatingProject).toBe(true); // modified

--- a/integration-tests/tests/api/rate-limit/emails.spec.ts
+++ b/integration-tests/tests/api/rate-limit/emails.spec.ts
@@ -15,7 +15,9 @@ function filterEmailsByOrg(orgSlug: string, emails: emails.Email[]) {
 test('rate limit approaching and reached for organization', async () => {
   const { createOrg, ownerToken, ownerEmail } = await initSeed().createOwner();
   const { createProject, organization } = await createOrg();
-  const { createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
+  const { createTargetAccessToken, waitForRequestsCollected } = await createProject(
+    ProjectType.Single,
+  );
 
   await updateOrgRateLimit(
     {
@@ -45,7 +47,7 @@ test('rate limit approaching and reached for organization', async () => {
   expect(collectResult.status).toEqual(200);
 
   await waitForRequestsCollected(10);
-  
+
   // wait for the rate limit email to send...
   await pollFor(async () => {
     let sent = await emails.history();
@@ -65,7 +67,7 @@ test('rate limit approaching and reached for organization', async () => {
   expect(collectMoreResult.status).toEqual(200);
 
   await waitForRequestsCollected(12);
-  
+
   // wait for the quota email to send...
   await pollFor(async () => {
     let sent = await emails.history();

--- a/integration-tests/tests/api/rate-limit/emails.spec.ts
+++ b/integration-tests/tests/api/rate-limit/emails.spec.ts
@@ -1,6 +1,6 @@
 import { ProjectType } from 'testkit/gql/graphql';
 import * as emails from '../../../testkit/emails';
-import { updateOrgRateLimit, waitFor } from '../../../testkit/flow';
+import { pollFor, updateOrgRateLimit, waitFor } from '../../../testkit/flow';
 import { initSeed } from '../../../testkit/seed';
 
 function filterEmailsByOrg(orgSlug: string, emails: emails.Email[]) {
@@ -15,7 +15,7 @@ function filterEmailsByOrg(orgSlug: string, emails: emails.Email[]) {
 test('rate limit approaching and reached for organization', async () => {
   const { createOrg, ownerToken, ownerEmail } = await initSeed().createOwner();
   const { createProject, organization } = await createOrg();
-  const { createTargetAccessToken } = await createProject(ProjectType.Single);
+  const { createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
 
   await updateOrgRateLimit(
     {
@@ -44,7 +44,13 @@ test('rate limit approaching and reached for organization', async () => {
   const collectResult = await collectOperations(new Array(10).fill(op));
   expect(collectResult.status).toEqual(200);
 
-  await waitFor(8000);
+  await waitForRequestsCollected(10);
+  
+  // wait for the rate limit email to send...
+  await pollFor(async () => {
+    let sent = await emails.history();
+    return filterEmailsByOrg(organization.slug, sent)?.length === 1;
+  });
 
   let sent = await emails.history();
   expect(sent).toContainEqual({
@@ -58,7 +64,13 @@ test('rate limit approaching and reached for organization', async () => {
   const collectMoreResult = await collectOperations([op, op]);
   expect(collectMoreResult.status).toEqual(200);
 
-  await waitFor(7000);
+  await waitForRequestsCollected(12);
+  
+  // wait for the quota email to send...
+  await pollFor(async () => {
+    let sent = await emails.history();
+    return filterEmailsByOrg(organization.slug, sent)?.length === 2;
+  });
 
   sent = await emails.history();
 
@@ -73,7 +85,8 @@ test('rate limit approaching and reached for organization', async () => {
   const collectEvenMoreResult = await collectOperations([op, op]);
   expect(collectEvenMoreResult.status).toEqual(429);
 
-  await waitFor(5000);
+  // @note we can't poll for any state here because nothing should change. Must wait unfortunately...
+  await waitFor(4_000);
 
   // Nothing new
   sent = await emails.history();

--- a/integration-tests/tests/api/schema/unused.spec.ts
+++ b/integration-tests/tests/api/schema/unused.spec.ts
@@ -35,7 +35,7 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, target } = await createProject(ProjectType.Single);
+    const { createTargetAccessToken, target, waitForOperationsCollected } = await createProject(ProjectType.Single);
 
     // Create a token with write rights
     const writeToken = await createTargetAccessToken({});
@@ -123,7 +123,7 @@ test.concurrent(
       ],
     });
     expect(collectResult.status).toEqual(200);
-    await waitFor(8000);
+    await waitForOperationsCollected(1);
 
     const secondQuery = await execute({
       document: IntegrationTestsUnusedSchemaQuery,

--- a/integration-tests/tests/api/schema/unused.spec.ts
+++ b/integration-tests/tests/api/schema/unused.spec.ts
@@ -35,7 +35,9 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, target, waitForOperationsCollected } = await createProject(ProjectType.Single);
+    const { createTargetAccessToken, target, waitForOperationsCollected } = await createProject(
+      ProjectType.Single,
+    );
 
     // Create a token with write rights
     const writeToken = await createTargetAccessToken({});

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -8,13 +8,19 @@ import { graphql } from 'testkit/gql';
 import { BreakingChangeFormulaType, ProjectType } from 'testkit/gql/graphql';
 import { execute } from 'testkit/graphql';
 import { getServiceHost } from 'testkit/utils';
+import { T } from 'vitest/dist/chunks/reporters.d.CfRkRKN2';
 import { UTCDate } from '@date-fns/utc';
 // eslint-disable-next-line hive/enforce-deps-in-dev
 import { normalizeOperation } from '@graphql-hive/core';
 import { createHive } from '../../../../packages/libraries/core/src';
 import { collectSchemaCoordinates } from '../../../../packages/libraries/core/src/client/collect-schema-coordinates';
 import { clickHouseQuery } from '../../../testkit/clickhouse';
-import { createTarget, pollFor, updateTargetValidationSettings, waitFor } from '../../../testkit/flow';
+import {
+  createTarget,
+  pollFor,
+  updateTargetValidationSettings,
+  waitFor,
+} from '../../../testkit/flow';
 import { initSeed } from '../../../testkit/seed';
 import { CollectedOperation } from '../../../testkit/usage';
 
@@ -134,9 +140,12 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, readOperationBody, readOperationsStats, waitForOperationsCollected } = await createProject(
-      ProjectType.Single,
-    );
+    const {
+      createTargetAccessToken,
+      readOperationBody,
+      readOperationsStats,
+      waitForOperationsCollected,
+    } = await createProject(ProjectType.Single);
     const writeToken = await createTargetAccessToken({});
 
     const raw_document = `
@@ -253,9 +262,12 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, readOperationsStats, readOperationBody, waitForRequestsCollected } = await createProject(
-      ProjectType.Single,
-    );
+    const {
+      createTargetAccessToken,
+      readOperationsStats,
+      readOperationBody,
+      waitForRequestsCollected,
+    } = await createProject(ProjectType.Single);
     const writeToken = await createTargetAccessToken({});
 
     const batchSize = 1000;
@@ -448,9 +460,13 @@ test.concurrent('check usage from two selected targets', async ({ expect }) => {
 test.concurrent('check usage not from excluded client names', async ({ expect }) => {
   const { createOrg, ownerToken } = await initSeed().createOwner();
   const { organization, createProject } = await createOrg();
-  const { project, target, createTargetAccessToken, toggleTargetValidation, waitForRequestsCollected } = await createProject(
-    ProjectType.Single,
-  );
+  const {
+    project,
+    target,
+    createTargetAccessToken,
+    toggleTargetValidation,
+    waitForRequestsCollected,
+  } = await createProject(ProjectType.Single);
 
   const token = await createTargetAccessToken({});
 
@@ -654,9 +670,13 @@ describe('changes with usage data', () => {
     test.concurrent(input.title, async ({ expect }) => {
       const { createOrg } = await initSeed().createOwner();
       const { createProject } = await createOrg();
-      const { target, createTargetAccessToken, toggleTargetValidation, waitForOperationsCollected, readOperationsStats } = await createProject(
-        ProjectType.Single,
-      );
+      const {
+        target,
+        createTargetAccessToken,
+        toggleTargetValidation,
+        waitForOperationsCollected,
+        readOperationsStats,
+      } = await createProject(ProjectType.Single);
 
       const token = await createTargetAccessToken({
         target,
@@ -721,7 +741,7 @@ describe('changes with usage data', () => {
       ]);
 
       expect(collectResult.status).toEqual(200);
-      await waitForOperationsCollected(n+1);
+      await waitForOperationsCollected(n + 1);
 
       await expect(
         token
@@ -1198,7 +1218,9 @@ describe('changes with usage data', () => {
 test.concurrent('number of produced and collected operations should match', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
-  const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
+  const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(
+    ProjectType.Single,
+  );
   const writeToken = await createTargetAccessToken({});
 
   const batchSize = 1000;
@@ -1281,7 +1303,9 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
+    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(
+      ProjectType.Single,
+    );
     const writeToken = await createTargetAccessToken({});
 
     await writeToken.collectLegacyOperations([
@@ -1306,7 +1330,6 @@ test.concurrent(
         },
       },
     ]);
-
 
     await waitForRequestsCollected(2);
 
@@ -1337,7 +1360,9 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
+    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(
+      ProjectType.Single,
+    );
     const writeToken = await createTargetAccessToken({});
 
     await writeToken.collectLegacyOperations([
@@ -1396,7 +1421,9 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
+    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(
+      ProjectType.Single,
+    );
     const writeToken = await createTargetAccessToken({});
 
     await writeToken.collectLegacyOperations([
@@ -1449,7 +1476,9 @@ test.concurrent(
 test.concurrent('ignore operations with syntax errors', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
-  const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
+  const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(
+    ProjectType.Single,
+  );
   const writeToken = await createTargetAccessToken({});
 
   const collectResult = await writeToken.collectLegacyOperations([
@@ -1510,7 +1539,9 @@ test.concurrent('ignore operations with syntax errors', async ({ expect }) => {
 test.concurrent('ensure correct data', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject, organization } = await createOrg();
-  const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
+  const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(
+    ProjectType.Single,
+  );
   const writeToken = await createTargetAccessToken({});
 
   // Organization was created, but the rate limiter may be not aware of it yet.
@@ -1822,7 +1853,9 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject, setDataRetention } = await createOrg();
-    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
+    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(
+      ProjectType.Single,
+    );
     const writeToken = await createTargetAccessToken({});
 
     const dataRetentionInDays = 60;
@@ -2180,8 +2213,12 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, toggleTargetValidation, updateTargetValidationSettings, waitForRequestsCollected } =
-      await createProject(ProjectType.Single);
+    const {
+      createTargetAccessToken,
+      toggleTargetValidation,
+      updateTargetValidationSettings,
+      waitForRequestsCollected,
+    } = await createProject(ProjectType.Single);
     const token = await createTargetAccessToken({});
 
     const sdl = /* GraphQL */ `
@@ -2393,8 +2430,12 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, toggleTargetValidation, updateTargetValidationSettings, waitForRequestsCollected } =
-      await createProject(ProjectType.Single);
+    const {
+      createTargetAccessToken,
+      toggleTargetValidation,
+      updateTargetValidationSettings,
+      waitForRequestsCollected,
+    } = await createProject(ProjectType.Single);
     const token = await createTargetAccessToken({});
     await toggleTargetValidation(true);
     await updateTargetValidationSettings({
@@ -2555,8 +2596,12 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, toggleTargetValidation, updateTargetValidationSettings, waitForRequestsCollected } =
-      await createProject(ProjectType.Single);
+    const {
+      createTargetAccessToken,
+      toggleTargetValidation,
+      updateTargetValidationSettings,
+      waitForRequestsCollected,
+    } = await createProject(ProjectType.Single);
     const token = await createTargetAccessToken({});
     await toggleTargetValidation(true);
     await updateTargetValidationSettings({
@@ -2784,35 +2829,40 @@ test.concurrent(
       },
     });
 
-    await waitFor(10_000);
+    let firstSchemaCheckId: string | undefined;
+    await pollFor(async () => {
+      try {
+        const used = await token
+          .checkSchema(/* GraphQL */ `
+            type Query {
+              a: String
+              b: String
+            }
 
-    const used = await token
-      .checkSchema(/* GraphQL */ `
-        type Query {
-          a: String
-          b: String
+            type Subscription {
+              b: String
+            }
+          `)
+          .then(r => r.expectNoGraphQLErrors());
+
+        if (used.schemaCheck.__typename === 'SchemaCheckError') {
+          expect(used.schemaCheck.errors).toEqual({
+            nodes: [
+              {
+                message: "Field 'a' was removed from object type 'Subscription'",
+              },
+            ],
+            total: 1,
+          });
+          firstSchemaCheckId = used.schemaCheck.schemaCheck?.id;
+          return true;
         }
-
-        type Subscription {
-          b: String
-        }
-      `)
-      .then(r => r.expectNoGraphQLErrors());
-
-    if (used.schemaCheck.__typename !== 'SchemaCheckError') {
-      throw new Error(`Expected SchemaCheckError, got ${used.schemaCheck.__typename}`);
-    }
-
-    expect(used.schemaCheck.errors).toEqual({
-      nodes: [
-        {
-          message: "Field 'a' was removed from object type 'Subscription'",
-        },
-      ],
-      total: 1,
+        return false;
+      } catch (e) {
+        console.error(e);
+        return false;
+      }
     });
-
-    const firstSchemaCheckId = used.schemaCheck.schemaCheck?.id;
 
     if (!firstSchemaCheckId) {
       throw new Error('Expected schemaCheckId to be defined');
@@ -2895,19 +2945,19 @@ test.concurrent(
     await pollFor(async () => {
       try {
         const irrelevant = await token
-        .checkSchema(/* GraphQL */ `
-          type Query {
-            a: String
-            b: String
-          }
+          .checkSchema(/* GraphQL */ `
+            type Query {
+              a: String
+              b: String
+            }
 
-          type Subscription {
-            b: String
-          }
-        `)
-        .then(r => r.expectNoGraphQLErrors());
-          if (irrelevant?.schemaCheck.__typename === 'SchemaCheckSuccess') {
-            expect(irrelevant.schemaCheck.changes).toEqual(
+            type Subscription {
+              b: String
+            }
+          `)
+          .then(r => r.expectNoGraphQLErrors());
+        if (irrelevant?.schemaCheck.__typename === 'SchemaCheckSuccess') {
+          expect(irrelevant.schemaCheck.changes).toEqual(
             expect.objectContaining({
               nodes: expect.arrayContaining([
                 expect.objectContaining({
@@ -2921,14 +2971,11 @@ test.concurrent(
           return true;
         }
         return false;
-      }
-      catch (e) {
+      } catch (e) {
         console.error(e);
         return false;
       }
-    })
-
-    
+    });
 
     // Make it relevant again, by making 3 subscriptions
 
@@ -2963,17 +3010,17 @@ test.concurrent(
     await pollFor(async () => {
       try {
         const relevant = await token
-        .checkSchema(/* GraphQL */ `
-          type Query {
-            a: String
-            b: String
-          }
+          .checkSchema(/* GraphQL */ `
+            type Query {
+              a: String
+              b: String
+            }
 
-          type Subscription {
-            b: String
-          }
-        `)
-        .then(r => r.expectNoGraphQLErrors());
+            type Subscription {
+              b: String
+            }
+          `)
+          .then(r => r.expectNoGraphQLErrors());
 
         if (relevant.schemaCheck.__typename === 'SchemaCheckError') {
           expect(relevant.schemaCheck.errors).toEqual({
@@ -2987,8 +3034,7 @@ test.concurrent(
           return true;
         }
         return false;
-      }
-      catch (e) {
+      } catch (e) {
         console.error(e);
         return false;
       }
@@ -2999,9 +3045,13 @@ test.concurrent(
 test.concurrent('ensure percentage precision up to 2 decimal places', async ({ expect }) => {
   const { createOrg, ownerToken } = await initSeed().createOwner();
   const { createProject, organization } = await createOrg();
-  const { project, target, createTargetAccessToken, toggleTargetValidation, waitForRequestsCollected } = await createProject(
-    ProjectType.Single,
-  );
+  const {
+    project,
+    target,
+    createTargetAccessToken,
+    toggleTargetValidation,
+    waitForRequestsCollected,
+  } = await createProject(ProjectType.Single);
   const token = await createTargetAccessToken({});
 
   const schemaPublishResult = await token
@@ -3039,7 +3089,7 @@ test.concurrent('ensure percentage precision up to 2 decimal places', async ({ e
     }),
   );
 
-  await waitForRequestsCollected(9801+199);
+  await waitForRequestsCollected(9801 + 199);
 
   const result = await clickHouseQuery<{
     target: string;
@@ -3144,8 +3194,13 @@ test.concurrent('ensure percentage precision up to 2 decimal places', async ({ e
 test.concurrent('(legacy) collect an operation from "unknown" client', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
-  const { createTargetAccessToken, readOperationBody, readOperationsStats, readClientStats, waitForRequestsCollected } =
-    await createProject(ProjectType.Single);
+  const {
+    createTargetAccessToken,
+    readOperationBody,
+    readOperationsStats,
+    readClientStats,
+    waitForRequestsCollected,
+  } = await createProject(ProjectType.Single);
   const writeToken = await createTargetAccessToken({});
 
   const collectResult = await writeToken.collectLegacyOperations([
@@ -3167,7 +3222,7 @@ test.concurrent('(legacy) collect an operation from "unknown" client', async ({ 
     },
   ]);
   expect(collectResult.status).toEqual(200);
-  await waitForRequestsCollected(1)
+  await waitForRequestsCollected(1);
 
   const from = formatISO(subHours(Date.now(), 6));
   const to = formatISO(Date.now());
@@ -3247,8 +3302,13 @@ test.concurrent('(legacy) collect an operation from "unknown" client', async ({ 
 test.concurrent('collect an operation from "unknown" client', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
-  const { createTargetAccessToken, readOperationBody, readOperationsStats, readClientStats, waitForRequestsCollected } =
-    await createProject(ProjectType.Single);
+  const {
+    createTargetAccessToken,
+    readOperationBody,
+    readOperationsStats,
+    readClientStats,
+    waitForRequestsCollected,
+  } = await createProject(ProjectType.Single);
   const writeToken = await createTargetAccessToken({});
 
   const collectResult = await writeToken.collectUsage({
@@ -3360,8 +3420,13 @@ test.concurrent('collect an operation from "unknown" client', async ({ expect })
 test.concurrent('collect an operation from undefined client', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
-  const { createTargetAccessToken, readOperationBody, readOperationsStats, readClientStats, waitForRequestsCollected } =
-    await createProject(ProjectType.Single);
+  const {
+    createTargetAccessToken,
+    readOperationBody,
+    readOperationsStats,
+    readClientStats,
+    waitForRequestsCollected,
+  } = await createProject(ProjectType.Single);
   const writeToken = await createTargetAccessToken({});
 
   const collectResult = await writeToken.collectUsage({

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -14,7 +14,7 @@ import { normalizeOperation } from '@graphql-hive/core';
 import { createHive } from '../../../../packages/libraries/core/src';
 import { collectSchemaCoordinates } from '../../../../packages/libraries/core/src/client/collect-schema-coordinates';
 import { clickHouseQuery } from '../../../testkit/clickhouse';
-import { createTarget, updateTargetValidationSettings, waitFor } from '../../../testkit/flow';
+import { createTarget, pollFor, updateTargetValidationSettings, waitFor } from '../../../testkit/flow';
 import { initSeed } from '../../../testkit/seed';
 import { CollectedOperation } from '../../../testkit/usage';
 
@@ -51,6 +51,7 @@ test.concurrent(
       toggleTargetValidation,
       readOperationBody,
       readOperationsStats,
+      waitForOperationsCollected,
     } = await createProject(ProjectType.Single);
     const writeToken = await createTargetAccessToken({});
 
@@ -92,7 +93,7 @@ test.concurrent(
       },
     ]);
     expect(collectResult.status).toEqual(200);
-    await waitFor(10_000);
+    await waitForOperationsCollected(1);
 
     // should be breaking because the field is used now
     const usedCheckResult = await readToken
@@ -133,7 +134,7 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, readOperationBody, readOperationsStats } = await createProject(
+    const { createTargetAccessToken, readOperationBody, readOperationsStats, waitForOperationsCollected } = await createProject(
       ProjectType.Single,
     );
     const writeToken = await createTargetAccessToken({});
@@ -216,7 +217,7 @@ test.concurrent(
       },
     ]);
     expect(collectResult.status).toEqual(200);
-    await waitFor(8000);
+    await waitForOperationsCollected(1);
 
     const from = formatISO(subHours(Date.now(), 6));
     const to = formatISO(Date.now());
@@ -252,7 +253,7 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, readOperationsStats, readOperationBody } = await createProject(
+    const { createTargetAccessToken, readOperationsStats, readOperationBody, waitForRequestsCollected } = await createProject(
       ProjectType.Single,
     );
     const writeToken = await createTargetAccessToken({});
@@ -275,7 +276,7 @@ test.concurrent(
       );
     }
 
-    await waitFor(8000);
+    await waitForRequestsCollected(totalAmount);
 
     const from = formatISO(subHours(Date.now(), 6));
     const to = formatISO(Date.now());
@@ -306,6 +307,7 @@ test.concurrent('check usage from two selected targets', async ({ expect }) => {
     target: staging,
     createTargetAccessToken,
     toggleTargetValidation,
+    waitForRequestsCollected,
   } = await createProject(ProjectType.Single);
 
   const productionTargetResult = await createTarget(
@@ -383,7 +385,7 @@ test.concurrent('check usage from two selected targets', async ({ expect }) => {
   ]);
 
   expect(collectResult.status).toEqual(200);
-  await waitFor(8000);
+  await waitForRequestsCollected(3, { target: productionTarget });
 
   // should not be breaking because the field is unused on staging
   // ping is used but on production
@@ -446,7 +448,7 @@ test.concurrent('check usage from two selected targets', async ({ expect }) => {
 test.concurrent('check usage not from excluded client names', async ({ expect }) => {
   const { createOrg, ownerToken } = await initSeed().createOwner();
   const { organization, createProject } = await createOrg();
-  const { project, target, createTargetAccessToken, toggleTargetValidation } = await createProject(
+  const { project, target, createTargetAccessToken, toggleTargetValidation, waitForRequestsCollected } = await createProject(
     ProjectType.Single,
   );
 
@@ -537,7 +539,7 @@ test.concurrent('check usage not from excluded client names', async ({ expect })
     },
   ]);
   expect(collectResult.status).toEqual(200);
-  await waitFor(8000);
+  await waitForRequestsCollected(4);
 
   // should be breaking because the field is used
   // Query.me would be removed, but was requested by cli and app
@@ -652,7 +654,7 @@ describe('changes with usage data', () => {
     test.concurrent(input.title, async ({ expect }) => {
       const { createOrg } = await initSeed().createOwner();
       const { createProject } = await createOrg();
-      const { target, createTargetAccessToken, toggleTargetValidation } = await createProject(
+      const { target, createTargetAccessToken, toggleTargetValidation, waitForOperationsCollected, readOperationsStats } = await createProject(
         ProjectType.Single,
       );
 
@@ -699,6 +701,10 @@ describe('changes with usage data', () => {
         fields = input.reportOperation.fields;
       }
 
+      const from = formatISO(subHours(Date.now(), 1));
+      const to = formatISO(Date.now());
+      const n = (await readOperationsStats(from, to)).totalOperations;
+
       const collectResult = await token.collectLegacyOperations([
         {
           timestamp: Date.now(),
@@ -715,7 +721,7 @@ describe('changes with usage data', () => {
       ]);
 
       expect(collectResult.status).toEqual(200);
-      await waitFor(8000);
+      await waitForOperationsCollected(n+1);
 
       await expect(
         token
@@ -1192,7 +1198,7 @@ describe('changes with usage data', () => {
 test.concurrent('number of produced and collected operations should match', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
-  const { target, createTargetAccessToken } = await createProject(ProjectType.Single);
+  const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
   const writeToken = await createTargetAccessToken({});
 
   const batchSize = 1000;
@@ -1233,7 +1239,7 @@ test.concurrent('number of produced and collected operations should match', asyn
     );
   }
 
-  await waitFor(10000);
+  await waitForRequestsCollected(totalAmount);
 
   const result = await clickHouseQuery<{
     target: string;
@@ -1275,7 +1281,7 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { target, createTargetAccessToken } = await createProject(ProjectType.Single);
+    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
     const writeToken = await createTargetAccessToken({});
 
     await writeToken.collectLegacyOperations([
@@ -1301,7 +1307,8 @@ test.concurrent(
       },
     ]);
 
-    await waitFor(8000);
+
+    await waitForRequestsCollected(2);
 
     const coordinatesResult = await clickHouseQuery<{
       target: string;
@@ -1330,7 +1337,7 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { target, createTargetAccessToken } = await createProject(ProjectType.Single);
+    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
     const writeToken = await createTargetAccessToken({});
 
     await writeToken.collectLegacyOperations([
@@ -1356,7 +1363,7 @@ test.concurrent(
       },
     ]);
 
-    await waitFor(8000);
+    await waitForRequestsCollected(2);
 
     const coordinatesResult = await clickHouseQuery<{
       coordinate: string;
@@ -1389,7 +1396,7 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { target, createTargetAccessToken } = await createProject(ProjectType.Single);
+    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
     const writeToken = await createTargetAccessToken({});
 
     await writeToken.collectLegacyOperations([
@@ -1415,7 +1422,7 @@ test.concurrent(
       },
     ]);
 
-    await waitFor(8000);
+    await waitForRequestsCollected(2);
 
     const coordinatesResult = await clickHouseQuery<{
       target: string;
@@ -1442,7 +1449,7 @@ test.concurrent(
 test.concurrent('ignore operations with syntax errors', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
-  const { target, createTargetAccessToken } = await createProject(ProjectType.Single);
+  const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
   const writeToken = await createTargetAccessToken({});
 
   const collectResult = await writeToken.collectLegacyOperations([
@@ -1476,7 +1483,8 @@ test.concurrent('ignore operations with syntax errors', async ({ expect }) => {
     }),
   );
 
-  await waitFor(8000);
+  // @note rejected doesnt count... Assume if 1 has been collected that the other has too.
+  await waitForRequestsCollected(1);
 
   const coordinatesResult = await clickHouseQuery<{
     target: string;
@@ -1502,7 +1510,7 @@ test.concurrent('ignore operations with syntax errors', async ({ expect }) => {
 test.concurrent('ensure correct data', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject, organization } = await createOrg();
-  const { target, createTargetAccessToken } = await createProject(ProjectType.Single);
+  const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
   const writeToken = await createTargetAccessToken({});
 
   // Organization was created, but the rate limiter may be not aware of it yet.
@@ -1537,7 +1545,7 @@ test.concurrent('ensure correct data', async ({ expect }) => {
     },
   ]);
 
-  await waitFor(8000);
+  await waitForRequestsCollected(2);
 
   // operation_collection
   const operationCollectionResult = await clickHouseQuery<{
@@ -1814,7 +1822,7 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject, setDataRetention } = await createOrg();
-    const { target, createTargetAccessToken } = await createProject(ProjectType.Single);
+    const { target, createTargetAccessToken, waitForRequestsCollected } = await createProject(ProjectType.Single);
     const writeToken = await createTargetAccessToken({});
 
     const dataRetentionInDays = 60;
@@ -1850,7 +1858,7 @@ test.concurrent(
       },
     ]);
 
-    await waitFor(8000);
+    await waitForRequestsCollected(2);
 
     // operation_collection
     const operationCollectionResult = await clickHouseQuery<{
@@ -2172,7 +2180,7 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, toggleTargetValidation, updateTargetValidationSettings } =
+    const { createTargetAccessToken, toggleTargetValidation, updateTargetValidationSettings, waitForRequestsCollected } =
       await createProject(ProjectType.Single);
     const token = await createTargetAccessToken({});
 
@@ -2287,7 +2295,7 @@ test.concurrent(
 
     collectA();
 
-    await waitFor(8000);
+    await waitForRequestsCollected(1);
 
     const used = await token
       .checkSchema(/* GraphQL */ `
@@ -2322,7 +2330,7 @@ test.concurrent(
       percentage: 50,
     });
 
-    await waitFor(8000);
+    await waitForRequestsCollected(4);
 
     const below = await token
       .checkSchema(/* GraphQL */ `
@@ -2354,7 +2362,7 @@ test.concurrent(
     collectA();
     collectA();
 
-    await waitFor(8000);
+    await waitForRequestsCollected(7);
 
     const relevant = await token
       .checkSchema(/* GraphQL */ `
@@ -2385,7 +2393,7 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, toggleTargetValidation, updateTargetValidationSettings } =
+    const { createTargetAccessToken, toggleTargetValidation, updateTargetValidationSettings, waitForRequestsCollected } =
       await createProject(ProjectType.Single);
     const token = await createTargetAccessToken({});
     await toggleTargetValidation(true);
@@ -2487,7 +2495,7 @@ test.concurrent(
 
     collectA();
 
-    await waitFor(8000);
+    await waitForRequestsCollected(1);
 
     const below = await token
       .checkSchema(/* GraphQL */ `
@@ -2516,7 +2524,7 @@ test.concurrent(
     // Now let's make Query.a above threshold by making a 2nd query for Query.a
     collectA();
 
-    await waitFor(8000);
+    await waitForRequestsCollected(2);
 
     const above = await token
       .checkSchema(/* GraphQL */ `
@@ -2547,7 +2555,7 @@ test.concurrent(
   async ({ expect }) => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();
-    const { createTargetAccessToken, toggleTargetValidation, updateTargetValidationSettings } =
+    const { createTargetAccessToken, toggleTargetValidation, updateTargetValidationSettings, waitForRequestsCollected } =
       await createProject(ProjectType.Single);
     const token = await createTargetAccessToken({});
     await toggleTargetValidation(true);
@@ -2644,7 +2652,7 @@ test.concurrent(
     collectA();
     collectB();
 
-    await waitFor(8000);
+    await waitForRequestsCollected(2);
 
     // try to remove `Query.a`
     const above = await token
@@ -2776,7 +2784,7 @@ test.concurrent(
       },
     });
 
-    await waitFor(10000);
+    await waitFor(10_000);
 
     const used = await token
       .checkSchema(/* GraphQL */ `
@@ -2884,36 +2892,43 @@ test.concurrent(
       percentage: 50,
     });
 
-    await waitFor(8000);
+    await pollFor(async () => {
+      try {
+        const irrelevant = await token
+        .checkSchema(/* GraphQL */ `
+          type Query {
+            a: String
+            b: String
+          }
 
-    const irrelevant = await token
-      .checkSchema(/* GraphQL */ `
-        type Query {
-          a: String
-          b: String
+          type Subscription {
+            b: String
+          }
+        `)
+        .then(r => r.expectNoGraphQLErrors());
+          if (irrelevant?.schemaCheck.__typename === 'SchemaCheckSuccess') {
+            expect(irrelevant.schemaCheck.changes).toEqual(
+            expect.objectContaining({
+              nodes: expect.arrayContaining([
+                expect.objectContaining({
+                  message:
+                    "Field 'a' was removed from object type 'Subscription' (non-breaking based on usage)",
+                }),
+              ]),
+              total: 1,
+            }),
+          );
+          return true;
         }
+        return false;
+      }
+      catch (e) {
+        console.error(e);
+        return false;
+      }
+    })
 
-        type Subscription {
-          b: String
-        }
-      `)
-      .then(r => r.expectNoGraphQLErrors());
-
-    if (irrelevant.schemaCheck.__typename !== 'SchemaCheckSuccess') {
-      throw new Error(`Expected SchemaCheckSuccess, got ${irrelevant.schemaCheck.__typename}`);
-    }
-
-    expect(irrelevant.schemaCheck.changes).toEqual(
-      expect.objectContaining({
-        nodes: expect.arrayContaining([
-          expect.objectContaining({
-            message:
-              "Field 'a' was removed from object type 'Subscription' (non-breaking based on usage)",
-          }),
-        ]),
-        total: 1,
-      }),
-    );
+    
 
     // Make it relevant again, by making 3 subscriptions
 
@@ -2945,32 +2960,38 @@ test.concurrent(
       },
     });
 
-    await waitFor(8000);
+    await pollFor(async () => {
+      try {
+        const relevant = await token
+        .checkSchema(/* GraphQL */ `
+          type Query {
+            a: String
+            b: String
+          }
 
-    const relevant = await token
-      .checkSchema(/* GraphQL */ `
-        type Query {
-          a: String
-          b: String
+          type Subscription {
+            b: String
+          }
+        `)
+        .then(r => r.expectNoGraphQLErrors());
+
+        if (relevant.schemaCheck.__typename === 'SchemaCheckError') {
+          expect(relevant.schemaCheck.errors).toEqual({
+            nodes: [
+              {
+                message: "Field 'a' was removed from object type 'Subscription'",
+              },
+            ],
+            total: 1,
+          });
+          return true;
         }
-
-        type Subscription {
-          b: String
-        }
-      `)
-      .then(r => r.expectNoGraphQLErrors());
-
-    if (relevant.schemaCheck.__typename !== 'SchemaCheckError') {
-      throw new Error(`Expected SchemaCheckError, got ${relevant.schemaCheck.__typename}`);
-    }
-
-    expect(relevant.schemaCheck.errors).toEqual({
-      nodes: [
-        {
-          message: "Field 'a' was removed from object type 'Subscription'",
-        },
-      ],
-      total: 1,
+        return false;
+      }
+      catch (e) {
+        console.error(e);
+        return false;
+      }
     });
   },
 );
@@ -2978,7 +2999,7 @@ test.concurrent(
 test.concurrent('ensure percentage precision up to 2 decimal places', async ({ expect }) => {
   const { createOrg, ownerToken } = await initSeed().createOwner();
   const { createProject, organization } = await createOrg();
-  const { project, target, createTargetAccessToken, toggleTargetValidation } = await createProject(
+  const { project, target, createTargetAccessToken, toggleTargetValidation, waitForRequestsCollected } = await createProject(
     ProjectType.Single,
   );
   const token = await createTargetAccessToken({});
@@ -3018,7 +3039,7 @@ test.concurrent('ensure percentage precision up to 2 decimal places', async ({ e
     }),
   );
 
-  await waitFor(10000);
+  await waitForRequestsCollected(9801+199);
 
   const result = await clickHouseQuery<{
     target: string;
@@ -3123,7 +3144,7 @@ test.concurrent('ensure percentage precision up to 2 decimal places', async ({ e
 test.concurrent('(legacy) collect an operation from "unknown" client', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
-  const { createTargetAccessToken, readOperationBody, readOperationsStats, readClientStats } =
+  const { createTargetAccessToken, readOperationBody, readOperationsStats, readClientStats, waitForRequestsCollected } =
     await createProject(ProjectType.Single);
   const writeToken = await createTargetAccessToken({});
 
@@ -3146,7 +3167,7 @@ test.concurrent('(legacy) collect an operation from "unknown" client', async ({ 
     },
   ]);
   expect(collectResult.status).toEqual(200);
-  await waitFor(8000);
+  await waitForRequestsCollected(1)
 
   const from = formatISO(subHours(Date.now(), 6));
   const to = formatISO(Date.now());
@@ -3226,7 +3247,7 @@ test.concurrent('(legacy) collect an operation from "unknown" client', async ({ 
 test.concurrent('collect an operation from "unknown" client', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
-  const { createTargetAccessToken, readOperationBody, readOperationsStats, readClientStats } =
+  const { createTargetAccessToken, readOperationBody, readOperationsStats, readClientStats, waitForRequestsCollected } =
     await createProject(ProjectType.Single);
   const writeToken = await createTargetAccessToken({});
 
@@ -3258,7 +3279,7 @@ test.concurrent('collect an operation from "unknown" client', async ({ expect })
     ],
   });
   expect(collectResult.status).toEqual(200);
-  await waitFor(8000);
+  await waitForRequestsCollected(1);
 
   const from = formatISO(subHours(Date.now(), 6));
   const to = formatISO(Date.now());
@@ -3339,7 +3360,7 @@ test.concurrent('collect an operation from "unknown" client', async ({ expect })
 test.concurrent('collect an operation from undefined client', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
-  const { createTargetAccessToken, readOperationBody, readOperationsStats, readClientStats } =
+  const { createTargetAccessToken, readOperationBody, readOperationsStats, readClientStats, waitForRequestsCollected } =
     await createProject(ProjectType.Single);
   const writeToken = await createTargetAccessToken({});
 
@@ -3371,7 +3392,7 @@ test.concurrent('collect an operation from undefined client', async ({ expect })
     ],
   });
   expect(collectResult.status).toEqual(200);
-  await waitFor(8000);
+  await waitForRequestsCollected(1);
 
   const from = formatISO(subHours(Date.now(), 6));
   const to = formatISO(Date.now());

--- a/integration-tests/tests/api/tokens.spec.ts
+++ b/integration-tests/tests/api/tokens.spec.ts
@@ -51,14 +51,17 @@ test.concurrent('deleting a token should clear the cache', async () => {
   // Fetch the token info again to make sure it's cached
   await expect(fetchTokenInfo()).resolves.toEqual(expect.objectContaining(expectedResult));
   // To make sure the cache is cleared, we need to wait for at least 5 seconds
-  await pollFor(async () => {
-    try {
-      await fetchTokenInfo();
-      return false;
-    } catch (e) {
-      return true;
-    }
-  }, { maxWait: 5_500})
+  await pollFor(
+    async () => {
+      try {
+        await fetchTokenInfo();
+        return false;
+      } catch (e) {
+        return true;
+      }
+    },
+    { maxWait: 5_500 },
+  );
   await expect(fetchTokenInfo()).rejects.toThrow();
 });
 

--- a/integration-tests/tests/api/tokens.spec.ts
+++ b/integration-tests/tests/api/tokens.spec.ts
@@ -1,4 +1,4 @@
-import { readTokenInfo, waitFor } from 'testkit/flow';
+import { pollFor, readTokenInfo } from 'testkit/flow';
 import { ProjectType } from 'testkit/gql/graphql';
 import { initSeed } from '../../testkit/seed';
 
@@ -51,7 +51,14 @@ test.concurrent('deleting a token should clear the cache', async () => {
   // Fetch the token info again to make sure it's cached
   await expect(fetchTokenInfo()).resolves.toEqual(expect.objectContaining(expectedResult));
   // To make sure the cache is cleared, we need to wait for at least 5 seconds
-  await waitFor(5500);
+  await pollFor(async () => {
+    try {
+      await fetchTokenInfo();
+      return false;
+    } catch (e) {
+      return true;
+    }
+  }, { maxWait: 5_500})
   await expect(fetchTokenInfo()).rejects.toThrow();
 });
 


### PR DESCRIPTION
### Background

Integration tests currently contain a lot of `waitFor` calls which are static wait periods to ensure certain async operations are processed. To avoid excessively flaky tests, the wait period must exceed what is typically necessary. This time adds up.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

A `pollFor` testkit function was recently added. This PR makes use of, and enhances that function, to improve test consistency and speed.

`tests/api/target/usage.spec.ts` was especially impacted by this change. Locally, the time to run these tests went from 87s to 26s.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->
- [x] Testing
