### PR TITLE
Upgrade graphql-inspector to flag defaulted inputs as dangerous

### DIFF
--- a/.changeset/nasty-birds-invent.md
+++ b/.changeset/nasty-birds-invent.md
@@ -1,0 +1,6 @@
+---
+'hive': patch
+---
+
+"INPUT_FIELD_ADDED" is now classified as Dangerous (was NonBreaking) when the added field has a
+default value, since rolling deploys can expose consumers to the default before producers are ready.

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@graphql-codegen/urql-introspection": "3.0.1",
     "@graphql-eslint/eslint-plugin": "3.20.1",
     "@graphql-inspector/cli": "6.0.6",
-    "@graphql-inspector/core": "7.1.2",
+    "@graphql-inspector/core": "7.1.3",
     "@graphql-inspector/patch": "0.1.3",
     "@graphql-tools/load": "8.1.2",
     "@manypkg/get-packages": "2.2.2",

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@graphql-hive/core": "workspace:*",
-    "@graphql-inspector/core": "7.1.2",
+    "@graphql-inspector/core": "7.1.3",
     "@graphql-tools/code-file-loader": "~8.1.0",
     "@graphql-tools/graphql-file-loader": "~8.1.0",
     "@graphql-tools/json-file-loader": "~8.0.0",

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -23,7 +23,7 @@
     "@date-fns/utc": "2.1.1",
     "@graphql-hive/core": "workspace:*",
     "@graphql-hive/signal": "1.0.0",
-    "@graphql-inspector/core": "7.1.2",
+    "@graphql-inspector/core": "7.1.3",
     "@graphql-tools/merge": "9.1.1",
     "@hive/cdn-script": "workspace:*",
     "@hive/postgres": "workspace:*",

--- a/packages/services/storage/package.json
+++ b/packages/services/storage/package.json
@@ -15,7 +15,7 @@
     "db:generate": "schemats generate --config schemats.cjs -o src/db/types.ts && prettier --write src/db/types.ts"
   },
   "devDependencies": {
-    "@graphql-inspector/core": "7.1.2",
+    "@graphql-inspector/core": "7.1.3",
     "@hive/postgres": "workspace:*",
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.120.2",

--- a/packages/services/workflows/package.json
+++ b/packages/services/workflows/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@graphql-hive/logger": "1.0.9",
-    "@graphql-inspector/core": "7.1.2",
+    "@graphql-inspector/core": "7.1.3",
     "@graphql-inspector/patch": "0.1.3",
     "@graphql-yoga/redis-event-target": "3.0.3",
     "@hive/postgres": "workspace:*",

--- a/packages/web/app/package.json
+++ b/packages/web/app/package.json
@@ -25,7 +25,7 @@
     "@graphiql/toolkit": "0.9.1",
     "@graphql-codegen/client-preset-swc-plugin": "0.2.0",
     "@graphql-hive/laboratory": "workspace:*",
-    "@graphql-inspector/core": "7.1.2",
+    "@graphql-inspector/core": "7.1.3",
     "@graphql-inspector/patch": "0.1.3",
     "@graphql-tools/mock": "9.0.25",
     "@graphql-typed-document-node/core": "3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,8 +141,8 @@ importers:
         specifier: 6.0.6
         version: 6.0.6(@types/node@24.12.2)(encoding@0.1.13)(graphql@16.9.0)
       '@graphql-inspector/core':
-        specifier: 7.1.2
-        version: 7.1.2(graphql@16.9.0)
+        specifier: 7.1.3
+        version: 7.1.3(graphql@16.9.0)
       '@graphql-inspector/patch':
         specifier: 0.1.3
         version: 0.1.3(graphql@16.9.0)
@@ -505,8 +505,8 @@ importers:
         specifier: workspace:*
         version: link:../core/dist
       '@graphql-inspector/core':
-        specifier: 7.1.2
-        version: 7.1.2(graphql@16.9.0)
+        specifier: 7.1.3
+        version: 7.1.3(graphql@16.9.0)
       '@graphql-tools/code-file-loader':
         specifier: ~8.1.0
         version: 8.1.0(graphql@16.9.0)
@@ -1108,8 +1108,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@graphql-inspector/core':
-        specifier: 7.1.2
-        version: 7.1.2(graphql@16.9.0)
+        specifier: 7.1.3
+        version: 7.1.3(graphql@16.9.0)
       '@graphql-tools/merge':
         specifier: 9.1.1
         version: 9.1.1(graphql@16.9.0)
@@ -1776,8 +1776,8 @@ importers:
   packages/services/storage:
     devDependencies:
       '@graphql-inspector/core':
-        specifier: 7.1.2
-        version: 7.1.2(graphql@16.9.0)
+        specifier: 7.1.3
+        version: 7.1.3(graphql@16.9.0)
       '@hive/postgres':
         specifier: workspace:*
         version: link:../../internal/postgres
@@ -2001,8 +2001,8 @@ importers:
         specifier: 1.0.9
         version: 1.0.9(pino@10.3.0)
       '@graphql-inspector/core':
-        specifier: 7.1.2
-        version: 7.1.2(graphql@16.9.0)
+        specifier: 7.1.3
+        version: 7.1.3(graphql@16.9.0)
       '@graphql-inspector/patch':
         specifier: 0.1.3
         version: 0.1.3(graphql@16.9.0)
@@ -2112,8 +2112,8 @@ importers:
         specifier: workspace:*
         version: link:../../libraries/laboratory
       '@graphql-inspector/core':
-        specifier: 7.1.2
-        version: 7.1.2(graphql@16.9.0)
+        specifier: 7.1.3
+        version: 7.1.3(graphql@16.9.0)
       '@graphql-inspector/patch':
         specifier: 0.1.3
         version: 0.1.3(graphql@16.9.0)
@@ -4340,8 +4340,8 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
 
-  '@graphql-inspector/core@7.1.2':
-    resolution: {integrity: sha512-yYuWN3/2lQsICwy0PL24hPYeNvDP62Z/t7CfQHcB9V4DJhDtNpoyUYBOwBB1YSwNs4nE9ZQhuv2VeBUZigKVQQ==}
+  '@graphql-inspector/core@7.1.3':
+    resolution: {integrity: sha512-KY5UlRVn3Q12mBeGCu0Z2dmKYUl+eiHpLPo5cyQBWmAibjatPe0IO3I9THW/9rPusafbh3cRnGpYHIH/SxyASQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -22562,7 +22562,7 @@ snapshots:
       object-inspect: 1.13.2
       tslib: 2.6.2
 
-  '@graphql-inspector/core@7.1.2(graphql@16.9.0)':
+  '@graphql-inspector/core@7.1.3(graphql@16.9.0)':
     dependencies:
       dependency-graph: 1.0.0
       graphql: 16.9.0


### PR DESCRIPTION
### Background

Rolling deploys can expose consumers to the default before producers are ready

Internal Ticket: https://linear.app/the-guild/issue/CONSOLE-2034/add-check-for-default-parameters-in-hive-schema-validation

### Description

"INPUT_FIELD_ADDED" is now classified as Dangerous (was NonBreaking) when the added field has a
default value