### PR TITLE
fix: better reasons for abort controllers in lab and error handling

### DIFF
--- a/.changeset/fuzzy-clocks-tickle.md
+++ b/.changeset/fuzzy-clocks-tickle.md
@@ -1,0 +1,6 @@
+---
+'@graphql-hive/laboratory': patch
+'@graphql-hive/render-laboratory': patch
+---
+
+Better reasons for abort controllers in lab

--- a/packages/libraries/laboratory/src/lib/endpoint.ts
+++ b/packages/libraries/laboratory/src/lib/endpoint.ts
@@ -132,7 +132,7 @@ export const useEndpoint = (props: {
         try {
           await fetchSchema(intervalController.signal);
         } catch {
-          intervalController.abort();
+          intervalController.abort('Polling schema failed');
         }
       },
       5000,
@@ -140,7 +140,7 @@ export const useEndpoint = (props: {
     );
 
     return () => {
-      intervalController.abort();
+      intervalController.abort('Polling schema aborted');
     };
   }, [shouldPollSchema, fetchSchema]);
 

--- a/packages/libraries/laboratory/src/lib/operations.ts
+++ b/packages/libraries/laboratory/src/lib/operations.ts
@@ -456,7 +456,7 @@ export const useOperations = (
       setStopOperationsFunctions(prev => ({
         ...prev,
         [activeOperation.id]: () => {
-          abortController.abort();
+          abortController.abort('Operation aborted by user');
         },
       }));
 
@@ -505,6 +505,10 @@ export const useOperations = (
           delete newStopOperationsFunctions[activeOperation.id];
           return newStopOperationsFunctions;
         });
+
+        if (abortController.signal.aborted) {
+          return null;
+        }
 
         if (error instanceof Error) {
           return new GraphQLError(error.message);

--- a/packages/libraries/laboratory/src/lib/utils.ts
+++ b/packages/libraries/laboratory/src/lib/utils.ts
@@ -26,14 +26,14 @@ export async function asyncInterval(
   while (!signal?.aborted) {
     await fn();
 
-    await new Promise<void>((resolve, reject) => {
+    await new Promise<void>(resolve => {
       const timer = setTimeout(resolve, delay);
 
       signal?.addEventListener(
         'abort',
         () => {
           clearTimeout(timer);
-          reject(new DOMException('Aborted', 'AbortError'));
+          resolve();
         },
         { once: true },
       );


### PR DESCRIPTION
### Background

Hive console got spammed with abort controller in lab error recently

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

1. Better reasons for abort controllers
2. Better handling of aborted by user operation
3. asyncInterval to not throw DOMException when aborted by itself

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for developing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
