### PR TITLE
docs(apollo-gateway): fix `startStandaloneServer` usage

### DIFF
--- a/packages/web/docs/src/content/other-integrations/apollo-gateway.mdx
+++ b/packages/web/docs/src/content/other-integrations/apollo-gateway.mdx
@@ -71,7 +71,7 @@ const gateway = new ApolloGateway({
 
 const server = new ApolloServer({ gateway })
 
-const { url } = await startStandaloneServer({ server })
+const { url } = await startStandaloneServer(server)
 console.log(`🚀 Server ready at ${url}`)
 ```
 
@@ -113,7 +113,7 @@ const server = new ApolloServer({
   ]
 })
 
-const { url } = await startStandaloneServer({ server })
+const { url } = await startStandaloneServer(server)
 console.log(`🚀 Server ready at ${url}`)
 ```
 


### PR DESCRIPTION
Update apollo-gateway example and pass `server` correctly (see https://www.apollographql.com/docs/apollo-server/api/standalone) 