### PR TITLE
fix: show correct error code for introspection failure in dev command

### DIFF
--- a/.changeset/eight-mails-beg.md
+++ b/.changeset/eight-mails-beg.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+Show correct error code (116) with origin service for failed introspection result.

--- a/integration-tests/testkit/cli.ts
+++ b/integration-tests/testkit/cli.ts
@@ -294,7 +294,7 @@ export function createCLI(tokens: { readwrite: string; readonly: string }) {
     services: Array<{
       name: string;
       url: string;
-      sdl: string;
+      sdl?: string;
     }>;
     remote: boolean;
     write?: string;
@@ -317,8 +317,7 @@ export function createCLI(tokens: { readwrite: string; readonly: string }) {
             name,
             '--url',
             url,
-            '--schema',
-            await generateTmpFile(sdl, 'graphql'),
+            ...(sdl ? ['--schema', await generateTmpFile(sdl, 'graphql')] : []),
           ].join(' ');
         }),
       )),

--- a/integration-tests/tests/cli/dev.spec.ts
+++ b/integration-tests/tests/cli/dev.spec.ts
@@ -343,5 +343,6 @@ describe('dev --remote', () => {
     );
     // make sure correct error  code is being thrown
     await expect(cmd).rejects.toThrowError('[116]');
+    await expect(cmd).rejects.not.toThrow('[115]');
   });
 });

--- a/integration-tests/tests/cli/dev.spec.ts
+++ b/integration-tests/tests/cli/dev.spec.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { ProjectType } from 'testkit/gql/graphql';
 import { createCLI } from '../../testkit/cli';
 import { initSeed } from '../../testkit/seed';
+import { createHTTPGraphQLServer } from './introspect.spec';
 
 function tmpFile(extension: string) {
   const dir = tmpdir();
@@ -315,5 +316,32 @@ describe('dev --remote', () => {
 
     // The command should fail because the latest version contains a non-shareable field and we don't override the corrupted subgraph
     await expect(cmd).rejects.toThrowError('Non-shareable field');
+  });
+
+  test.concurrent('correct error on failed introspection', async ({ expect }) => {
+    const server = await createHTTPGraphQLServer();
+    const { createOrg } = await initSeed().createOwner();
+    const { createProject } = await createOrg();
+    const { createTargetAccessToken } = await createProject(ProjectType.Federation);
+    const { secret } = await createTargetAccessToken({});
+    const cli = createCLI({ readwrite: secret, readonly: secret });
+
+    const supergraph = tmpFile('graphql');
+    const cmd = cli.dev({
+      remote: true,
+      services: [
+        {
+          name: 'bar',
+          url: server.url + '/graphql-federation-no-introspection',
+        },
+      ],
+      write: supergraph.filepath,
+    });
+
+    await expect(cmd).rejects.toThrowError(
+      `Could not get introspection result from the service 'bar'`,
+    );
+    // make sure correct error  code is being thrown
+    await expect(cmd).rejects.toThrowError('[116]');
   });
 });

--- a/integration-tests/tests/cli/introspect.spec.ts
+++ b/integration-tests/tests/cli/introspect.spec.ts
@@ -2,10 +2,11 @@ import { AddressInfo } from 'node:net';
 import { parse } from 'graphql';
 import { createSchema, createYoga } from 'graphql-yoga';
 import { buildSubgraphSchema } from '@apollo/subgraph';
+import { useDisableIntrospection } from '@graphql-yoga/plugin-disable-introspection';
 import { createServer } from '@hive/service-common';
 import { introspect } from '../../testkit/cli';
 
-async function createHTTPGraphQLServer() {
+export async function createHTTPGraphQLServer() {
   const server = await createServer({
     sentryErrorHandler: false,
     log: {
@@ -98,6 +99,27 @@ async function createHTTPGraphQLServer() {
     ],
   });
 
+  const yogaNoIntrospection = createYoga({
+    graphqlEndpoint: '/graphql-federation-no-introspection',
+    logging: false,
+    schema: buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        extend type Query {
+          me: User
+          user(id: ID!): User
+          users: [User]
+        }
+
+        type User @key(fields: "id") {
+          id: ID!
+          name: String
+          username: String
+        }
+      `),
+    }),
+    plugins: [useDisableIntrospection()],
+  });
+
   server.route({
     // Bind to the Yoga's endpoint to avoid rendering on any path
     url: yoga.graphqlEndpoint,
@@ -124,6 +146,13 @@ async function createHTTPGraphQLServer() {
     url: yogaFederationProtected.graphqlEndpoint,
     method: ['GET', 'POST', 'OPTIONS'],
     handler: (req, reply) => yogaFederationProtected.handleNodeRequestAndResponse(req, reply),
+  });
+
+  server.route({
+    // Bind to the Yoga's endpoint to avoid rendering on any path
+    url: yogaNoIntrospection.graphqlEndpoint,
+    method: ['GET', 'POST', 'OPTIONS'],
+    handler: (req, reply) => yogaNoIntrospection.handleNodeRequestAndResponse(req, reply),
   });
 
   await server.listen({
@@ -258,4 +287,13 @@ test.concurrent('can introspect protected federation with header', async ({ expe
 
     union _Entity = User
   `);
+});
+
+test.concurrent('error handling on server with no introspection enabeld', async ({ expect }) => {
+  const server = await createHTTPGraphQLServer();
+  const command = introspect([server.url + '/graphql-federation-no-introspection']);
+  await expect(command).rejects.toThrowError(
+    'Could not get introspection result from the service.',
+  );
+  await expect(command).rejects.toThrowError('[115]');
 });

--- a/integration-tests/tests/cli/introspect.spec.ts
+++ b/integration-tests/tests/cli/introspect.spec.ts
@@ -289,7 +289,7 @@ test.concurrent('can introspect protected federation with header', async ({ expe
   `);
 });
 
-test.concurrent('error handling on server with no introspection enabeld', async ({ expect }) => {
+test.concurrent('error handling on server with no introspection enabled', async ({ expect }) => {
   const server = await createHTTPGraphQLServer();
   const command = introspect([server.url + '/graphql-federation-no-introspection']);
   await expect(command).rejects.toThrowError(

--- a/integration-tests/tests/cli/introspect.spec.ts
+++ b/integration-tests/tests/cli/introspect.spec.ts
@@ -295,5 +295,6 @@ test.concurrent('error handling on server with no introspection enabled', async 
   await expect(command).rejects.toThrowError(
     'Could not get introspection result from the service.',
   );
-  await expect(command).rejects.toThrowError('[115]');
+  await expect(command).rejects.toThrow('[116]');
+  await expect(command).rejects.not.toThrow('[115]');
 });

--- a/packages/libraries/cli/src/commands/dev.ts
+++ b/packages/libraries/cli/src/commands/dev.ts
@@ -490,7 +490,7 @@ export default class Dev extends Command<typeof Dev> {
         return {
           name: input.name,
           url: input.url,
-          sdl: await this.resolveSdlFromUrl(input.url),
+          sdl: await this.resolveSdlFromUrl(input.name, input.url),
           input: {
             kind: 'url' as const,
             url: input.url,
@@ -509,13 +509,16 @@ export default class Dev extends Command<typeof Dev> {
     return sdl;
   }
 
-  private async resolveSdlFromUrl(url: string) {
+  private async resolveSdlFromUrl(serviceName: string, url: string) {
     const sdl = await loadSchema('only-federation-introspection', url, {
       logger: this.logger,
+    }).catch(err => {
+      this.logFailure(err);
+      throw new IntrospectionError(serviceName);
     });
 
     if (!sdl) {
-      throw new IntrospectionError();
+      throw new IntrospectionError(serviceName);
     }
 
     return sdl;

--- a/packages/libraries/cli/src/helpers/errors.ts
+++ b/packages/libraries/cli/src/helpers/errors.ts
@@ -240,11 +240,11 @@ export class APIError extends HiveCLIError {
 }
 
 export class IntrospectionError extends HiveCLIError {
-  constructor() {
+  constructor(serviceName?: string) {
     super(
       ExitCode.ERROR,
       errorCode(ErrorCategory.GENERIC, 16),
-      'Could not get introspection result from the service. Make sure introspection is enabled by the server.',
+      `Could not get introspection result from the service${serviceName ? ` '${serviceName}'` : ''}. Make sure introspection is enabled by the server.`,
     );
   }
 }

--- a/packages/libraries/cli/src/helpers/graphql-request.ts
+++ b/packages/libraries/cli/src/helpers/graphql-request.ts
@@ -1,10 +1,11 @@
-import { print, type ExecutionResult } from 'graphql';
+import { print, type ExecutionResult, type GraphQLError } from 'graphql';
 import { http } from '@graphql-hive/core';
 import { LegacyLogger } from '@graphql-hive/core/typings/client/types';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import {
   APIError,
   HTTPError,
+  IntrospectionError,
   InvalidRegistryTokenError,
   isAggregateError,
   MissingArgumentsError,
@@ -93,6 +94,9 @@ export function graphqlRequest(config: {
         if (jsonData.errors[0].message === 'Invalid token provided') {
           throw new InvalidRegistryTokenError();
         }
+        if (isIntrospectionDisabledError(jsonData.errors[0])) {
+          throw new IntrospectionError();
+        }
 
         config.logger?.debug?.(jsonData.errors.map(String).join('\n'));
         throw new APIError(
@@ -108,4 +112,23 @@ export function graphqlRequest(config: {
 
 export function cleanRequestId(requestId?: string | null) {
   return requestId ? requestId.split(',')[0].trim() : undefined;
+}
+
+export function isIntrospectionDisabledError(error: GraphQLError): boolean {
+  // Default implementation - this is the string used by graphql-js and thus the majority of all other implementations
+  // as they use graphql-js as a reference.
+  // https://github.com/graphql/graphql-js/blob/8eb6383ae7447514343457abb2063c40e5dc81bc/src/validation/rules/custom/NoSchemaIntrospectionCustomRule.ts#L30
+  if (error.message.includes('GraphQL introspection has been disabled')) {
+    return true;
+  }
+  // Apollo Server
+  // https://github.com/apollographql/apollo-server/blob/19d0ffca703f85f0184532393aa3fff687f30bca/packages/server/src/validationRules/NoIntrospection.ts#L20
+  if (error.extensions['validationErrorCode'] === 'INTROSPECTION_DISABLED') {
+    return true;
+  }
+  // https://github.com/apollographql/apollo-server/blob/19d0ffca703f85f0184532393aa3fff687f30bca/packages/server/src/validationRules/NoIntrospection.ts#L15
+  if (error.message.includes('GraphQL introspection is not allowed')) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
### Background

Closes https://github.com/graphql-hive/console/issues/8006

### Description

The dev command did fail with API error instead of an introspection error in case a service can not be introspected. This resolves that scenario, improves the error message to include the service name and adds tests to avoid regressions
