### PR TITLE
fix: qp was failing to render if flatten/condition are rendered as hi…

### DIFF
--- a/.changeset/cool-guests-sing.md
+++ b/.changeset/cool-guests-sing.md
@@ -1,0 +1,6 @@
+---
+'@graphql-hive/laboratory': patch
+'@graphql-hive/render-laboratory': patch
+---
+
+Proper handling of flatter/condition as high order nodes to not break lab qp

--- a/packages/libraries/laboratory/src/components/laboratory/operation.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/operation.tsx
@@ -208,6 +208,10 @@ export const ResponseQueryPlan = ({ historyItem }: { historyItem?: LaboratoryHis
     }
   }, [historyItem]);
 
+  if (!queryPlan) {
+    return null;
+  }
+
   return (
     <div className="relative size-full">
       <ToggleGroup

--- a/packages/libraries/laboratory/src/lib/query-plan/utils.tsx
+++ b/packages/libraries/laboratory/src/lib/query-plan/utils.tsx
@@ -610,9 +610,7 @@ function visitNode(
       break;
 
     case 'Flatten':
-      result = null;
-
-      visitNode(
+      result = visitNode(
         node.node,
         result,
         nodes,
@@ -674,10 +672,8 @@ function visitNode(
       break;
 
     case 'Condition':
-      result = null;
-
       if (node.ifClause) {
-        visitNode(
+        result = visitNode(
           node.ifClause,
           result,
           nodes,
@@ -689,9 +685,8 @@ function visitNode(
           </div>,
           renderConditionNode(node),
         );
-      }
-      if (node.elseClause) {
-        visitNode(
+      } else if (node.elseClause) {
+        result = visitNode(
           node.elseClause,
           result,
           nodes,


### PR DESCRIPTION
…gh order component and not child of parallel

### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

While testing gateway qp, found out that it was failing to render visual mode if flatten/config are rendered as hight order node.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

Applied fix to properly handle this scenario

### Checklist

<!---
We are following the OWASP Secure Coding Practices for developing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
