### PR TITLE
fix: oom for deprecated schema explorer

### DIFF
--- a/.changeset/wild-bags-know.md
+++ b/.changeset/wild-bags-know.md
@@ -1,0 +1,6 @@
+---
+'hive': patch
+---
+
+Prevent potential resource exhaustion in the deprecated schema explorer for large
+schemas.

--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -907,15 +907,6 @@ export class OperationsManager {
       typename: string;
     } & TargetSelector,
   ) {
-    await this.session.assertPerformAction({
-      action: 'project:describe',
-      organizationId: args.organizationId,
-      params: {
-        organizationId: args.organizationId,
-        projectId: args.projectId,
-      },
-    });
-
     const loader = this.getClientNamesPerCoordinateOfTypeLoader({
       target: args.targetId,
       period: args.period,

--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -1118,6 +1118,14 @@ export class OperationsManager {
   }: {
     period: DateRange;
   } & TargetSelector) {
+    this.logger.debug(
+      'Count coordinates of target. (organizationId=%s, projectId=%s, targetId=%s, period=%o)',
+      organization,
+      project,
+      target,
+      period,
+    );
+
     await this.session.assertPerformAction({
       action: 'project:describe',
       organizationId: organization,
@@ -1131,6 +1139,15 @@ export class OperationsManager {
       target,
       period,
     });
+
+    this.logger.debug(
+      '%d coordinates found. (organizationId=%s, projectId=%s, targetId=%s, period=%o)',
+      rows.length,
+      organization,
+      project,
+      target,
+      period,
+    );
 
     const records: {
       [coordinate: string]: {

--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -2140,6 +2140,8 @@ export class OperationsReader {
   }
 
   async countCoordinatesOfTarget({ target, period }: { target: string; period: DateRange }) {
+    this.logger.debug('Count coordinates of target. (targetId=%s, period=%o)', target, period);
+
     const result = await this.clickHouse.query<{
       coordinate: string;
       total: number;
@@ -2158,6 +2160,8 @@ export class OperationsReader {
         period,
       }),
     );
+
+    this.logger.debug('%d rows found. (targetId=%s, period=%o)', result.rows, target, period);
 
     return result.data.map(row => ({
       coordinate: row.coordinate,

--- a/packages/services/api/src/modules/schema/resolvers/DeprecatedSchemaExplorer.ts
+++ b/packages/services/api/src/modules/schema/resolvers/DeprecatedSchemaExplorer.ts
@@ -1,5 +1,5 @@
+import { memo } from '@graphql-hive/core/src/client/utils';
 import { OperationsManager } from '../../operations/providers/operations-manager';
-import { Logger } from '../../shared/providers/logger';
 import { buildGraphQLTypesFromSDL, withUsedByClients } from '../utils';
 import type { DeprecatedSchemaExplorerResolvers } from './../../../__generated__/types';
 
@@ -7,21 +7,25 @@ export const DeprecatedSchemaExplorer: DeprecatedSchemaExplorerResolvers = {
   types: ({ sdl, supergraph, usage }, _, { injector }) => {
     const operationsManager = injector.get(OperationsManager);
 
-    async function getStats(typename: string) {
-      const stats = await operationsManager.countCoordinatesOfTarget({
-        targetId: usage.targetId,
-        organizationId: usage.organizationId,
-        projectId: usage.projectId,
-        period: usage.period,
-      });
+    // NOTE: this function is super heavy.
+    const getStats = memo(
+      async function _getStats(typename: string) {
+        const stats = await operationsManager.countCoordinatesOfTarget({
+          targetId: usage.targetId,
+          organizationId: usage.organizationId,
+          projectId: usage.projectId,
+          period: usage.period,
+        });
 
-      return withUsedByClients(stats, {
-        selector: usage,
-        period: usage.period,
-        operationsManager,
-        typename,
-      });
-    }
+        return withUsedByClients(stats, {
+          selector: usage,
+          period: usage.period,
+          operationsManager,
+          typename,
+        });
+      },
+      arg => arg,
+    );
 
     return buildGraphQLTypesFromSDL(sdl, getStats, supergraph).sort((a, b) =>
       a.entity.name.localeCompare(b.entity.name),

--- a/packages/services/api/src/modules/schema/resolvers/DeprecatedSchemaExplorer.ts
+++ b/packages/services/api/src/modules/schema/resolvers/DeprecatedSchemaExplorer.ts
@@ -1,23 +1,6 @@
 import { OperationsManager } from '../../operations/providers/operations-manager';
-import { buildGraphQLTypesFromSDL, withUsedByClients } from '../utils';
+import { buildGraphQLTypesFromSDL, memo, withUsedByClients } from '../utils';
 import type { DeprecatedSchemaExplorerResolvers } from './../../../__generated__/types';
-
-function memo<R, A, K>(fn: (arg: A) => R, cacheKeyFn: (arg: A) => K): (arg: A) => R {
-  let memoizedResult: R | null = null;
-  let memoizedKey: K | null = null;
-
-  return (arg: A) => {
-    const currentKey = cacheKeyFn(arg);
-    if (memoizedKey === currentKey) {
-      return memoizedResult!;
-    }
-
-    memoizedKey = currentKey;
-    memoizedResult = fn(arg);
-
-    return memoizedResult;
-  };
-}
 
 export const DeprecatedSchemaExplorer: DeprecatedSchemaExplorerResolvers = {
   types: ({ sdl, supergraph, usage }, _, { injector }) => {

--- a/packages/services/api/src/modules/schema/resolvers/DeprecatedSchemaExplorer.ts
+++ b/packages/services/api/src/modules/schema/resolvers/DeprecatedSchemaExplorer.ts
@@ -1,4 +1,5 @@
 import { OperationsManager } from '../../operations/providers/operations-manager';
+import { Logger } from '../../shared/providers/logger';
 import { buildGraphQLTypesFromSDL, withUsedByClients } from '../utils';
 import type { DeprecatedSchemaExplorerResolvers } from './../../../__generated__/types';
 

--- a/packages/services/api/src/modules/schema/resolvers/DeprecatedSchemaExplorer.ts
+++ b/packages/services/api/src/modules/schema/resolvers/DeprecatedSchemaExplorer.ts
@@ -1,7 +1,23 @@
-import { memo } from '@graphql-hive/core/src/client/utils';
 import { OperationsManager } from '../../operations/providers/operations-manager';
 import { buildGraphQLTypesFromSDL, withUsedByClients } from '../utils';
 import type { DeprecatedSchemaExplorerResolvers } from './../../../__generated__/types';
+
+function memo<R, A, K>(fn: (arg: A) => R, cacheKeyFn: (arg: A) => K): (arg: A) => R {
+  let memoizedResult: R | null = null;
+  let memoizedKey: K | null = null;
+
+  return (arg: A) => {
+    const currentKey = cacheKeyFn(arg);
+    if (memoizedKey === currentKey) {
+      return memoizedResult!;
+    }
+
+    memoizedKey = currentKey;
+    memoizedResult = fn(arg);
+
+    return memoizedResult;
+  };
+}
 
 export const DeprecatedSchemaExplorer: DeprecatedSchemaExplorerResolvers = {
   types: ({ sdl, supergraph, usage }, _, { injector }) => {

--- a/packages/services/api/src/modules/schema/utils.ts
+++ b/packages/services/api/src/modules/schema/utils.ts
@@ -385,3 +385,20 @@ export function stringifyDefaultValue(value: unknown): string | null {
   }
   return null;
 }
+
+export function memo<R, A, K>(fn: (arg: A) => R, cacheKeyFn: (arg: A) => K): (arg: A) => R {
+  let memoizedResult: R | null = null;
+  let memoizedKey: K | null = null;
+
+  return (arg: A) => {
+    const currentKey = cacheKeyFn(arg);
+    if (memoizedKey === currentKey) {
+      return memoizedResult!;
+    }
+
+    memoizedKey = currentKey;
+    memoizedResult = fn(arg);
+
+    return memoizedResult;
+  };
+}


### PR DESCRIPTION
### Background

Some big GraphQL schemas exhaust resources via the deprecated schema explorer GraphQL types and fields.

### Description

Add memoization for the type stats lookup, to prevent allocating a lot of objects.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
