### PR TITLE
Add logs for active subscriptions that are missing payment methods

### DIFF
--- a/packages/services/api/src/modules/commerce/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/commerce/resolvers/Organization.ts
@@ -63,7 +63,7 @@ export const Organization: Pick<
     const logger = injector.get(Logger);
 
     if (!subscriptionInfo) {
-      logger.info('No active subscription for organization (id=%s)', org.id)
+      logger.info('No active subscription for organization (id=%s)', org.id);
       return {
         hasActiveSubscription: false,
         canUpdateSubscription: true,
@@ -89,7 +89,7 @@ export const Organization: Pick<
     );
 
     if (!subscriptionInfo.paymentMethod) {
-      logger.warn('Active subscription found but is missing a payment method (id=%s)', org.id)
+      logger.warn('Active subscription found but is missing a payment method (id=%s)', org.id);
     }
 
     return {

--- a/packages/services/api/src/modules/commerce/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/commerce/resolvers/Organization.ts
@@ -60,7 +60,10 @@ export const Organization: Pick<
       organizationId: billingRecord.organizationId,
     });
 
+    const logger = injector.get(Logger);
+
     if (!subscriptionInfo) {
+      logger.info('No active subscription for organization (id=%s)', org.id)
       return {
         hasActiveSubscription: false,
         canUpdateSubscription: true,
@@ -84,6 +87,10 @@ export const Organization: Pick<
     const hasPaymentIssues = invoices?.some(
       i => i.charge !== null && typeof i.charge === 'object' && i.charge?.failure_code !== null,
     );
+
+    if (!subscriptionInfo.paymentMethod) {
+      logger.warn('Active subscription found but is missing a payment method (id=%s)', org.id)
+    }
 
     return {
       hasActiveSubscription: subscriptionInfo.subscription !== null,

--- a/packages/services/commerce/src/stripe-billing/index.ts
+++ b/packages/services/commerce/src/stripe-billing/index.ts
@@ -92,10 +92,13 @@ export const stripeBillingRouter = router({
 
       const actualSubscription = subscriptions[0] || null;
 
-      const paymentMethod = await ctx.stripeBilling.stripe.customers.listPaymentMethods(customer.id, {
-        type: 'card',
-        limit: 1,
-      });
+      const paymentMethod = await ctx.stripeBilling.stripe.customers.listPaymentMethods(
+        customer.id,
+        {
+          type: 'card',
+          limit: 1,
+        },
+      );
 
       return {
         paymentMethod: paymentMethod.data[0] || null,

--- a/packages/services/commerce/src/stripe-billing/index.ts
+++ b/packages/services/commerce/src/stripe-billing/index.ts
@@ -92,9 +92,9 @@ export const stripeBillingRouter = router({
 
       const actualSubscription = subscriptions[0] || null;
 
-      const paymentMethod = await ctx.stripeBilling.stripe.paymentMethods.list({
-        customer: customer.id,
+      const paymentMethod = await ctx.stripeBilling.stripe.customers.listPaymentMethods(customer.id, {
         type: 'card',
+        limit: 1,
       });
 
       return {


### PR DESCRIPTION
### Background

We recently had an issue where a customer was unable to update their payment information even though they have an active subscription.
<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description


This adds logs to help us better understand if the missing payment method case is happening. And it updates the payment method call to use stripe's recommended "List Customer Payment Methods" api

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
