### PR TITLE
fix: only show edit perflight script button if user has permissions

### DIFF
--- a/.changeset/olive-ghosts-shout.md
+++ b/.changeset/olive-ghosts-shout.md
@@ -1,0 +1,6 @@
+---
+'hive': patch
+---
+
+Only show the "edit preflight script" button in the laboratory when the users has permissions to
+edit it.

--- a/packages/services/api/src/modules/collection/module.graphql.ts
+++ b/packages/services/api/src/modules/collection/module.graphql.ts
@@ -158,6 +158,7 @@ export const typeDefs = gql`
   extend type Target {
     viewerCanViewLaboratory: Boolean!
     viewerCanModifyLaboratory: Boolean!
+    viewerCanModifyPreflightScript: Boolean!
     documentCollection(id: ID!): DocumentCollection
     documentCollections(first: Int = 100, after: String = null): DocumentCollectionConnection!
     documentCollectionOperation(id: ID!): DocumentCollectionOperation

--- a/packages/services/api/src/modules/collection/resolvers/Target.ts
+++ b/packages/services/api/src/modules/collection/resolvers/Target.ts
@@ -7,6 +7,7 @@ export const Target: Pick<
   | 'documentCollectionOperation'
   | 'documentCollections'
   | 'viewerCanModifyLaboratory'
+  | 'viewerCanModifyPreflightScript'
   | 'viewerCanViewLaboratory'
   | '__isTypeOf'
 > = {
@@ -30,6 +31,17 @@ export const Target: Pick<
   viewerCanModifyLaboratory: (target, _arg, { session }) => {
     return session.canPerformAction({
       action: 'laboratory:modify',
+      organizationId: target.orgId,
+      params: {
+        organizationId: target.orgId,
+        projectId: target.projectId,
+        targetId: target.id,
+      },
+    });
+  },
+  viewerCanModifyPreflightScript: async (target, _arg, { session }) => {
+    return session.canPerformAction({
+      action: 'laboratory:modifyPreflightScript',
       organizationId: target.orgId,
       params: {
         organizationId: target.orgId,

--- a/packages/web/app/src/lib/preflight/graphiql-plugin.tsx
+++ b/packages/web/app/src/lib/preflight/graphiql-plugin.tsx
@@ -134,6 +134,7 @@ const PreflightScript_TargetFragment = graphql(`
       id
       sourceCode
     }
+    viewerCanModifyPreflightScript
   }
 `);
 
@@ -424,6 +425,7 @@ export function usePreflight(args: {
     isEnabled,
     setIsEnabled,
     content: target?.preflightScript?.sourceCode ?? '',
+    viewerCanModifyPreflightScript: target?.viewerCanModifyPreflightScript ?? false,
     environmentVariables,
     setEnvironmentVariables,
     state,
@@ -493,37 +495,41 @@ function PreflightContent() {
 
   return (
     <>
-      <PreflightModal
-        // to unmount on submit/close
-        key={String(showModal)}
-        isOpen={showModal}
-        toggle={toggleShowModal}
-        execute={value =>
-          preflight.execute(value, true).catch(err => {
-            console.error(err);
-          })
-        }
-        state={preflight.state}
-        abortExecution={preflight.abortExecution}
-        logs={preflight.logs}
-        clearLogs={preflight.clearLogs}
-        content={preflight.content}
-        onContentChange={handleContentChange}
-        envValue={preflight.environmentVariables}
-        onEnvValueChange={preflight.setEnvironmentVariables}
-      />
+      {preflight.viewerCanModifyPreflightScript && (
+        <PreflightModal
+          // to unmount on submit/close
+          key={String(showModal)}
+          isOpen={showModal}
+          toggle={toggleShowModal}
+          execute={value =>
+            preflight.execute(value, true).catch(err => {
+              console.error(err);
+            })
+          }
+          state={preflight.state}
+          abortExecution={preflight.abortExecution}
+          logs={preflight.logs}
+          clearLogs={preflight.clearLogs}
+          content={preflight.content}
+          onContentChange={handleContentChange}
+          envValue={preflight.environmentVariables}
+          onEnvValueChange={preflight.setEnvironmentVariables}
+        />
+      )}
       <div className="graphiql-doc-explorer-title flex items-center justify-between gap-4">
         Preflight Script
-        <Button
-          variant="orangeLink"
-          size="icon-sm"
-          className="size-auto gap-1"
-          onClick={toggleShowModal}
-          data-cy="preflight-modal-button"
-        >
-          <Pencil1Icon className="shrink-0" />
-          Edit
-        </Button>
+        {preflight.viewerCanModifyPreflightScript && (
+          <Button
+            variant="orangeLink"
+            size="icon-sm"
+            className="size-auto gap-1"
+            onClick={toggleShowModal}
+            data-cy="preflight-modal-button"
+          >
+            <Pencil1Icon className="shrink-0" />
+            Edit
+          </Button>
+        )}
       </div>
       <Subtitle>
         Before each GraphQL request begins, this script is executed automatically - for example, to


### PR DESCRIPTION
### Background

We show the edit preflight script button and allow editing it even though user does not have the permissions and the http call to save the updates will fail.

