### PR TITLE
Fix broken link

### DIFF
--- a/packages/web/docs/src/content/self-hosting/get-started.mdx
+++ b/packages/web/docs/src/content/self-hosting/get-started.mdx
@@ -24,7 +24,7 @@ The easiest way of running GraphQL Hive is using [Docker](https://www.docker.com
 [docker-compose](https://docs.docker.com/compose/).
 
 All the services required for running GraphQL Hive are published to the GitHub container registry
-([GraphQL Hive Docker Images](https://github.com/graphql-hive?tab=packages)).
+([GraphQL Hive Docker Images](https://github.com/orgs/graphql-hive/packages)).
 
 Please make sure to install the Docker daemon as well as `docker-compose` on your machine before
 proceeding.


### PR DESCRIPTION
### Background

Was looking at the self-hosted docs and found a link which didn't work as expected.

### Description

Fixed the link by replacing it with the new URL