### PR TITLE
feat: write app deployment manifest to CDN

### DIFF
--- a/.changeset/easy-nights-pick.md
+++ b/.changeset/easy-nights-pick.md
@@ -1,0 +1,6 @@
+---
+'hive': minor
+---
+
+Write app deployment manifest to CDN upon app activation and retirement. The app deployment manifest
+can be used to discover what hashes belong to an app deployment version.

--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -2217,6 +2217,18 @@ test('app deployment manifest is written to and accessible via CDN', async () =>
   }).then(res => res.expectNoGraphQLErrors());
   expect(addDocumentsToAppDeployment.error).toBeNull();
 
+  const cdnAccess = await createCdnAccess();
+  const persistedOperationUrl = `${cdnAccess.cdnUrl}/apps/app-name/app-version`;
+
+  let response = await fetch(persistedOperationUrl, {
+    method: 'GET',
+    headers: {
+      'X-Hive-CDN-Key': cdnAccess.secretAccessToken,
+    },
+  });
+  // before the app deployment is activated it shall not exist.
+  expect(response.status).toEqual(404);
+
   const { activateAppDeployment } = await execute({
     document: ActivateAppDeployment,
     variables: {
@@ -2229,14 +2241,13 @@ test('app deployment manifest is written to and accessible via CDN', async () =>
   }).then(res => res.expectNoGraphQLErrors());
   expect(activateAppDeployment.error).toBeNull();
 
-  const cdnAccess = await createCdnAccess();
-  const persistedOperationUrl = `${cdnAccess.cdnUrl}/apps/app-name/app-version`;
-  let response = await fetch(persistedOperationUrl, {
+  response = await fetch(persistedOperationUrl, {
     method: 'GET',
     headers: {
       'X-Hive-CDN-Key': cdnAccess.secretAccessToken,
     },
   });
+  expect(response.status).toEqual(200);
   let manifest = await response.json();
   expect(manifest).toMatchObject({
     appName: 'app-name',
@@ -2266,6 +2277,7 @@ test('app deployment manifest is written to and accessible via CDN', async () =>
       'X-Hive-CDN-Key': cdnAccess.secretAccessToken,
     },
   });
+  expect(response.status).toEqual(200);
   manifest = await response.json();
   expect(manifest).toMatchObject({
     appName: 'app-name',

--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -2157,6 +2157,125 @@ test('app deployment usage reporting', async () => {
   expect(data.target?.appDeployment?.lastUsed).toEqual(expect.any(String));
 });
 
+test('app deployment manifest is written to and accessible via CDN', async () => {
+  const { createOrg } = await initSeed().createOwner();
+  const { createProject, setFeatureFlag } = await createOrg();
+  await setFeatureFlag('appDeployments', true);
+  const { createTargetAccessToken, createCdnAccess } = await createProject();
+  const token = await createTargetAccessToken({});
+
+  const { createAppDeployment } = await execute({
+    document: CreateAppDeployment,
+    variables: {
+      input: {
+        appName: 'app-name',
+        appVersion: 'app-version',
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+  expect(createAppDeployment.error).toBeNull();
+
+  await token.publishSchema({
+    sdl: /* GraphQL */ `
+      type Query {
+        a: String
+        b: String
+        c: String
+        d: String
+      }
+    `,
+  });
+
+  const { addDocumentsToAppDeployment } = await execute({
+    document: AddDocumentsToAppDeployment,
+    variables: {
+      input: {
+        appName: 'app-name',
+        appVersion: 'app-version',
+        documents: [
+          {
+            hash: 'aaa',
+            body: 'query { a }',
+          },
+          {
+            hash: 'bbb',
+            body: 'query { b }',
+          },
+          {
+            hash: 'ccc',
+            body: 'query { c }',
+          },
+          {
+            hash: 'ddd',
+            body: 'query { d }',
+          },
+        ],
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+  expect(addDocumentsToAppDeployment.error).toBeNull();
+
+  const { activateAppDeployment } = await execute({
+    document: ActivateAppDeployment,
+    variables: {
+      input: {
+        appName: 'app-name',
+        appVersion: 'app-version',
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+  expect(activateAppDeployment.error).toBeNull();
+
+  const cdnAccess = await createCdnAccess();
+  const persistedOperationUrl = `${cdnAccess.cdnUrl}/apps/app-name/app-version`;
+  let response = await fetch(persistedOperationUrl, {
+    method: 'GET',
+    headers: {
+      'X-Hive-CDN-Key': cdnAccess.secretAccessToken,
+    },
+  });
+  let manifest = await response.json();
+  expect(manifest).toMatchObject({
+    appName: 'app-name',
+    appVersion: 'app-version',
+    documentHashes: ['aaa', 'bbb', 'ccc', 'ddd'],
+    id: expect.any(String),
+    isActive: true,
+  });
+
+  // Retire flow.
+
+  const { retireAppDeployment } = await execute({
+    document: RetireAppDeployment,
+    variables: {
+      input: {
+        appName: 'app-name',
+        appVersion: 'app-version',
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+  expect(retireAppDeployment.error).toBeNull();
+
+  response = await fetch(persistedOperationUrl, {
+    method: 'GET',
+    headers: {
+      'X-Hive-CDN-Key': cdnAccess.secretAccessToken,
+    },
+  });
+  manifest = await response.json();
+  expect(manifest).toMatchObject({
+    appName: 'app-name',
+    appVersion: 'app-version',
+    documentHashes: ['aaa', 'bbb', 'ccc', 'ddd'],
+    id: expect.any(String),
+    isActive: false,
+  });
+});
+
 test('activeAppDeployments returns empty list when no active deployments exist', async () => {
   const { createOrg, ownerToken } = await initSeed().createOwner();
   const { createProject, setFeatureFlag, organization } = await createOrg();

--- a/packages/services/api/src/modules/app-deployments/providers/app-deployments.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/app-deployments.ts
@@ -1,7 +1,11 @@
 import { differenceInCalendarDays, startOfDay, subDays } from 'date-fns';
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import { z } from 'zod';
-import { buildAppDeploymentIsEnabledKey } from '@hive/cdn-script/artifact-storage-reader';
+import {
+  AppDeploymentManifestModel,
+  buildAppDeploymentIsEnabledKey,
+  buildAppDeploymentManifestKey,
+} from '@hive/cdn-script/artifact-storage-reader';
 import {
   PostgresDatabasePool,
   psql,
@@ -366,6 +370,27 @@ export class AppDeployments {
     };
   }
 
+  private async _getAllDocumentHashesForAppDeployment(
+    appDeployment: AppDeploymentRecord,
+  ): Promise<Array<string>> {
+    return await this.clickhouse
+      .query({
+        query: cSql`
+        SELECT
+          DISTINCT "document_hash" AS "hash"
+        FROM
+          "app_deployment_documents"
+        WHERE
+          "app_deployment_id" = ${appDeployment.id}
+      `,
+        queryId: 'app-deployment-document-ids',
+        timeout: 10_000,
+      })
+      .then(res =>
+        z.array(z.object({ hash: z.string() }).transform(row => row.hash)).parse(res.data),
+      );
+  }
+
   async activateAppDeployment(args: {
     organizationId: string;
     targetId: string;
@@ -431,8 +456,11 @@ export class AppDeployments {
       };
     }
 
+    const appDeploymentDocumentHashes =
+      await this._getAllDocumentHashesForAppDeployment(appDeployment);
+
     for (const s3 of this.s3) {
-      const result = await s3.client.fetch(
+      let result = await s3.client.fetch(
         [
           s3.endpoint,
           s3.bucket,
@@ -456,6 +484,38 @@ export class AppDeployments {
 
       if (result.statusCode !== 200) {
         throw new Error(`Failed to enable app deployment: ${result.statusMessage}`);
+      }
+
+      result = await s3.client.fetch(
+        [
+          s3.endpoint,
+          s3.bucket,
+          buildAppDeploymentManifestKey(
+            appDeployment.targetId,
+            appDeployment.name,
+            appDeployment.version,
+          ),
+        ].join('/'),
+        {
+          method: 'PUT',
+          body: JSON.stringify({
+            id: appDeployment.id,
+            appName: appDeployment.name,
+            appVersion: appDeployment.version,
+            documentHashes: appDeploymentDocumentHashes.sort(),
+            isActive: true,
+          } satisfies z.TypeOf<typeof AppDeploymentManifestModel>),
+          headers: {
+            'content-type': 'application/json',
+          },
+          aws: {
+            signQuery: true,
+          },
+        },
+      );
+
+      if (result.statusCode !== 200) {
+        throw new Error(`Failed to write app manifest: ${result.statusMessage}`);
       }
     }
 
@@ -690,8 +750,11 @@ export class AppDeployments {
       }
     }
 
+    const appDeploymentDocumentHashes =
+      await this._getAllDocumentHashesForAppDeployment(appDeployment);
+
     for (const s3 of this.s3) {
-      const result = await s3.client.fetch(
+      let result = await s3.client.fetch(
         [
           s3.endpoint,
           s3.bucket,
@@ -721,6 +784,38 @@ export class AppDeployments {
         throw new Error(
           `Failed to disable app deployment. Request failed with status code "${result.statusMessage}".`,
         );
+      }
+
+      result = await s3.client.fetch(
+        [
+          s3.endpoint,
+          s3.bucket,
+          buildAppDeploymentManifestKey(
+            appDeployment.targetId,
+            appDeployment.name,
+            appDeployment.version,
+          ),
+        ].join('/'),
+        {
+          method: 'PUT',
+          body: JSON.stringify({
+            id: appDeployment.id,
+            appName: appDeployment.name,
+            appVersion: appDeployment.version,
+            documentHashes: appDeploymentDocumentHashes.sort(),
+            isActive: false,
+          } satisfies z.TypeOf<typeof AppDeploymentManifestModel>),
+          headers: {
+            'content-type': 'application/json',
+          },
+          aws: {
+            signQuery: true,
+          },
+        },
+      );
+
+      if (result.statusCode !== 200) {
+        throw new Error(`Failed to write app manifest: ${result.statusMessage}`);
       }
     }
 

--- a/packages/services/api/src/modules/app-deployments/providers/app-deployments.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/app-deployments.ts
@@ -376,13 +376,13 @@ export class AppDeployments {
     return await this.clickhouse
       .query({
         query: cSql`
-        SELECT
-          DISTINCT "document_hash" AS "hash"
-        FROM
-          "app_deployment_documents"
-        WHERE
-          "app_deployment_id" = ${appDeployment.id}
-      `,
+          SELECT
+            DISTINCT "document_hash" AS "hash"
+          FROM
+            "app_deployment_documents"
+          WHERE
+            "app_deployment_id" = ${appDeployment.id}
+        `,
         queryId: 'app-deployment-document-ids',
         timeout: 10_000,
       })

--- a/packages/services/cdn-worker/src/analytics.ts
+++ b/packages/services/cdn-worker/src/analytics.ts
@@ -61,7 +61,8 @@ type Event =
         | 'GET cdn-legacy-keys'
         | 'GET cdn-access-token'
         | 'GET persistedOperation'
-        | 'HEAD appDeploymentIsEnabled';
+        | 'HEAD appDeploymentIsEnabled'
+        | 'GET appDeploymentManifest';
       // Either 3 digit status code or error code e.g. timeout, http error etc.
       statusCodeOrErrCode: number | string;
       /** duration in milliseconds */

--- a/packages/services/cdn-worker/src/artifact-handler.ts
+++ b/packages/services/cdn-worker/src/artifact-handler.ts
@@ -69,6 +69,12 @@ const VersionedParamsModel = zod.object({
     .transform(value => value ?? null),
 });
 
+export const AppDeploymentsManifestParamsModel = zod.object({
+  targetId: zod.string(),
+  appName: zod.string(),
+  appVersion: zod.string(),
+});
+
 const PersistedOperationParamsModel = zod.object({
   targetId: zod.string(),
   appName: zod.string(),
@@ -472,6 +478,73 @@ export const createArtifactRequestHandler = (deps: ArtifactRequestHandler) => {
         deps.requestCache?.set(request, response);
         return response;
       }
+    },
+  );
+  router.get(
+    '/artifacts/v1/:targetId/apps/:appName/:appVersion',
+    async function AppDeploymentManifestHandler(request) {
+      const parseResult = AppDeploymentsManifestParamsModel.safeParse(request.params);
+
+      if (parseResult.success === false) {
+        analytics.track(
+          { type: 'error', value: ['invalid-params'] },
+          request.params?.targetId ?? 'unknown',
+        );
+
+        return createResponse(
+          analytics,
+          'Not found.',
+          {
+            status: 404,
+          },
+          request.params?.targetId ?? 'unknown',
+          request,
+        );
+      }
+
+      const params = parseResult.data;
+
+      const maybeResponse = await authenticate(request, params.targetId);
+
+      if (maybeResponse !== null) {
+        return maybeResponse;
+      }
+
+      const manifest = await deps.artifactStorageReader.readAppDeploymentManifest(
+        params.targetId,
+        params.appName,
+        params.appVersion,
+      );
+
+      if (manifest === null) {
+        return createResponse(
+          analytics,
+          'Not found.',
+          {
+            status: 404,
+          },
+          request.params?.targetId ?? 'unknown',
+          request,
+        );
+      }
+
+      const response = createResponse(
+        analytics,
+        JSON.stringify(manifest),
+        // We're using here a public location, because we expose the Location to the end user and
+        // the public S3 endpoint may differ from the internal S3 endpoint. E.g. within a docker network.
+        // If they are the same, private and public locations will be the same.
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+        params.targetId,
+        request,
+      );
+
+      return response;
     },
   );
 

--- a/packages/services/cdn-worker/src/artifact-handler.ts
+++ b/packages/services/cdn-worker/src/artifact-handler.ts
@@ -467,9 +467,6 @@ export const createArtifactRequestHandler = (deps: ArtifactRequestHandler) => {
         const response = createResponse(
           analytics,
           result.body,
-          // We're using here a public location, because we expose the Location to the end user and
-          // the public S3 endpoint may differ from the internal S3 endpoint. E.g. within a docker network.
-          // If they are the same, private and public locations will be the same.
           { status: 200 },
           params.targetId,
           request,
@@ -531,9 +528,6 @@ export const createArtifactRequestHandler = (deps: ArtifactRequestHandler) => {
       const response = createResponse(
         analytics,
         JSON.stringify(manifest),
-        // We're using here a public location, because we expose the Location to the end user and
-        // the public S3 endpoint may differ from the internal S3 endpoint. E.g. within a docker network.
-        // If they are the same, private and public locations will be the same.
         {
           status: 200,
           headers: {

--- a/packages/services/cdn-worker/src/artifact-storage-reader.ts
+++ b/packages/services/cdn-worker/src/artifact-storage-reader.ts
@@ -408,7 +408,6 @@ export class ArtifactStorageReader {
     }
 
     const body = await response.json();
-    console.log(body);
     return AppDeploymentManifestModel.parse(body);
   }
 

--- a/packages/services/cdn-worker/src/artifact-storage-reader.ts
+++ b/packages/services/cdn-worker/src/artifact-storage-reader.ts
@@ -3,6 +3,14 @@ import type { Analytics } from './analytics';
 import { AwsClient } from './aws';
 import type { Breadcrumb } from './breadcrumbs';
 
+export const AppDeploymentManifestModel = zod.object({
+  id: zod.string().uuid(),
+  appName: zod.string(),
+  appVersion: zod.string(),
+  isActive: zod.boolean(),
+  documentHashes: zod.array(zod.string()),
+});
+
 export function buildArtifactStorageKey(
   targetId: string,
   artifactType: string,
@@ -50,11 +58,18 @@ const AppDeploymentIsEnabledKeyModel = zod.tuple([
 /**
  * S3 key for determining whether app deployment is enabled or not.
  * Note: we validate to avoid invalid keys / collisions that could be caused by type errors.
+ *
  **/
 export function buildAppDeploymentIsEnabledKey(
   ...args: [targetId: string, appName: string, appVersion: string]
 ) {
   return ['apps-enabled', ...AppDeploymentIsEnabledKeyModel.parse(args)].join('/');
+}
+
+export function buildAppDeploymentManifestKey(
+  ...args: [targetId: string, appName: string, appVersion: string]
+) {
+  return ['apps-manifest', ...AppDeploymentIsEnabledKeyModel.parse(args)].join('/');
 }
 
 /**
@@ -351,6 +366,50 @@ export class ArtifactStorageReader {
     });
 
     return response.status === 200;
+  }
+
+  async readAppDeploymentManifest(targetId: string, appName: string, appVersion: string) {
+    const key = buildAppDeploymentManifestKey(targetId, appName, appVersion);
+
+    const response = await this.request({
+      key,
+      method: 'GET',
+      onAttempt: args => {
+        if (args.result.type === 'error') {
+          this.breadcrumb(
+            `Fetch attempt failed (source=${args.isMirror ? 'mirror' : 'primary'}, attempt=${args.attempt} duration=${args.duration}, result=${args.result.type}, key=${key}, message=${args.result.error.message})`,
+          );
+        } else {
+          this.breadcrumb(
+            `Fetch attempt succeeded (source=${args.isMirror ? 'mirror' : 'primary'}, attempt=${args.attempt} duration=${args.duration}, result=${args.result.type}, key=${key})`,
+          );
+        }
+        this.analytics?.track(
+          {
+            type: args.isMirror ? 's3' : 'r2',
+            statusCodeOrErrCode:
+              args.result.type === 'error'
+                ? String(args.result.error.name ?? 'unknown')
+                : args.result.response.status,
+            action: 'GET appDeploymentManifest',
+            duration: args.duration,
+          },
+          targetId,
+        );
+      },
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (response.status !== 200) {
+      throw new Error('Failed to retrieve app deployment manifest');
+    }
+
+    const body = await response.json();
+    console.log(body);
+    return AppDeploymentManifestModel.parse(body);
   }
 
   async loadAppDeploymentPersistedOperation(


### PR DESCRIPTION
### Background

By knowing the app deployment name and version it is currently impossible to retrieve a list of all documents that belong to the version via the CDN.

- [RFC: App Deployment Manifest](https://guild-oss.slack.com/docs/TAYJ1FSUA/F0ASURR7CQ1)

### Description

Write a app deployment manifest to the CDN that contains all the document hashes and whether the app deployment is enabled or disabled.

The endpoint `/apps/:appname/:appVersion` returns a JSON manifest with the following information:

```json5
{
  id: "some uuid",
  isActive: false,
  appName: "app-name",
  appVersion: "app-version",
  // list of all hashes this app version contains
  documentHashes: ["aaa", "bbb", "ccc", "ddd"],
}
```

This enabled routers to pre-load documents of app deployments and the router MCP plugin to load all available tools for an app deployment version.

### Out of Scope

This pull request does not introduce **backfilling app deployment manifests** for existing published app deployments.

- We can introduce this later on before we start adjusting gateway/router to leverage this endpoint
- For now this manifest is only needed in the context of the MCP gateway plugin, where this trade-off is acceptable

### Checklist

- [x] Input validation
- [x] Output encoding
- [x] Access control
- [x] Testing
