### PR TITLE
fix:  app deployment publish permissions

### DIFF
--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -1787,6 +1787,9 @@ test('get app deployment documents via GraphQL API', async () => {
       input: {
         appName: 'app-name',
         appVersion: 'app-version',
+        target: {
+          byId: target.id,
+        },
         documents: [
           {
             hash: 'aaa',
@@ -1822,7 +1825,7 @@ test('get app deployment documents via GraphQL API', async () => {
       appDeploymentName: 'app-name',
       appDeploymentVersion: 'app-version',
     },
-    authToken: organizationAccessToken.privateAccessKey,
+    authToken: token.secret,
   }).then(res => res.expectNoGraphQLErrors());
   expect(result.target).toMatchObject({
     appDeployment: {

--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -1,7 +1,6 @@
 import { buildASTSchema, parse } from 'graphql';
 import { createLogger } from 'graphql-yoga';
 import { pollFor } from 'testkit/flow';
-import { ResourceAssignmentModeType } from 'testkit/gql/graphql';
 import { initSeed } from 'testkit/seed';
 import { getServiceHost } from 'testkit/utils';
 import z from 'zod';
@@ -9,6 +8,7 @@ import { createHive } from '@graphql-hive/core';
 import { psql } from '@hive/postgres';
 import { clickHouseInsert } from '../../testkit/clickhouse';
 import { graphql } from '../../testkit/gql';
+import { ResourceAssignmentModeType } from '../../testkit/gql/graphql';
 import { execute } from '../../testkit/graphql';
 
 const CreateAppDeployment = graphql(`

--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -1,6 +1,7 @@
 import { buildASTSchema, parse } from 'graphql';
 import { createLogger } from 'graphql-yoga';
 import { pollFor } from 'testkit/flow';
+import { ResourceAssignmentModeType } from 'testkit/gql/graphql';
 import { initSeed } from 'testkit/seed';
 import { getServiceHost } from 'testkit/utils';
 import z from 'zod';
@@ -1742,8 +1743,9 @@ test('retire app deployments fails without feature flag enabled for organization
 });
 
 test('get app deployment documents via GraphQL API', async () => {
-  const { createOrg, ownerToken } = await initSeed().createOwner();
-  const { createProject, setFeatureFlag, organization } = await createOrg();
+  const { createOrg } = await initSeed().createOwner();
+  const { createProject, setFeatureFlag, organization, createOrganizationAccessToken } =
+    await createOrg();
   await setFeatureFlag('appDeployments', true);
   const { createTargetAccessToken, project, target } = await createProject();
   const token = await createTargetAccessToken({});
@@ -1769,6 +1771,14 @@ test('get app deployment documents via GraphQL API', async () => {
         d: String
       }
     `,
+  });
+
+  // Ensure this is possible with the minimal available permissions.
+  const organizationAccessToken = await createOrganizationAccessToken({
+    permissions: ['appDeployment:create'],
+    resources: {
+      mode: ResourceAssignmentModeType.All,
+    },
   });
 
   const { addDocumentsToAppDeployment } = await execute({
@@ -1797,7 +1807,7 @@ test('get app deployment documents via GraphQL API', async () => {
         ],
       },
     },
-    authToken: token.secret,
+    authToken: organizationAccessToken.privateAccessKey,
   }).then(res => res.expectNoGraphQLErrors());
   expect(addDocumentsToAppDeployment.error).toBeNull();
 
@@ -1812,7 +1822,7 @@ test('get app deployment documents via GraphQL API', async () => {
       appDeploymentName: 'app-name',
       appDeploymentVersion: 'app-version',
     },
-    authToken: ownerToken,
+    authToken: organizationAccessToken.privateAccessKey,
   }).then(res => res.expectNoGraphQLErrors());
   expect(result.target).toMatchObject({
     appDeployment: {

--- a/packages/services/api/src/modules/app-deployments/providers/app-deployments-manager.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/app-deployments-manager.ts
@@ -124,7 +124,7 @@ export class AppDeploymentsManager {
       },
     });
 
-    const target = await this.targetManager.getTarget(selector);
+    const target = await this.targetManager.getTargetById(selector);
 
     return await this.appDeployments.addDocumentsToAppDeployment({
       target,


### PR DESCRIPTION
### Background

https://github.com/graphql-hive/console/pull/8029 introduced this bug where suddenly `project:describe` permissions are needed. This was caught on the staging deployment.

### Description

Changes the code to behave like previously and adjust the test case for the functionality to use a scoped down access token to prevent a future regression. 

### Checklist

- [x] Testing
