### PR TITLE
fix: use consistent format for changelog dates

### DIFF
--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -30,12 +30,7 @@ for (const file of files) {
       .replace(/\/page$/, '');
 
     changelogRecords.push({
-      date: new Date(data.date).toLocaleDateString(undefined, {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-        calendar: 'gregory',
-      }),
+      date: new Date(data.date).toISOString().split('T')[0],
       href: `https://the-guild.dev/graphql/hive/product-updates/${pathname}`,
       title: data.title,
       description: data.description || '',


### PR DESCRIPTION
### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->
The current implementation of `generate-changelog.js` calls `Date.toLocaleString()` with `undefined` as the first parameter. This generates locale-dependent results, which can be non-ISO-8601-compliant and therefore error in the usages. This was generated in my case:

```ts
export const latestChangelog = [
  {
    "date": "2025년 9월 15일",
    "href": "https://the-guild.dev/graphql/hive/product-updates/2025-09-15-unused-deprecated-schema-graphql-api",
    "title": "Find unused Types and deprecated Fields via the Hive Console API",
    "description": "You can now automate finding deprecated fields and unused schema parts via the Hive Console GraphQL API."
  },
  {
    "date": "2025년 9월 3일",
    "href": "https://the-guild.dev/graphql/hive/product-updates/2025-09-03-schema-proposals",
    "title": "Schema Proposals Preview",
    "description": "A progress update on a much awaited feature -- Schema Proposals!"
  },
  {
    "date": "2025년 8월 10일",
    "href": "https://the-guild.dev/graphql/hive/product-updates/2025-08-10-public-graphql-api",
    "title": "Launching the Public Hive Console GraphQL API",
    "description": "Hive Console now has an official public API powered by GraphQL"
  },
  {
    "date": "2025년 5월 20일",
    "href": "https://the-guild.dev/graphql/hive/product-updates/2025-05-20-advanced-breaking-changes",
    "title": "Input Based Breaking Change Detection",
    "description": "Improvements to Hive's breaking change detection to make it easier and safer to migrate schemas."
  }
];
```

Which is indeed not ISO compliant.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
Replaced the `Date.toLocaleString()` usage in the script with `Date.toISOString()` to ensure the script generates date strings with consistent formatting.
