### PR TITLE
update target history nav to include versionId if applicable to fix n…

### DIFF
--- a/.changeset/witty-ghosts-rush.md
+++ b/.changeset/witty-ghosts-rush.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Fix schema version browser history navigation.

--- a/packages/web/app/src/components/layouts/target.tsx
+++ b/packages/web/app/src/components/layouts/target.tsx
@@ -67,6 +67,9 @@ const TargetLayoutQuery = graphql(`
           viewerCanViewLaboratory
           viewerCanViewAppDeployments
           viewerCanAccessSettings
+          latestSchemaVersion {
+            id
+          }
         }
       }
     }
@@ -103,6 +106,7 @@ export const TargetLayout = ({
   const currentOrganization = query.data?.organization;
   const currentProject = query.data?.organization?.project;
   const currentTarget = query.data?.organization?.project?.target;
+  const latestSchemaVersion = query.data?.organization?.project?.target?.latestSchemaVersion?.id;
 
   const isCDNEnabled = query.data?.isCDNEnabled === true;
 
@@ -180,11 +184,12 @@ export const TargetLayout = ({
                     </TabsTrigger>
                     <TabsTrigger variant="menu" value={Page.History} asChild>
                       <Link
-                        to="/$organizationSlug/$projectSlug/$targetSlug/history"
+                        to="/$organizationSlug/$projectSlug/$targetSlug/history/$versionId"
                         params={{
                           organizationSlug: currentOrganization.slug,
                           projectSlug: currentProject.slug,
                           targetSlug: currentTarget.slug,
+                          versionId: latestSchemaVersion ?? '',
                         }}
                       >
                         History


### PR DESCRIPTION
…avigation

### Background

Fixing back button for history in navigation

Closes #6839
Closes #6885

### Description

Affects: WebApp -> target.tsx

Implement the latest schema version on this page to directly link to the latest schema version to fix back button errors. If it doesn't exist do not append any string, this will emulate the same current functionality.

Checked in my local space and the back button works as expected for no history and multiple versions history.
