### PR TITLE
Remove erroneous 100 operations limit from Pricing

### DIFF
--- a/packages/web/docs/src/components/pricing/plans-table.tsx
+++ b/packages/web/docs/src/components/pricing/plans-table.tsx
@@ -122,12 +122,12 @@ export function PlansTable({ className }: { className?: string }) {
             <tr>
               <PlansTableCell className="whitespace-pre">Operations per month</PlansTableCell>
               <PlansTableCell activePlan={activePlan} plan="Hobby">
-                Limit of 100 operations
+                1M operations per month
               </PlansTableCell>
               <PlansTableCell activePlan={activePlan} plan="Pro">
                 1M operations per month
                 <br className="max-sm:inline" />
-                Then $10 per million operations
+                <span className="font-normal">Then $10 per million operations</span>
               </PlansTableCell>
               <PlansTableCell activePlan={activePlan} plan="Enterprise">
                 Custom operation limit
@@ -411,7 +411,7 @@ function PlansTableCell({
     <td
       aria-hidden={plan !== currentPlan}
       className={cn(
-        'border-beige-400 border-b border-r p-4 first:border-l first:font-medium max-md:w-1/2 max-sm:text-sm sm:py-6 md:w-1/4 [&:not(:first-child)]:border-l-0 [&:not(:first-child)]:text-center [&:not(:first-child)]:text-sm [&:not(:first-child)]:text-green-800 md:[.subheader+tr>&:last-child]:rounded-tr-3xl max-md:[.subheader+tr>&:not(:first-child,:has(+td[aria-hidden=false]))]:rounded-tr-3xl [.subheader+tr>&]:border-t [.subheader+tr>&]:first:rounded-tl-3xl md:[tr:is(:has(+.subheader),:last-child)>&:last-child]:rounded-br-3xl max-md:[tr:is(:has(+.subheader),:last-child)>&:not(:first-child,:has(+td[aria-hidden=false]))]:rounded-br-3xl [tr:is(:last-child,:has(+.subheader))>&]:first:rounded-bl-3xl',
+        'border-beige-400 border-b border-r p-4 font-medium first:border-l first:font-medium max-md:w-1/2 max-sm:text-sm sm:py-6 md:w-1/4 [&:not(:first-child)]:border-l-0 [&:not(:first-child)]:text-center [&:not(:first-child)]:text-sm [&:not(:first-child)]:text-green-800 md:[.subheader+tr>&:last-child]:rounded-tr-3xl max-md:[.subheader+tr>&:not(:first-child,:has(+td[aria-hidden=false]))]:rounded-tr-3xl [.subheader+tr>&]:border-t [.subheader+tr>&]:first:rounded-tl-3xl md:[tr:is(:has(+.subheader),:last-child)>&:last-child]:rounded-br-3xl max-md:[tr:is(:has(+.subheader),:last-child)>&:not(:first-child,:has(+td[aria-hidden=false]))]:rounded-br-3xl [tr:is(:last-child,:has(+.subheader))>&]:first:rounded-bl-3xl',
         plan && plan !== currentPlan && 'max-md:hidden',
         className,
       )}


### PR DESCRIPTION
### Description

Closes #6873.

We previously showed wrong limit of operations for the Hobby plan. This PR fixes it.
