### PR TITLE
fix: correct selecting "all" app deployments when creating an access token

### DIFF
--- a/.changeset/late-rules-fail.md
+++ b/.changeset/late-rules-fail.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Fix selecting "All" app deployments in target when creating an access token

--- a/packages/services/api/src/modules/organization/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Organization.ts
@@ -207,8 +207,12 @@ export const Organization: Pick<
   availableMemberPermissionGroups: () => {
     return OrganizationMemberPermissions.permissionGroups;
   },
-  availableOrganizationAccessTokenPermissionGroups: () => {
-    return OrganizationAccessTokensPermissions.permissionGroups;
+  availableOrganizationAccessTokenPermissionGroups: async organization => {
+    const permissionGroups = OrganizationAccessTokensPermissions.permissionGroups;
+    if (!organization.featureFlags.appDeployments) {
+      return permissionGroups.filter(p => p.id !== 'app-deployments');
+    }
+    return permissionGroups;
   },
   accessTokens: async (organization, args, { injector }) => {
     return injector.get(OrganizationAccessTokens).getPaginated({

--- a/packages/web/app/src/components/organization/members/resource-selector.tsx
+++ b/packages/web/app/src/components/organization/members/resource-selector.tsx
@@ -517,7 +517,7 @@ export function ResourceSelector(props: {
     const targetId = targetState.activeTarget.targetSelection.targetId;
 
     if (
-      targetState.activeTarget.targetSelection.services.mode ===
+      targetState.activeTarget.targetSelection.appDeployments.mode ===
       GraphQLSchema.ResourceAssignmentModeType.All
     ) {
       return {
@@ -700,25 +700,30 @@ export function ResourceSelector(props: {
                     )}
                   </span>
                   {/** Service All / Granular Toggle */}
-                  {serviceState && serviceState !== 'none' && (
-                    <div className="ml-auto text-xs">
-                      <button
-                        className={cn(serviceState.selection !== '*' && 'text-orange-500')}
-                        onClick={serviceState.setGranular}
-                      >
-                        Select
-                      </button>
-                      {' / '}
-                      <button
-                        className={cn('mr-1', serviceState.selection === '*' && 'text-orange-500')}
-                        onClick={serviceState.setAll}
-                      >
-                        All
-                      </button>
-                    </div>
-                  )}
+                  {serviceState &&
+                    serviceState !== 'none' &&
+                    serviceAppsState === ServicesAppsState.service && (
+                      <div className="ml-auto text-xs">
+                        <button
+                          className={cn(serviceState.selection !== '*' && 'text-orange-500')}
+                          onClick={serviceState.setGranular}
+                        >
+                          Select
+                        </button>
+                        {' / '}
+                        <button
+                          className={cn(
+                            'mr-1',
+                            serviceState.selection === '*' && 'text-orange-500',
+                          )}
+                          onClick={serviceState.setAll}
+                        >
+                          All
+                        </button>
+                      </div>
+                    )}
                   {/** Apps All / Granular Toggle */}
-                  {appsState && (
+                  {appsState && serviceAppsState === ServicesAppsState.apps && (
                     <div className="ml-auto text-xs">
                       <button
                         className={cn(appsState.selection !== '*' && 'text-orange-500')}
@@ -949,7 +954,7 @@ export function ResourceSelector(props: {
                           </div>
                         ) : appsState.selection === '*' ? (
                           <div className="text-muted-foreground px-2 text-xs">
-                            Access to all services in target granted.
+                            Access to all apps in target granted.
                           </div>
                         ) : (
                           <>

--- a/packages/web/app/src/components/organization/settings/access-tokens/create-access-token-sheet-content.tsx
+++ b/packages/web/app/src/components/organization/settings/access-tokens/create-access-token-sheet-content.tsx
@@ -170,12 +170,14 @@ export function CreateAccessTokenSheetContent(
         });
       }
       return;
-    } else if (result.error) {
+    }
+    if (result.error) {
       toast({
         variant: 'destructive',
         title: 'An error occured',
         description: 'Something went wrong. Try again later.',
       });
+      return;
     }
   }
 

--- a/packages/web/app/src/components/organization/settings/access-tokens/create-access-token-sheet-content.tsx
+++ b/packages/web/app/src/components/organization/settings/access-tokens/create-access-token-sheet-content.tsx
@@ -170,6 +170,12 @@ export function CreateAccessTokenSheetContent(
         });
       }
       return;
+    } else if (result.error) {
+      toast({
+        variant: 'destructive',
+        title: 'An error occured',
+        description: 'Something went wrong. Try again later.',
+      });
     }
   }
 

--- a/packages/web/docs/src/content/gateway/logging-and-error-handling.mdx
+++ b/packages/web/docs/src/content/gateway/logging-and-error-handling.mdx
@@ -74,7 +74,8 @@ only log info, warn and error messages.
 By default, Hive Gateway uses the built-in `console` logger. However, you can also integrate Hive
 Gateway with [Winston](https://github.com/winstonjs/winston) on Node.js environments.
 
-You need to install `winston` and `@graphql-hive/logger-winston` packages to use Winston with Hive Gateway.
+You need to install `winston` and `@graphql-hive/logger-winston` packages to use Winston with Hive
+Gateway.
 
 ```sh npm2yarn
 npm i winston @graphql-hive/logger-winston

--- a/packages/web/docs/src/content/gateway/other-features/security/demand-control.mdx
+++ b/packages/web/docs/src/content/gateway/other-features/security/demand-control.mdx
@@ -62,8 +62,8 @@ export const gatewayConfig = defineConfig({
 
 When a query is planned by the gateway,
 
-- For each operation, the `operationTypeCost` function is called with the operation type. (By default
-  only mutations have a cost `10`)
+- For each operation, the `operationTypeCost` function is called with the operation type. (By
+  default only mutations have a cost `10`)
 - For each field in the operation, the `fieldCost` function is called with the field node. (By
   default fields have a cost of `0`)
 - For each type in the operation, the `typeCost` function is called with the type. (By default

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3599,6 +3599,7 @@ packages:
 
   '@fastify/vite@6.0.7':
     resolution: {integrity: sha512-+dRo9KUkvmbqdmBskG02SwigWl06Mwkw8SBDK1zTNH6vd4DyXbRvI7RmJEmBkLouSU81KTzy1+OzwHSffqSD6w==}
+    bundledDependencies: []
 
   '@floating-ui/core@1.2.6':
     resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}


### PR DESCRIPTION
### Background

https://github.com/graphql-hive/console/issues/6920

### Description

Fixes the toggling between services and app deployments to address the select / all buttons.
