### PR TITLE
OIDC verification domains are now inserted and compared against lower…

### DIFF
--- a/.changeset/funny-ravens-read.md
+++ b/.changeset/funny-ravens-read.md
@@ -1,0 +1,13 @@
+---
+'hive': patch
+---
+
+OIDC verification domains are now inserted and compared against lowercase domains. Any existing domains that use an uppercase letter must be converted to lowercase. This is to avoid an unnecessary convert to LOWER() in the SQL statements.
+
+To convert existing domains, run the SQL query:
+```
+UPDATE oidc_integration_domains
+SET domain_name=LOWER(domain_name)
+WHERE domain_name != LOWER(domain_name)
+;
+```

--- a/packages/services/api/src/modules/oidc-integrations/providers/oidc-integration.store.ts
+++ b/packages/services/api/src/modules/oidc-integrations/providers/oidc-integration.store.ts
@@ -9,7 +9,7 @@ const SharedOIDCIntegrationDomainFieldsModel = z.object({
   id: z.string().uuid(),
   organizationId: z.string().uuid(),
   oidcIntegrationId: z.string().uuid(),
-  domainName: z.string(),
+  domainName: z.string().transform(name => name.toLowerCase()),
   createdAt: z.string(),
 });
 
@@ -86,7 +86,7 @@ export class OIDCIntegrationStore {
       ) VALUES (
         ${organizationId}
         , ${oidcIntegrationId}
-        , ${domainName}
+        , ${domainName.toLowerCase()}
       )
       ON CONFLICT ("oidc_integration_id", "domain_name")
         DO NOTHING
@@ -131,7 +131,7 @@ export class OIDCIntegrationStore {
       FROM
         "oidc_integration_domains"
       WHERE
-        "domain_name" = ${domainName}
+        "domain_name" = ${domainName.toLowerCase()}
         AND "verified_at" IS NOT NULL
     `;
 
@@ -149,7 +149,7 @@ export class OIDCIntegrationStore {
         "oidc_integration_domains"
       WHERE
         "oidc_integration_id" = ${oidcIntegrationId}
-        AND "domain_name" = ${domainName}
+        AND "domain_name" = ${domainName.toLowerCase()}
         AND "verified_at" IS NOT NULL
     `;
 


### PR DESCRIPTION
…case domains

### Background

Fixes a bug where a user's email domain can return with casing that doesn't match what's stored in the verified domains table.

### Description

Converts the inputted domains to lower when creating a verified domain or when looking up a verified domain.

There's a few ways to solve this. We could adjust the index and lookup to use `LOWER()` and avoid the small migration. But we only have a single domain at this time that has this issue.

I opted to implement the fix this way to avoid having to adjust indices or anything more extensive.

---

We must run the provided SQL command to convert a domain to lower after deployment so that this domain matches future auth attempts.
