### PR TITLE
fix(cli): raise IntrospectionError (116) for introspection-disabled responses

### DIFF
--- a/packages/libraries/cli/src/helpers/errors.ts
+++ b/packages/libraries/cli/src/helpers/errors.ts
@@ -240,12 +240,12 @@ export class APIError extends HiveCLIError {
 }
 
 export class IntrospectionError extends HiveCLIError {
-  constructor() {
-    super(
-      ExitCode.ERROR,
-      errorCode(ErrorCategory.GENERIC, 16),
-      'Could not get introspection result from the service. Make sure introspection is enabled by the server.',
-    );
+  constructor(cause?: Error | string) {
+    const detail = cause instanceof Error ? cause.message : cause;
+    const message = detail
+      ? `Could not get introspection result from the service: ${detail}. Make sure introspection is enabled by the server.`
+      : 'Could not get introspection result from the service. Make sure introspection is enabled by the server.';
+    super(ExitCode.ERROR, errorCode(ErrorCategory.GENERIC, 16), message);
   }
 }
 

--- a/packages/libraries/cli/src/helpers/graphql-request.ts
+++ b/packages/libraries/cli/src/helpers/graphql-request.ts
@@ -5,6 +5,7 @@ import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import {
   APIError,
   HTTPError,
+  IntrospectionError,
   InvalidRegistryTokenError,
   isAggregateError,
   MissingArgumentsError,
@@ -93,6 +94,9 @@ export function graphqlRequest(config: {
         if (jsonData.errors[0].message === 'Invalid token provided') {
           throw new InvalidRegistryTokenError();
         }
+        if (isIntrospectionDisabledMessage(jsonData.errors[0].message)) {
+          throw new IntrospectionError(jsonData.errors[0].message);
+        }
 
         config.logger?.debug?.(jsonData.errors.map(String).join('\n'));
         throw new APIError(
@@ -108,4 +112,16 @@ export function graphqlRequest(config: {
 
 export function cleanRequestId(requestId?: string | null) {
   return requestId ? requestId.split(',')[0].trim() : undefined;
+}
+
+// Apollo Server, GraphQL Yoga, and others emit messages like
+// "GraphQL introspection is not allowed by Apollo Server..." or
+// "GraphQL introspection has been disabled, but the requested query contained..."
+// when introspection is turned off in production. Detecting this up front lets
+// us throw IntrospectionError (116) instead of a generic APIError (115) so
+// every CLI command that talks to the user's origin server surfaces a
+// consistent, actionable error code.
+export function isIntrospectionDisabledMessage(message: string | undefined | null): boolean {
+  if (!message) return false;
+  return /graphql\s+introspection\s+(is\s+not\s+allowed|has\s+been\s+disabled)/i.test(message);
 }


### PR DESCRIPTION
Fixes #8006

## What changed

When Apollo Server (or Yoga, or similar) rejects an introspection query, it returns a normal GraphQL response body whose first error is something like:

```
GraphQL introspection is not allowed by Apollo Server, but the query contained __schema or __type.
To enable introspection, pass introspection: true to ApolloServer in production
```

`graphqlRequest()` classified that as a generic `APIError` (code `115`), which pointed the user at "API error" documentation instead of "introspection disabled." The tell-tale server message was in the CLI output but the error code was misleading.

This PR detects the introspection-disabled message before the generic `APIError` fallback fires:

```ts
if (isIntrospectionDisabledMessage(jsonData.errors[0].message)) {
  throw new IntrospectionError(jsonData.errors[0].message);
}
```

`IntrospectionError` now accepts an optional cause so the server's original wording is preserved in the final message. The existing no-arg call sites in `introspect.ts` and `dev.ts` still compile.

The detection regex covers the two phrasings used across Apollo Server and GraphQL Yoga:

- `graphql introspection is not allowed ...`
- `graphql introspection has been disabled ...`

## Why it matters across commands

The fix lives in `graphqlRequest`, so every command that goes through it picks up the right code:

- `hive introspect <url>` already caught downstream errors and re-threw `IntrospectionError`, but only for the `loadSchema` path — requests via the federation loader's `_Service` probe were still surfacing as `APIError`. Now consistent.
- `hive schema check <url>` and `hive schema publish <url>` now also return `116` instead of `115` when the origin blocks introspection.

## Scope

- `packages/libraries/cli/src/helpers/graphql-request.ts` — one new condition before the generic throw, one new helper.
- `packages/libraries/cli/src/helpers/errors.ts` — `IntrospectionError` constructor now accepts an optional cause.

No public API surface change on the CLI; no behavior change for successful introspections or other error codes.
