### PR TITLE
fix: explorer field filter input cursor reset

### DIFF
--- a/.changeset/stale-mice-push.md
+++ b/.changeset/stale-mice-push.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+fix explorer field input cursor reset

--- a/packages/web/app/src/components/target/explorer/provider.tsx
+++ b/packages/web/app/src/components/target/explorer/provider.tsx
@@ -152,11 +152,15 @@ export function useArgumentListToggle() {
 }
 
 export function usePeriodSelector() {
-  const { period, setPeriod, startDate, refreshResolvedPeriod } = useSchemaExplorerContext();
-  return {
-    setPeriod,
-    period,
-    startDate,
-    refreshResolvedPeriod,
-  };
+  const ctx = useSchemaExplorerContext();
+  const selector = useMemo(() => {
+    const { period, setPeriod, startDate, refreshResolvedPeriod } = ctx;
+    return {
+      setPeriod,
+      period,
+      startDate,
+      refreshResolvedPeriod,
+    };
+  }, [ctx]);
+  return selector;
 }


### PR DESCRIPTION
### Background

If you try typing in the current input, it will kick your cursor to the end of the input text. This is because it has an issue with rerendering that element which causes the input text state to get lost.

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

This fixes the re-rendering in several places by using callbacks/memos -- making the page more efficient and fixing the problem behavior.
