### PR TITLE
Get schema version by action id index

### DIFF
--- a/.changeset/afraid-years-look.md
+++ b/.changeset/afraid-years-look.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Add pg index for getSchemaVersionByActionId to improve lookup performance

--- a/packages/migrations/src/actions/2025.05.28T00-00-00.schema-log-by-ids.ts
+++ b/packages/migrations/src/actions/2025.05.28T00-00-00.schema-log-by-ids.ts
@@ -1,0 +1,21 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+/**
+ * Adds an index specifically for getSchemaVersionByActionId.
+ */
+export default {
+  name: '2025.05.28T00-00-00.schema-log-by-ids.ts',
+  noTransaction: true,
+  run: ({ sql }) => [
+    {
+      name: 'index schema_log_by_ids',
+      query: sql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "schema_log_by_ids" ON "schema_log"(
+          "project_id"
+          , "target_id"
+          , "commit"
+          )
+      `,
+    },
+  ],
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -166,5 +166,6 @@ export const runPGMigrations = async (args: { slonik: DatabasePool; runTo?: stri
       await import('./actions/2025.05.15T00-00-00.redundant-indices'),
       await import('./actions/2025.05.15T00-00-00.contracts-foreign-key-constraint-fix'),
       await import('./actions/2025.05.15T00-00-01.organization-member-pagination'),
+      await import('./actions/2025.05.28T00-00-00.schema-log-by-ids'),
     ],
   });


### PR DESCRIPTION
### Background

When reviewing the performance of our API, [this trace](https://hiveprod.grafana.net/explore?schemaVersion=1&panes=%7B%22y71%22%3A%7B%22datasource%22%3A%22grafanacloud-traces%22%2C%22queries%22%3A%5B%7B%22query%22%3A%22f08333006ea28604e2bc93abd283a40b%22%2C%22queryType%22%3A%22traceql%22%2C%22refId%22%3A%22A%22%2C%22datasource%22%3A%7B%22type%22%3A%22tempo%22%2C%22uid%22%3A%22grafanacloud-traces%22%7D%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%2C%22panelsState%22%3A%7B%22trace%22%3A%7B%22spanId%22%3A%2273174bbf35f11537%22%7D%7D%7D%7D&orgId=1) stood out:

This shows the call for `getSchemaVersionByActionId` taking almost 20s!

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

The SQL call in question is:
```
SELECT
          ${schemaVersionSQLFields()}
        FROM
          "schema_versions"
        WHERE
          "action_id" = ANY(
            SELECT
              "id"
            FROM
              "schema_log"
            WHERE
              "schema_log"."project_id" = ${args.projectId}
              AND "schema_log"."target_id" = ${args.targetId}
              AND "schema_log"."commit" = ${args.actionId}
          )
        LIMIT 1
```

`schema_log` was missing an index for these three columns.
