### PR TITLE
update stripe to show a message if it's blocked

### DIFF
--- a/.changeset/six-socks-turn.md
+++ b/.changeset/six-socks-turn.md
@@ -1,0 +1,5 @@
+---
+'hive': minor
+---
+
+add user message when stripe is blocked

--- a/packages/web/app/src/lib/billing/stripe.tsx
+++ b/packages/web/app/src/lib/billing/stripe.tsx
@@ -10,6 +10,7 @@ import { loadStripe } from '@stripe/stripe-js/pure';
 import { getStripePublicKey } from './stripe-public-key';
 
 export const HiveStripeWrapper: FC<{ children: ReactNode }> = ({ children }) => {
+  const [blocked, setBlocked] = useState(false);
   // eslint-disable-next-line react/hook-use-state -- we don't need setter
   const [stripe] = useState<ReturnType<typeof loadStripe> | void>(async () => {
     if (env.nodeEnv !== 'production') {
@@ -25,6 +26,7 @@ export const HiveStripeWrapper: FC<{ children: ReactNode }> = ({ children }) => 
     try {
       return await loadStripe(stripePublicKey);
     } catch (e) {
+      setBlocked(true);
       const message =
         e instanceof Error ? e.message : typeof e === 'string' ? e : 'Failed to load Stripe.js';
       captureMessage(message, {
@@ -33,6 +35,18 @@ export const HiveStripeWrapper: FC<{ children: ReactNode }> = ({ children }) => 
       return null;
     }
   });
+
+  if (blocked) {
+    return (
+      <div>
+        <p>We couldn’t load Stripe. This might be caused by an ad blocker or privacy extension.</p>
+        <p>
+          Please try disabling ad blocking for this site or allow requests to{' '}
+          <code>js.stripe.com</code>, then refresh the page.
+        </p>
+      </div>
+    );
+  }
 
   if (!stripe) {
     return children;


### PR DESCRIPTION
### Background

https://github.com/graphql-hive/console/issues/6635

Update to show a message if stripe is blocked

### Description

just return some text if stripe is blocked - just tested launching the block in a loadable page
<img width="843" height="184" alt="image" src="https://github.com/user-attachments/assets/6ce4e916-556a-42ab-8bd6-a352202d36c2" />


### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
