### PR TITLE
Update resources-requirements.mdx

### DIFF
--- a/packages/web/docs/src/content/gateway/deployment/resources-requirements.mdx
+++ b/packages/web/docs/src/content/gateway/deployment/resources-requirements.mdx
@@ -36,3 +36,5 @@ By default, the gateway uses the available parallelism (number of CPUs, based on
 
 You can set the `FORK` environment variable to specify the number of workers you want to spawn. For
 example, to spawn 12 workers, set `FORK=12`.
+
+Consider setting `DEBUG=0` if you don't need debug logs. This can have significant impact on CPU usage.

--- a/packages/web/docs/src/content/gateway/deployment/resources-requirements.mdx
+++ b/packages/web/docs/src/content/gateway/deployment/resources-requirements.mdx
@@ -37,4 +37,4 @@ By default, the gateway uses the available parallelism (number of CPUs, based on
 You can set the `FORK` environment variable to specify the number of workers you want to spawn. For
 example, to spawn 12 workers, set `FORK=12`.
 
-Consider setting `DEBUG=0` if you don't need debug logs. This can have significant impact on CPU usage.
+Consider unsetting the `DEBUG` env variable if you don't need debug logs. This can have significant impact on CPU usage.


### PR DESCRIPTION
Mention `DEBUG` variable in context of performance.

### Background

During rollout of the gateway, we noticed increased CPU usage when compared to existing gateway service. We investigated that debug logs affect this.

### Description

Mention `DEBUG` env variable in the documentation.

### Checklist

- [X] System configuration
