### PR TITLE
feat: make schema log lookup target_id independent

### DIFF
--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -404,7 +404,7 @@ export class SchemaManager {
 
   async getSchemaLogById(schemaLogId: string) {
     this.logger.debug('Fetching schema log by id (schemaLogId=%s)', schemaLogId);
-    return this.schemaVersions.getSchemLogById(schemaLogId);
+    return this.schemaVersions.getSchemaLogById(schemaLogId);
   }
 
   @traceFn('SchemaManager.createVersion', {

--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -402,12 +402,9 @@ export class SchemaManager {
     return connection;
   }
 
-  async getSchemaLog(selector: { commit: string } & TargetSelector) {
-    this.logger.debug('Fetching schema log (selector=%o)', selector);
-    return this.schemaVersions.getSchemLog({
-      commit: selector.commit,
-      targetId: selector.targetId,
-    });
+  async getSchemaLogById(schemaLogId: string) {
+    this.logger.debug('Fetching schema log by id (schemaLogId=%s)', schemaLogId);
+    return this.schemaVersions.getSchemLogById(schemaLogId);
   }
 
   @traceFn('SchemaManager.createVersion', {
@@ -1286,12 +1283,7 @@ export class SchemaManager {
       };
     }
 
-    const log = await this.getSchemaLog({
-      commit: schemaVersion.actionId,
-      organizationId: schemaVersion.organizationId,
-      projectId: schemaVersion.projectId,
-      targetId: schemaVersion.targetId,
-    });
+    const log = await this.getSchemaLogById(schemaVersion.actionId);
 
     if ('commit' in log && log.commit) {
       const project = await this.storage.getProject({

--- a/packages/services/api/src/modules/schema/providers/schema-version-store.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-store.ts
@@ -881,14 +881,14 @@ export class SchemaVersionStore {
       FROM
         "schema_versions"
       WHERE
-        "action_id" = (
+        "target_id" = ${target.id}
+        AND "action_id" = (
           SELECT
             "id"
           FROM
             "schema_log"
           WHERE
             "schema_log"."project_id" = ${target.projectId}
-            AND "schema_log"."target_id" = ${target.id}
             AND "schema_log"."commit" = ${commit}
           ORDER BY "schema_log"."created_at" DESC
           LIMIT 1

--- a/packages/services/api/src/modules/schema/providers/schema-version-store.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-store.ts
@@ -899,7 +899,7 @@ export class SchemaVersionStore {
     return SchemaVersionModel.nullable().parse(record);
   }
 
-  getSchemLogById = batch<string, SchemaLog>(async schemaLogIds => {
+  getSchemaLogById = batch<string, SchemaLog>(async schemaLogIds => {
     const rows = await this.pg.any(
       psql`/* getSchemaLog */
           SELECT

--- a/packages/services/api/src/modules/schema/providers/schema-version-store.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-store.ts
@@ -899,7 +899,7 @@ export class SchemaVersionStore {
     return SchemaVersionModel.nullable().parse(record);
   }
 
-  getSchemLog = batch<{ targetId: string; commit: string }, SchemaLog>(async selectors => {
+  getSchemLogById = batch<string, SchemaLog>(async schemaLogIds => {
     const rows = await this.pg.any(
       psql`/* getSchemaLog */
           SELECT
@@ -907,26 +907,19 @@ export class SchemaVersionStore {
             , p.type
           FROM schema_log as sl
           LEFT JOIN projects as p ON (p.id = sl.project_id)
-          WHERE (sl.id, sl.target_id) IN ((${psql.join(
-            selectors.map(s => psql`${s.commit}, ${s.targetId}`),
-            psql.fragment`), (`,
-          )}))
+          WHERE sl.id = ANY(${psql.array(schemaLogIds, 'uuid')})
       `,
     );
     const schemas = z.array(SchemaLogModel).parse(rows);
 
-    return selectors.map(selector => {
-      const schema = schemas.find(
-        row => row.id === selector.commit && row.target === selector.targetId,
-      );
+    return schemaLogIds.map(schemaLogId => {
+      const schema = schemas.find(row => row.id === schemaLogId);
 
       if (schema) {
         return Promise.resolve(schema);
       }
 
-      return Promise.reject(
-        new Error(`Schema log not found (commit=${selector.commit}, target=${selector.targetId})`),
-      );
+      return Promise.reject(new Error(`Schema log not found (schemaLogId=${schemaLogId})`));
     });
   });
 

--- a/packages/services/api/src/modules/schema/resolvers/SchemaVersion.ts
+++ b/packages/services/api/src/modules/schema/resolvers/SchemaVersion.ts
@@ -18,12 +18,7 @@ export const SchemaVersion: SchemaVersionResolvers = {
     return injector.get(SchemaVersionHelper).getHasSchemaChanges(version);
   },
   log: async (version, _, { injector }) => {
-    const log = await injector.get(SchemaManager).getSchemaLog({
-      commit: version.actionId,
-      organizationId: version.organizationId,
-      projectId: version.projectId,
-      targetId: version.targetId,
-    });
+    const log = await injector.get(SchemaManager).getSchemaLogById(version.actionId);
 
     if (log.kind === 'single') {
       return {


### PR DESCRIPTION
### Background

This is a prerequisite for rolling out https://github.com/graphql-hive/console/pull/8031 in a way that allows easy rollbacks.

### Description

The current implementation for resolving the GraphQL `SchemaVersion.log` field filters the result by the `target_id` column on the `schema_log` table.

Since https://github.com/graphql-hive/console/pull/8031 will introduce a way to associate a log from one target with another targets schema version, this would cause a runtime exception in case we need to revert and rollback the implementation as the `target_id` mismatch would prevent a successful lookup.

By making the lookup less "strict" rolling back https://github.com/graphql-hive/console/pull/8031 becomes straight-forward and requires no manual code changes.
