### PR TITLE
pass selected operations filter to query for pagination; add operation counts by selected client

### DIFF
--- a/.changeset/full-moments-sleep.md
+++ b/.changeset/full-moments-sleep.md
@@ -1,0 +1,5 @@
+---
+'hive': minor
+---
+
+add operation counts by selected client to insights filter

--- a/.changeset/moody-radios-switch.md
+++ b/.changeset/moody-radios-switch.md
@@ -1,0 +1,6 @@
+---
+'hive': patch
+---
+
+Fix paginated operations list filtering if there are many operations by passing a list of operation
+IDs to filter on

--- a/packages/web/app/src/components/target/insights/Filters.tsx
+++ b/packages/web/app/src/components/target/insights/Filters.tsx
@@ -39,9 +39,9 @@ function OperationsFilter({
   operationStatsConnection: FragmentType<
     typeof OperationsFilter_OperationStatsValuesConnectionFragment
   >;
-  clientOperationStatsConnection?: FragmentType<
-    typeof OperationsFilter_OperationStatsValuesConnectionFragment
-  > | undefined;
+  clientOperationStatsConnection?:
+    | FragmentType<typeof OperationsFilter_OperationStatsValuesConnectionFragment>
+    | undefined;
   selected?: string[];
 }): ReactElement {
   const operations = useFragment(
@@ -49,10 +49,12 @@ function OperationsFilter({
     operationStatsConnection,
   );
 
-  const clientFilteredOperations = clientOperationStatsConnection ? useFragment(
-    OperationsFilter_OperationStatsValuesConnectionFragment,
-    clientOperationStatsConnection,
-  ) : null;
+  const clientFilteredOperations = clientOperationStatsConnection
+    ? useFragment(
+        OperationsFilter_OperationStatsValuesConnectionFragment,
+        clientOperationStatsConnection,
+      )
+    : null;
 
   function getOperationHashes() {
     const items: string[] = [];
@@ -112,7 +114,9 @@ function OperationsFilter({
   const renderRow = useCallback<ComponentType<ListChildComponentProps>>(
     ({ index, style }) => {
       const operation = visibleOperations[index].node;
-      const clientOpStats = clientFilteredOperations?.edges.find(e => e.node.operationHash === operation.operationHash)?.node;
+      const clientOpStats = clientFilteredOperations?.edges.find(
+        e => e.node.operationHash === operation.operationHash,
+      )?.node;
 
       return (
         <OperationRow
@@ -168,7 +172,11 @@ function OperationsFilter({
             </Button>
           </div>
           <div className="grow pl-1">
-            {clientFilteredOperations && <div className='text-right text-gray-600 text-xs'><span className='text-gray-500'>selected</span> / all clients</div>}
+            {clientFilteredOperations && (
+              <div className="text-right text-xs text-gray-600">
+                <span className="text-gray-500">selected</span> / all clients
+              </div>
+            )}
             <AutoSizer>
               {({ height, width }) =>
                 !height || !width ? (
@@ -210,7 +218,8 @@ const OperationsFilterContainer_OperationStatsQuery = graphql(`
           ...OperationsFilter_OperationStatsValuesConnectionFragment
         }
       }
-      clientOperationStats: operationsStats(period: $period, filter: $filter) @include(if: $hasFilter) {
+      clientOperationStats: operationsStats(period: $period, filter: $filter)
+        @include(if: $hasFilter) {
         operations {
           edges {
             __typename
@@ -241,7 +250,7 @@ function OperationsFilterContainer({
   organizationSlug: string;
   projectSlug: string;
   targetSlug: string;
-  clientNames?: string[],
+  clientNames?: string[];
 }): ReactElement | null {
   const [query, refresh] = useQuery({
     query: OperationsFilterContainer_OperationStatsQuery,
@@ -305,14 +314,19 @@ function OperationRow({
 }: {
   operationStats: FragmentType<typeof OperationRow_OperationStatsValuesFragment>;
   /** Stats for the operation filtered by the selected clients */
-  clientOperationStats?: FragmentType<typeof OperationRow_OperationStatsValuesFragment> | null | false;
+  clientOperationStats?:
+    | FragmentType<typeof OperationRow_OperationStatsValuesFragment>
+    | null
+    | false;
   selected: boolean;
   onSelect(id: string, selected: boolean): void;
   style: any;
 }): ReactElement {
   const operation = useFragment(OperationRow_OperationStatsValuesFragment, operationStats);
   const requests = useFormattedNumber(operation.count);
-  const clientsOperation = clientOperationStats ? useFragment(OperationRow_OperationStatsValuesFragment, clientOperationStats) : undefined;
+  const clientsOperation = clientOperationStats
+    ? useFragment(OperationRow_OperationStatsValuesFragment, clientOperationStats)
+    : undefined;
   const hasClientOperation = clientOperationStats !== false;
   const clientsRequests = clientsOperation ? useFormattedNumber(clientsOperation.count) : null;
   const hash = operation.operationHash || '';
@@ -324,11 +338,16 @@ function OperationRow({
 
   const Totals = () => {
     if (hasClientOperation) {
-      return <div className="shrink-0 text-right text-gray-500 flex"><span>{clientsRequests ?? 0}</span><span className='ml-1 truncate text-gray-600'>/ {requests}</span></div>;
+      return (
+        <div className="flex shrink-0 text-right text-gray-500">
+          <span>{clientsRequests ?? 0}</span>
+          <span className="ml-1 truncate text-gray-600">/ {requests}</span>
+        </div>
+      );
     } else {
       return <div className="shrink-0 text-right text-gray-600">{requests}</div>;
     }
-  }
+  };
 
   return (
     <div style={style} className="flex items-center gap-4 truncate">
@@ -338,7 +357,7 @@ function OperationRow({
         className="flex w-full cursor-pointer items-center justify-between gap-4 overflow-hidden"
       >
         <span className="grow overflow-hidden text-ellipsis">{operation.name}</span>
-        <Totals/>
+        <Totals />
       </label>
     </div>
   );
@@ -359,7 +378,7 @@ export function OperationsFilterTrigger({
   organizationSlug: string;
   projectSlug: string;
   targetSlug: string;
-  clientNames?: string[],
+  clientNames?: string[];
 }): ReactElement {
   const [isOpen, toggle] = useToggle();
 

--- a/packages/web/app/src/components/target/insights/Filters.tsx
+++ b/packages/web/app/src/components/target/insights/Filters.tsx
@@ -344,9 +344,8 @@ function OperationRow({
           <span className="ml-1 truncate text-gray-600">/ {requests}</span>
         </div>
       );
-    } else {
-      return <div className="shrink-0 text-right text-gray-600">{requests}</div>;
     }
+    return <div className="shrink-0 text-right text-gray-600">{requests}</div>;
   };
 
   return (

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -241,7 +241,7 @@ function OperationsTable({
       )}
     >
       <Section.Title>Operations</Section.Title>
-      <Section.Subtitle>List of all operations with their statistics</Section.Subtitle>
+      <Section.Subtitle>List of all operations with their statistics, filtered by selected clients.</Section.Subtitle>
 
       <Table>
         <THead>

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -241,7 +241,9 @@ function OperationsTable({
       )}
     >
       <Section.Title>Operations</Section.Title>
-      <Section.Subtitle>List of all operations with their statistics, filtered by selected clients.</Section.Subtitle>
+      <Section.Subtitle>
+        List of all operations with their statistics, filtered by selected clients.
+      </Section.Subtitle>
 
       <Table>
         <THead>

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -384,7 +384,6 @@ const OperationsTableContainer_OperationsStatsFragment = graphql(`
 `);
 
 function OperationsTableContainer({
-  operationsFilter,
   organizationSlug,
   projectSlug,
   targetSlug,
@@ -395,7 +394,6 @@ function OperationsTableContainer({
   ...props
 }: {
   operationStats: FragmentType<typeof OperationsTableContainer_OperationsStatsFragment> | null;
-  operationsFilter: readonly string[];
   organizationSlug: string;
   projectSlug: string;
   targetSlug: string;
@@ -549,7 +547,6 @@ export function OperationsList({
     >
       <OperationsTableContainer
         operationStats={query.data?.target?.operationsStats ?? null}
-        operationsFilter={operationsFilter}
         className={className}
         setClientFilter={setClientFilter}
         clientFilter={clientFilter}

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -410,13 +410,6 @@ function OperationsTableContainer({
     const records: Operation[] = [];
     if (operationStats) {
       for (const { node: op } of operationStats.operations.edges) {
-        if (
-          operationsFilter.length > 0 &&
-          op.operationHash &&
-          !operationsFilter.includes(op.operationHash)
-        ) {
-          continue;
-        }
         records.push({
           id: op.id,
           name: op.name,
@@ -434,7 +427,7 @@ function OperationsTableContainer({
     }
 
     return records;
-  }, [operationStats?.operations.edges, operationsFilter]);
+  }, [operationStats?.operations.edges]);
 
   const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 20 });
 

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -517,7 +517,8 @@ export function OperationsList({
   projectSlug: string;
   targetSlug: string;
   period: DateRangeInput;
-  operationsFilter: readonly string[];
+  /** Operation IDs to filter on */
+  operationsFilter: string[];
   clientNamesFilter: string[];
   selectedPeriod: null | { to: string; from: string };
 }): ReactElement {
@@ -532,6 +533,7 @@ export function OperationsList({
       },
       period,
       filter: {
+        operationIds: operationsFilter,
         clientNames: clientNamesFilter,
       },
     },

--- a/packages/web/app/src/lib/urql.ts
+++ b/packages/web/app/src/lib/urql.ts
@@ -51,6 +51,7 @@ export const urqlClient = createClient({
         ClientStats: noKey,
         ClientStatsValues: noKey,
         OperationsStats: noKey,
+        OperationStatsValues: noKey,
         DurationValues: noKey,
         OrganizationPayload: noKey,
         SchemaChange: noKey,

--- a/packages/web/app/src/pages/target-insights.tsx
+++ b/packages/web/app/src/pages/target-insights.tsx
@@ -54,6 +54,7 @@ function OperationsView({
             period={dateRangeController.resolvedRange}
             selected={selectedOperations}
             onFilter={setSelectedOperations}
+            clientNames={selectedClients}
           />
           <ClientsFilterTrigger
             organizationSlug={organizationSlug}

--- a/scripts/seed-local-env.ts
+++ b/scripts/seed-local-env.ts
@@ -20,6 +20,7 @@ const usageReportingEndpoint =
     : envName === 'dev'
       ? 'https://app.dev.graphql-hive.com/usage'
       : 'http://localhost:4001';
+const target = process.env.TARGET;
 
 console.log(`
   Environment:                ${envName}
@@ -55,6 +56,7 @@ const createInstance = (
       : false,
     usage: isUsageReportingEnabled
       ? {
+          target: target || undefined,
           clientInfo: () => ({
             name: 'Fake Hive Client',
             version: '1.1.1',
@@ -348,6 +350,7 @@ async function federation() {
           sdl: schemaInventory,
           service: 'Inventory',
           url: 'https://inventory.localhost/graphql',
+          target: target ? { byId: target } : null,
         },
       },
     }),
@@ -369,6 +372,7 @@ async function federation() {
           sdl: schemaPandas,
           service: 'Panda',
           url: 'https://panda.localhost/graphql',
+          target: target ? { byId: target } : null,
         },
       },
     }),
@@ -391,6 +395,7 @@ async function federation() {
           sdl: schemaProducts,
           service: 'Products',
           url: 'https://products.localhost/graphql',
+          target: target ? { byId: target } : null,
         },
       },
     }),
@@ -413,6 +418,7 @@ async function federation() {
           sdl: schemaReviews,
           service: 'Reviews',
           url: 'https://reviews.localhost/graphql',
+          target: target ? { byId: target } : null,
         },
       },
     }),
@@ -435,6 +441,7 @@ async function federation() {
           sdl: schemaUsers,
           service: 'Users',
           url: 'https://users.localhost/graphql',
+          target: target ? { byId: target } : null,
         },
       },
     }),


### PR DESCRIPTION
### Background

https://linear.app/the-guild/issue/CONSOLE-1359/investigate-case-sensitivity-bug-in-hive-insights-tab

We received a report of filtering not behaving correctly on the operations list view.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

This passes the list of operations to the query so that the requested list includes only those operations. This is to avoid over fetching and having to filter client side.

And I've adjusted the dropdown for the operation list on insights so that it shows the number of requests for the selected clients filter, and the total count.

<img width="545" height="327" alt="Screenshot 2025-09-19 at 5 40 49 PM" src="https://github.com/user-attachments/assets/c970eeab-5b1a-4b96-8a7a-7f4b38959e62" />

If we like this, then we can apply the same logic to the client dropdown so that each accurately reflects what will be shown once filtered.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
