### PR TITLE
add progress log to cli app:create command

### DIFF
--- a/.changeset/bitter-goats-bow.md
+++ b/.changeset/bitter-goats-bow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+Add progress log to app:create


### PR DESCRIPTION
### Background

https://linear.app/the-guild/issue/CONSOLE-1378/hive-cli-appcreate-retries-and-never-exits-on-its-own

Investigating this shows that perhaps app:create is working but is taking a long time due to a large number of documents.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

This change adds a progress log so that in these cases, users can see why this command is taking so long and roughly estimate the remaining time.

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
