### PR TITLE
docs: Add delete target docs

### DIFF
--- a/packages/web/docs/src/content/graphql-api/target-management.mdx
+++ b/packages/web/docs/src/content/graphql-api/target-management.mdx
@@ -142,3 +142,20 @@ mutation UpdateTargetGraphQLEndpointUrl($input: UpdateTargetDangerousChangeClass
   }
 }
 ```
+
+## Delete a Target
+
+Use the `Mutation.deleteTarget` field for deleting a target within a project.
+
+```graphql
+mutation DeleteTarget($input: DeleteTargetInput!) {
+  deleteTarget(input: $input) {
+    ok {
+      deletedTargetId
+    }
+    error {
+      message
+    }
+  }
+}
+```


### PR DESCRIPTION
### Background

Delete target is public but is missing from our docs.

### Description

Adds doc with example operation
