### PR TITLE
fix(commerce): avoid overriding email when updating subscription

### DIFF
--- a/packages/services/commerce/src/stripe-billing/index.ts
+++ b/packages/services/commerce/src/stripe-billing/index.ts
@@ -1,5 +1,4 @@
 import { addDays, startOfMonth } from 'date-fns';
-import { Stripe } from 'stripe';
 import { z } from 'zod';
 import { publicProcedure, router } from '../trpc';
 
@@ -201,19 +200,6 @@ export const stripeBillingRouter = router({
               });
             }
           }
-        }
-
-        const updateParams: Stripe.CustomerUpdateParams = {};
-
-        if (organizationBillingRecord.billingEmailAddress) {
-          updateParams.email = organizationBillingRecord.billingEmailAddress;
-        }
-
-        if (Object.keys(updateParams).length > 0) {
-          await ctx.stripeBilling.stripe.customers.update(
-            organizationBillingRecord.externalBillingReference,
-            updateParams,
-          );
         }
       } else {
         throw new Error(


### PR DESCRIPTION
The condition doesn't make any sense, it's overriding the email to the one we have on record. Since subscription's main email is managed externally on Stripe, we don't really need to hold it on our end, or update it at all. A follow up PR can even remove this column from the database, as I don't this it's being used. 

Users are able to update their billing email using the Stripe magic link. 

Fixes CONSOLE-1308 