### PR TITLE
Hive json default

### DIFF
--- a/.changeset/swift-parents-divide.md
+++ b/.changeset/swift-parents-divide.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+fix fallback when hive.json is used but does not provide the requested value

--- a/packages/libraries/cli/src/base-command.ts
+++ b/packages/libraries/cli/src/base-command.ts
@@ -153,7 +153,7 @@ export default abstract class BaseCommand<T extends typeof Command> extends Comm
     } else {
       const configValue = this._userConfig!.get(key) as GetConfigurationValueType<TKey>;
 
-      if (configValue !== undefined && configValue !== null) {
+      if (configValue != null) {
         value = configValue;
       } else if (defaultValue) {
         value = defaultValue;

--- a/packages/libraries/cli/src/base-command.ts
+++ b/packages/libraries/cli/src/base-command.ts
@@ -151,11 +151,9 @@ export default abstract class BaseCommand<T extends typeof Command> extends Comm
     } else if (envName && env[envName] !== undefined) {
       value = env[envName] as TArgs[keyof TArgs] as NonNullable<GetConfigurationValueType<TKey>>;
     } else {
-      const configValue = this._userConfig!.get(key) as NonNullable<
-        GetConfigurationValueType<TKey>
-      >;
+      const configValue = this._userConfig!.get(key) as GetConfigurationValueType<TKey>;
 
-      if (configValue !== undefined) {
+      if (configValue !== undefined && configValue !== null) {
         value = configValue;
       } else if (defaultValue) {
         value = defaultValue;

--- a/packages/web/docs/src/content/gateway/other-features/security/demand-control.mdx
+++ b/packages/web/docs/src/content/gateway/other-features/security/demand-control.mdx
@@ -62,8 +62,8 @@ export const gatewayConfig = defineConfig({
 
 When a query is planned by the gateway,
 
-- For each operation, the `operationTypeCost` function is called with the operation type. (By default
-  only mutations have a cost `10`)
+- For each operation, the `operationTypeCost` function is called with the operation type. (By
+  default only mutations have a cost `10`)
 - For each field in the operation, the `fieldCost` function is called with the field node. (By
   default fields have a cost of `0`)
 - For each type in the operation, the `typeCost` function is called with the type. (By default


### PR DESCRIPTION
### Background

If the hive.json is used but a specific key is not provided, then the Config.get logic returns null, not undefined.
`packages/libraries/cli/src/helpers/config.ts`

This causes the fallback logic to not run and the value to be set to null in this case.

### Description

This change checks for null and undefined before falling back to the defaultValue.
