### PR TITLE
fix: dont touch external fields or objects in contract logic

### DIFF
--- a/integration-tests/tests/schema/contracts.spec.ts
+++ b/integration-tests/tests/schema/contracts.spec.ts
@@ -479,3 +479,185 @@ test('inaccessible is not applied on type if at least one type extension has a p
   expect(result.contracts?.[0].errors).toEqual([]);
   expect(result.contracts?.[0].sdl).toContain('type Brr {');
 });
+
+test('@external fields are always included if exclude @tag is used', async () => {
+  const result = await client.composeAndValidate.mutate({
+    type: 'federation',
+    native: true,
+    schemas: [
+      {
+        raw: /* GraphQL */ `
+          extend schema
+            @link(url: "https://specs.apollo.dev/link/v1.0")
+            @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key", "@tag"])
+
+          type Query {
+            user: User
+          }
+
+          type User @key(fields: "id") {
+            id: ID!
+            ssn: String @tag(name: "private")
+          }
+        `,
+        source: 'user.graphql',
+        url: 'https://localhost:3000/graphql',
+      },
+      {
+        raw: /* GraphQL */ `
+          extend schema
+            @link(url: "https://specs.apollo.dev/link/v1.0")
+            @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key", "@external", "@requires"])
+
+          type User @key(fields: "id") {
+            id: ID!
+            ssn: String @external
+            creditScore: Int @requires(fields: "ssn")
+          }
+        `,
+        source: 'credit.graphql',
+        url: 'https://localhost:3001/graphql',
+      }
+    ],
+    external: null,
+    contracts: [
+      {
+        id: 'foo',
+        filter: {
+          removeUnreachableTypesFromPublicApiSchema: false,
+          exclude: ['private'],
+          include: null,
+        },
+      },
+    ],
+  });
+
+  expect(result.errors).toEqual([]);
+  expect(result.contracts?.[0].errors).toEqual([]);
+  expect(result.contracts?.[0].sdl).toMatchInlineSnapshot(`
+    type User {
+      id: ID!
+      creditScore: Int
+    }
+
+    type Query {
+      user: User
+    }
+  `);
+});
+
+test('@external fields are always included if include @tag is used', async () => {
+  const result = await client.composeAndValidate.mutate({
+    type: 'federation',
+    native: true,
+    schemas: [
+      {
+        raw: /* GraphQL */ `
+          extend schema
+            @link(url: "https://specs.apollo.dev/link/v1.0")
+            @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key", "@tag"])
+
+          type Query {
+            user: User @tag(name: "public")
+          }
+
+          type User @key(fields: "id") {
+            id: ID! @tag(name: "public")
+            ssn: String
+          }
+        `,
+        source: 'user.graphql',
+        url: 'https://localhost:3000/graphql',
+      },
+      {
+        raw: /* GraphQL */ `
+          extend schema
+            @link(url: "https://specs.apollo.dev/link/v1.0")
+            @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key", "@external", "@requires", "@tag"])
+
+          type User @key(fields: "id") {
+            id: ID!
+            ssn: String @external
+            creditScore: Int @requires(fields: "ssn") @tag(name: "public")
+          }
+        `,
+        source: 'credit.graphql',
+        url: 'https://localhost:3001/graphql',
+      }
+    ],
+    external: null,
+    contracts: [
+      {
+        id: 'foo',
+        filter: {
+          removeUnreachableTypesFromPublicApiSchema: false,
+          exclude: null,
+          include: ['public'],
+        },
+      },
+    ],
+  });
+
+  expect(result.errors).toEqual([]);
+  expect(result.contracts?.[0].errors).toEqual([]);
+  expect(result.contracts?.[0].sdl).toMatchInlineSnapshot(`
+    type User {
+      id: ID!
+      creditScore: Int
+    }
+
+    type Query {
+      user: User
+    }
+  `);
+});
+
+test('include with exclude is possible', async () => {
+  const result = await client.composeAndValidate.mutate({
+    type: 'federation',
+    native: true,
+    schemas: [
+      {
+        raw: /* GraphQL */ `
+          extend schema
+            @link(url: "https://specs.apollo.dev/link/v1.0")
+            @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key", "@tag"])
+
+          type Query {
+            user: User @tag(name: "public")
+          }
+
+          type User @key(fields: "id") @tag(name: "public") {
+            id: ID!
+            ssn: String @tag(name: "private")
+          }
+        `,
+        source: 'user.graphql',
+        url: 'https://localhost:3000/graphql',
+      },
+    ],
+    external: null,
+    contracts: [
+      {
+        id: 'foo',
+        filter: {
+          removeUnreachableTypesFromPublicApiSchema: false,
+          exclude: ['private'],
+          include: ['public'],
+        },
+      },
+    ],
+  });
+
+  expect(result.errors).toEqual([]);
+  expect(result.contracts?.[0].errors).toEqual([]);
+  expect(result.contracts?.[0].sdl).toMatchInlineSnapshot(`
+    type Query {
+      user: User
+    }
+
+    type User {
+      id: ID!
+    }
+  `);
+});

--- a/integration-tests/tests/schema/contracts.spec.ts
+++ b/integration-tests/tests/schema/contracts.spec.ts
@@ -507,7 +507,10 @@ test('@external fields are always included if exclude @tag is used', async () =>
         raw: /* GraphQL */ `
           extend schema
             @link(url: "https://specs.apollo.dev/link/v1.0")
-            @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key", "@external", "@requires"])
+            @link(
+              url: "https://specs.apollo.dev/federation/v2.8"
+              import: ["@key", "@external", "@requires"]
+            )
 
           type User @key(fields: "id") {
             id: ID!
@@ -517,7 +520,7 @@ test('@external fields are always included if exclude @tag is used', async () =>
         `,
         source: 'credit.graphql',
         url: 'https://localhost:3001/graphql',
-      }
+      },
     ],
     external: null,
     contracts: [
@@ -573,7 +576,10 @@ test('@external fields are always included if include @tag is used', async () =>
         raw: /* GraphQL */ `
           extend schema
             @link(url: "https://specs.apollo.dev/link/v1.0")
-            @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key", "@external", "@requires", "@tag"])
+            @link(
+              url: "https://specs.apollo.dev/federation/v2.8"
+              import: ["@key", "@external", "@requires", "@tag"]
+            )
 
           type User @key(fields: "id") {
             id: ID!
@@ -583,7 +589,7 @@ test('@external fields are always included if include @tag is used', async () =>
         `,
         source: 'credit.graphql',
         url: 'https://localhost:3001/graphql',
-      }
+      },
     ],
     external: null,
     contracts: [

--- a/packages/services/schema/src/lib/federation-tag-extraction.ts
+++ b/packages/services/schema/src/lib/federation-tag-extraction.ts
@@ -111,6 +111,7 @@ export function applyTagFilterToInaccessibleTransformOnSubgraphSchema(
     '@inaccessible',
   );
   const tagDirectiveName = resolveImportName('https://specs.apollo.dev/federation', '@tag');
+  const externalDirectiveName = resolveImportName('https://specs.apollo.dev/federation', '@external');
 
   function getTagsForSchemaCoordinate(coordinate: string) {
     return tagRegister.get(coordinate) ?? new Set();
@@ -140,6 +141,11 @@ export function applyTagFilterToInaccessibleTransformOnSubgraphSchema(
     fieldLikeNode: InputValueDefinitionNode | FieldDefinitionNode,
     node: InputValueDefinitionNode,
   ) {
+    // Check for external tag because we cannot contribute directives to external fields.
+    if (node.directives?.find(d => d.name.value === externalDirectiveName)) {
+      return node;
+    }
+
     const tagsOnNode = getTagsForSchemaCoordinate(
       `${objectLikeNode.name.value}.${fieldLikeNode.name.value}(${node.name.value}:)`,
     );
@@ -210,6 +216,11 @@ export function applyTagFilterToInaccessibleTransformOnSubgraphSchema(
                 fieldArgumentHandler(node, fieldNode, argumentNode),
               ),
             } as FieldDefinitionNode;
+          }
+
+          // Check for external tag because we cannot contribute directives to external fields.
+          if (fieldNode.directives?.find(d => d.name.value === externalDirectiveName)) {
+            return fieldNode;
           }
 
           if (

--- a/packages/services/schema/src/lib/federation-tag-extraction.ts
+++ b/packages/services/schema/src/lib/federation-tag-extraction.ts
@@ -111,7 +111,10 @@ export function applyTagFilterToInaccessibleTransformOnSubgraphSchema(
     '@inaccessible',
   );
   const tagDirectiveName = resolveImportName('https://specs.apollo.dev/federation', '@tag');
-  const externalDirectiveName = resolveImportName('https://specs.apollo.dev/federation', '@external');
+  const externalDirectiveName = resolveImportName(
+    'https://specs.apollo.dev/federation',
+    '@external',
+  );
 
   function getTagsForSchemaCoordinate(coordinate: string) {
     return tagRegister.get(coordinate) ?? new Set();


### PR DESCRIPTION
### Background

https://linear.app/the-guild/issue/CONSOLE-1322/investigate-errors-with-public-contract-field-tagging

External fields cannot have `@tag` or `@inaccessible` added to them. Currently, "include" contracts require a `@tag` to avoid adding an `@inaccessible` directive. So an "include" contract cannot have external field unless it's marked with the tag in the non-external subgraph.

### Description

This fixes this case by not running the contract logic on external fields. The accessibility lies with the non-externalized definition.
