### PR TITLE
fix: do not apply contract logic on external object's fields

### DIFF
--- a/packages/services/schema/src/lib/__tests__/federation-tag-extraction.spec.ts
+++ b/packages/services/schema/src/lib/__tests__/federation-tag-extraction.spec.ts
@@ -449,6 +449,38 @@ describe('applyTagFilterToInaccessibleTransformOnSubgraphSchema', () => {
         }
       `);
     });
+
+    test('external objects do not apply inaccessible based on tags', () => {
+      const filter: Federation2SubgraphDocumentNodeByTagsFilter = {
+        include: new Set(['public']),
+        exclude: new Set(),
+      };
+      const sdl = parse(/* GraphQL */ `
+        extend schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@external"])
+
+        type Position @external {
+          x: Int!
+          y: Int!
+        }
+      `);
+
+      const output = applyTagFilterToInaccessibleTransformOnSubgraphSchema(
+        sdl,
+        buildSchemaCoordinateTagRegister([sdl]),
+        filter,
+      );
+
+      expect(print(output.typeDefs)).toMatchInlineSnapshot(`
+        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@external"])
+
+        type Position @external {
+          x: Int!
+          y: Int!
+        }
+      `);
+    });
   });
 
   describe('interface type', () => {

--- a/packages/services/schema/src/lib/federation-tag-extraction.ts
+++ b/packages/services/schema/src/lib/federation-tag-extraction.ts
@@ -144,11 +144,6 @@ export function applyTagFilterToInaccessibleTransformOnSubgraphSchema(
     fieldLikeNode: InputValueDefinitionNode | FieldDefinitionNode,
     node: InputValueDefinitionNode,
   ) {
-    // Check for external tag because we cannot contribute directives to external fields.
-    if (node.directives?.find(d => d.name.value === externalDirectiveName)) {
-      return node;
-    }
-
     const tagsOnNode = getTagsForSchemaCoordinate(
       `${objectLikeNode.name.value}.${fieldLikeNode.name.value}(${node.name.value}:)`,
     );
@@ -204,6 +199,7 @@ export function applyTagFilterToInaccessibleTransformOnSubgraphSchema(
 
     for (const node of nodes) {
       const tagsOnNode = getTagsForSchemaCoordinate(node.name.value);
+      const nodeIsExternal = !!node.directives?.find(d => d.name.value === externalDirectiveName);
 
       let newNode = {
         ...node,
@@ -222,7 +218,10 @@ export function applyTagFilterToInaccessibleTransformOnSubgraphSchema(
           }
 
           // Check for external tag because we cannot contribute directives to external fields.
-          if (fieldNode.directives?.find(d => d.name.value === externalDirectiveName)) {
+          const fieldIsExternal = !!fieldNode.directives?.find(
+            d => d.name.value === externalDirectiveName,
+          );
+          if (nodeIsExternal || fieldIsExternal) {
             return fieldNode;
           }
 


### PR DESCRIPTION
### Background

Requires federation-composition upgrade https://github.com/graphql-hive/federation-composition/pull/167

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

A recent change fixed a bug with `@external` fields for contracts. This extends that fix to objects.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
