### PR TITLE
fix: set Redis maxmemory eviction policy to allkeys-lru

### DIFF
--- a/.changeset/brave-laws-cut.md
+++ b/.changeset/brave-laws-cut.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+add eviction policy to redis

--- a/deployment/utils/redis.ts
+++ b/deployment/utils/redis.ts
@@ -120,6 +120,12 @@ export class Redis {
           args: [
             '/opt/bitnami/scripts/redis/run.sh',
             `--maxmemory ${memoryInMegabytes}mb`,
+            // Once Redis reaches maxmemory (90% of the container limit, see above),
+            // evict the least-recently-used keys instead of failing writes with OOM
+            // errors (the default `noeviction` behaviour). Everything Hive stores in
+            // this Redis is a cache / lock / rate-limit entry with a TTL, so evicting
+            // cold keys is safe and LRU keeps hot keys (locks, fresh counters) around.
+            '--maxmemory-policy allkeys-lru',
             // This disables snapshotting to save cpu and reduce latency spikes
             '--save ""',
           ],


### PR DESCRIPTION
## What

Add `--maxmemory-policy allkeys-lru` to the Redis runtime args in `deployment/utils/redis.ts`.

## Why

Redis had no `maxmemory-policy` configured, so it defaulted to `noeviction`. On reaching `maxmemory` (already set to 90% of the container limit), Redis rejects every write with `OOM command not allowed` instead of freeing space.

With `allkeys-lru`, Redis evicts the least-recently-used keys to make room for new writes. Everything stored in this Redis is a cache / lock / rate-limit entry with a TTL, so dropping cold keys is safe and LRU keeps hot keys resident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)