### PR TITLE
Extend Hive CLI timeout for schema:check from 20s to 55s 

### DIFF
--- a/.changeset/lazy-rules-rhyme.md
+++ b/.changeset/lazy-rules-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+Extend Hive CLI timeout for schema:check from 20s to 55s to better align with the server's timeout

--- a/packages/libraries/cli/src/commands/schema/check.ts
+++ b/packages/libraries/cli/src/commands/schema/check.ts
@@ -291,7 +291,7 @@ export default class SchemaCheck extends Command<typeof SchemaCheck> {
           },
         },
         /** Gateway timeout is 60 seconds. */
-        timeout: 60_000,
+        timeout: 55_000,
       });
 
       if (flags.experimentalJsonFile) {

--- a/packages/libraries/cli/src/commands/schema/check.ts
+++ b/packages/libraries/cli/src/commands/schema/check.ts
@@ -290,6 +290,8 @@ export default class SchemaCheck extends Command<typeof SchemaCheck> {
             schemaProposalId: flags.schemaProposalId,
           },
         },
+        /** Gateway timeout is 60 seconds. */
+        timeout: 55_000,
       });
 
       if (flags.experimentalJsonFile) {

--- a/packages/libraries/cli/src/commands/schema/check.ts
+++ b/packages/libraries/cli/src/commands/schema/check.ts
@@ -291,7 +291,7 @@ export default class SchemaCheck extends Command<typeof SchemaCheck> {
           },
         },
         /** Gateway timeout is 60 seconds. */
-        timeout: 55_000,
+        timeout: 60_000,
       });
 
       if (flags.experimentalJsonFile) {


### PR DESCRIPTION
### Background

We're seeing clients timeout on checks for large, complex schemas while the server eventually completes. This causes an unnecessary retry. The Hive CLI should have a timeout value that aligns closer with the server's timeout to avoid this situation.

### Description

Sets timeout to 60s for schema:check
