### PR TITLE
docs: fix missing docs redirects

### DIFF
--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -459,7 +459,7 @@ function LaboratoryPageContent(props: {
           <Title>Laboratory</Title>
           <Subtitle>Explore your GraphQL schema and run queries against your GraphQL API.</Subtitle>
           <p>
-            <DocsLink className="text-muted-foreground text-sm" href="/features/laboratory">
+            <DocsLink className="text-muted-foreground text-sm" href="/schema-registry/laboratory">
               Learn more about the Laboratory
             </DocsLink>
           </p>

--- a/packages/web/docs/next.config.js
+++ b/packages/web/docs/next.config.js
@@ -126,6 +126,11 @@ export default withGuildDocs({
       permanent: true,
     },
     {
+      source: '/docs/features/laboratory',
+      destination: '/docs/schema-registry/laboratory',
+      permanent: true,
+    },
+    {
       source: '/docs/features/laboratory/:path*',
       destination: '/docs/schema-registry/laboratory/:path*',
       permanent: true,
@@ -156,6 +161,11 @@ export default withGuildDocs({
       permanent: true,
     },
     {
+      source: '/docs/graphql-api',
+      destination: '/docs/api-reference/graphql-api',
+      permanent: true,
+    },
+    {
       source: '/docs/graphql-api/:path*',
       destination: '/docs/api-reference/graphql-api/:path*',
       permanent: true,
@@ -180,6 +190,11 @@ export default withGuildDocs({
       source: '/docs/self-hosting/federation-2',
       destination: '/docs/schema-registry/self-hosting/external-composition',
       permanent: true,
+    },
+    {
+      source: '/docs/integrations',
+      destination: '/docs/other-integrations',
+      permanent: false,
     },
     {
       source: '/docs/integrations/:path*',

--- a/packages/web/docs/next.config.js
+++ b/packages/web/docs/next.config.js
@@ -194,7 +194,7 @@ export default withGuildDocs({
     {
       source: '/docs/integrations',
       destination: '/docs/other-integrations',
-      permanent: false,
+      permanent: true,
     },
     {
       source: '/docs/integrations/:path*',


### PR DESCRIPTION
### Background

recent docs change adjusted paths

### Description

Fixes https://github.com/the-guild-org/website/issues/1864

Locally these redirects worked as they were. It's unclear why production behavior is different.