### PR TITLE
fix(server): reproduce and fix memory leak with graphql-modules

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -22,12 +22,19 @@ on:
 jobs:
   integration:
     runs-on: ubuntu-22.04
+    name: integration (${{ matrix.shardIndex }})
     strategy:
       fail-fast: false
       matrix:
-        # Divide integration tests into 3 shards, to run them in parallel.
-        shardIndex: [1, 2, 3]
-
+        include:
+          - shardIndex: 1
+            memoryLeakTest: '0'
+          - shardIndex: 2
+            memoryLeakTest: '0'
+          - shardIndex: 3
+            memoryLeakTest: '0'
+          - shardIndex: 'memory leaks'
+            memoryLeakTest: '1'
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}/${{ inputs.imageName }}/
       DOCKER_TAG: :${{ inputs.imageTag }}
@@ -80,10 +87,20 @@ jobs:
 
       - name: run integration tests
         timeout-minutes: 30
+        if: ${{ matrix.memoryLeakTest == '0' }}
         run: |
           pnpm test:integration --shard=${{ matrix.shardIndex }}/3
         env:
           VITEST_MAX_THREADS: ${{ steps.cpu-cores.outputs.count }}
+
+      - name: run mem leaks integration tests
+        timeout-minutes: 30
+        if: ${{ matrix.memoryLeakTest == '1' }}
+        run: |
+          pnpm test:integration
+        env:
+          VITEST_MAX_THREADS: 1
+          RUN_MEMORY_LEAKS_TESTS: '1'
 
       - name: log dump
         if: ${{ failure() }}

--- a/docker/shared/entrypoint.sh
+++ b/docker/shared/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 echo "Release: $RELEASE"
-node --heapsnapshot-signal=SIGUSR1 index.js
+node $NODEJS_FLAGS --heapsnapshot-signal=SIGUSR1 index.js

--- a/integration-tests/docker-compose.integration.yaml
+++ b/integration-tests/docker-compose.integration.yaml
@@ -3,7 +3,6 @@
 # This file also includes services that only exists in Hive's Cloud version, and are not available in the self-hosted version.
 # Please refer to TESTING.md for more information.
 
-version: '3.8'
 name: 'hive-tests'
 
 networks:
@@ -142,6 +141,8 @@ services:
   # Overrides only to `docker-compose.community.yaml` from now on:
   server:
     environment:
+      NODEJS_FLAGS: '--expose-gc'
+      EXPOSE_MEMORY_UTILS: '1'
       CDN_CF: '1'
       CDN_CF_BASE_PATH: http://local_cdn:3004
       CDN_CF_ACCOUNT_ID: 103df45224310d669213971ce28b5b70

--- a/integration-tests/tests/api/memory-leaks.spec.ts
+++ b/integration-tests/tests/api/memory-leaks.spec.ts
@@ -1,0 +1,93 @@
+import { updateSchemaComposition, waitFor } from 'testkit/flow';
+import { ProjectType } from 'testkit/gql/graphql';
+import { getServiceHost } from 'testkit/utils';
+import { initSeed } from '../../testkit/seed';
+
+const TEST_SCHEMA_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+const WAIT_TIME_GC = 3000; // 3 seconds
+const TEST_TIMEOUT = 60000;
+
+async function getServerMemoryStats(): Promise<{ heapUsed: number }> {
+  const registryAddress = await getServiceHost('server', 8082);
+  const response = await fetch(`http://${registryAddress}/memory-stats`);
+  return await response.json();
+}
+
+async function serverForceGc(): Promise<void> {
+  const registryAddress = await getServiceHost('server', 8082);
+  await fetch(`http://${registryAddress}/gc`, { method: 'POST' });
+  await waitFor(WAIT_TIME_GC);
+}
+
+function makeLargeSchemaSDL(existingSchema: string, targetBytes: number): string {
+  const parts: string[] = [existingSchema];
+  let size = parts[0].length;
+  let i = 0;
+  while (size < targetBytes) {
+    const line =
+      `type Pad${i} { a: String b: String c: String d: String e: String ` +
+      `f: String g: String h: String i: String j: String }`;
+    parts.push(line);
+    size += line.length + 1; // +1 for the join newline
+    i++;
+  }
+  return parts.join('\n');
+}
+
+describe.sequential('Memory Leak tests (sequential)', { concurrent: false }, () => {
+  test(
+    'Should not retain memory when SINGLE schema check fails',
+    async () => {
+      const { createOrg } = await initSeed().createOwner();
+      const { inviteAndJoinMember, createProject } = await createOrg();
+      await inviteAndJoinMember();
+      const { createTargetAccessToken } = await createProject(ProjectType.Single);
+      const { publishSchema, checkSchema } = await createTargetAccessToken({});
+
+      // Start from a clean slate
+      await serverForceGc();
+
+      const initialSchema = /* GraphQL */ `
+        type Query {
+          me: String
+        }
+      `;
+
+      const publishResult = await publishSchema({
+        sdl: initialSchema,
+      }).then(r => r.expectNoGraphQLErrors());
+      expect(publishResult.schemaPublish.__typename).toBe('SchemaPublishSuccess');
+
+      // Warm up for schema checks
+      let checkResult = await checkSchema(initialSchema).then(r => r.expectNoGraphQLErrors());
+      expect(checkResult.schemaCheck.__typename).toBe('SchemaCheckSuccess');
+
+      // Force GC, wait a bit, check memory usage before
+      await serverForceGc();
+      const statsBefore = await getServerMemoryStats();
+      console.log('container memory usage before schema check:', statsBefore.heapUsed, 'bytes');
+
+      // Create super large schema and check it
+      const largeSdl = makeLargeSchemaSDL(initialSchema, TEST_SCHEMA_SIZE_BYTES);
+      console.log('schema size:', largeSdl.length, 'bytes');
+      checkResult = await checkSchema(largeSdl).then(r => r.expectNoGraphQLErrors());
+      // the reason for this failure is because the schema-service rejects it as it's too big
+      // we don't really care about the issue, we just need a promise rejection while doing a schema check
+      // and this is a nice way to trigger it
+      expect(checkResult.schemaCheck.__typename).toBe('SchemaCheckError');
+
+      // Check memory after schema check and GC
+      await serverForceGc();
+      const statsAfter = await getServerMemoryStats();
+      console.log('container memory usage after schema check:', statsAfter.heapUsed, 'bytes');
+
+      const diff = statsAfter.heapUsed - statsBefore.heapUsed;
+      console.log('memory usage diff:', diff, 'bytes');
+
+      // minor data retained is ok, but we expect it to be super low
+      expect(diff).toBeLessThan(largeSdl.length);
+      expect(diff).toBeLessThan(1024 * 500); // 500kb
+    },
+    TEST_TIMEOUT,
+  );
+});

--- a/integration-tests/vite.config.ts
+++ b/integration-tests/vite.config.ts
@@ -1,4 +1,4 @@
-import { defaultExclude, defineConfig } from 'vitest/config';
+import { defaultExclude, defaultInclude, defineConfig } from 'vitest/config';
 
 const setupFiles = ['../scripts/serializer.ts', './expect.ts'];
 
@@ -7,6 +7,14 @@ if (!process.env.RUN_AGAINST_LOCAL_SERVICES) {
 } else {
   setupFiles.unshift('./local-dev.ts');
 }
+
+const RUN_MEMORY_LEAKS_TESTS = process.env.RUN_MEMORY_LEAKS_TESTS === '1';
+
+const exclude = RUN_MEMORY_LEAKS_TESTS
+  ? defaultExclude
+  : [...defaultExclude, 'tests/api/memory-leaks.spec.ts'];
+
+const include = RUN_MEMORY_LEAKS_TESTS ? ['tests/api/memory-leaks.spec.ts'] : defaultInclude;
 
 export default defineConfig({
   test: {
@@ -37,6 +45,7 @@ export default defineConfig({
     },
     setupFiles,
     testTimeout: 90_000,
-    exclude: defaultExclude,
+    exclude,
+    include,
   },
 });

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -61,7 +61,7 @@
     "got": "14.4.7",
     "graphile-worker": "0.16.6",
     "graphql": "16.9.0",
-    "graphql-modules": "3.1.1",
+    "graphql-modules": "3.1.2",
     "graphql-parse-resolve-info": "4.13.0",
     "graphql-scalars": "1.24.2",
     "graphql-yoga": "5.13.3",

--- a/packages/services/server/src/environment.ts
+++ b/packages/services/server/src/environment.ts
@@ -18,6 +18,10 @@ const emptyString = <T extends zod.ZodType>(input: T) => {
   }, input);
 };
 
+const TestUtilsModel = zod.object({
+  EXPOSE_MEMORY_UTILS: emptyString(zod.union([zod.literal('1'), zod.literal('0')]).optional()),
+});
+
 const EnvironmentModel = zod.object({
   PORT: emptyString(NumberFromString.optional()),
   SERVER_HOST: emptyString(zod.string().optional()),
@@ -289,6 +293,7 @@ const LogModel = zod.object({
 const processEnv = process.env;
 
 const configs = {
+  testUtils: TestUtilsModel.safeParse(processEnv),
   base: EnvironmentModel.safeParse(processEnv),
   commerce: CommerceModel.safeParse(processEnv),
   sentry: SentryModel.safeParse(processEnv),
@@ -358,6 +363,7 @@ const s3AuditLog = extractConfig(configs.s3AuditLog);
 const zendeskSupport = extractConfig(configs.zendeskSupport);
 const tracing = extractConfig(configs.tracing);
 const hivePersistedDocuments = extractConfig(configs.hivePersistedDocuments);
+const testUtils = extractConfig(configs.testUtils);
 
 const hiveUsageConfig =
   hive.HIVE_USAGE === '1'
@@ -381,6 +387,7 @@ export type HivePersistedDocumentsConfig = typeof hivePersistedDocumentsConfig;
 
 export const env = {
   environment: base.ENVIRONMENT,
+  exposeMemoryUtils: testUtils.EXPOSE_MEMORY_UTILS === '1',
   release: base.RELEASE ?? 'local',
   encryptionSecret: base.ENCRYPTION_SECRET,
   tracing: {

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -609,6 +609,42 @@ export async function main() {
       });
     }
 
+    if (env.exposeMemoryUtils) {
+      logger.debug('exposing memory utils endpoints');
+      server.route({
+        method: ['GET'],
+        url: '/memory-stats',
+        handler(req, reply) {
+          let mem = process.memoryUsage();
+          logger.debug('memory stats requested, raw memory usage', mem);
+
+          void reply.send({
+            heapTotal: mem.heapTotal,
+            heapUsed: mem.heapUsed,
+            external: mem.external,
+            rss: mem.rss,
+          });
+        },
+      });
+
+      server.route({
+        method: ['POST'],
+        url: '/gc',
+        handler(req, reply) {
+          if (global.gc) {
+            logger.debug('gc requested');
+            global.gc();
+            void reply.status(200);
+            void reply.send('gc triggered');
+          } else {
+            logger.debug('gc requested but not available');
+            void reply.status(500);
+            void reply.send('gc not available');
+          }
+        },
+      });
+    }
+
     if (env.prometheus) {
       await startMetrics(env.prometheus.labels.instance, {
         port: env.prometheus.port,

--- a/packages/services/server/turbo.json
+++ b/packages/services/server/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
-      "inputs": ["../../web/app/src/gql/persisted-documents.json"]
+      "inputs": ["$TURBO_DEFAULT$", "../../web/app/src/gql/persisted-documents.json"]
     },
     "dev": {
       "persistent": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1221,8 +1221,8 @@ importers:
         specifier: 16.9.0
         version: 16.9.0
       graphql-modules:
-        specifier: 3.1.1
-        version: 3.1.1(graphql@16.9.0)
+        specifier: 3.1.2
+        version: 3.1.2(graphql@16.9.0)
       graphql-parse-resolve-info:
         specifier: 4.13.0
         version: 4.13.0(graphql@16.9.0)
@@ -1583,7 +1583,7 @@ importers:
         version: 11.1.1(@envelop/core@5.5.1)(graphql@16.9.0)
       '@envelop/graphql-modules':
         specifier: 9.1.1
-        version: 9.1.1(@envelop/core@5.5.1)(graphql-modules@3.1.1(graphql@16.9.0))(graphql@16.9.0)
+        version: 9.1.1(@envelop/core@5.5.1)(graphql-modules@3.1.2(graphql@16.9.0))(graphql@16.9.0)
       '@envelop/types':
         specifier: 5.0.0
         version: 5.0.0
@@ -4577,12 +4577,6 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
-  '@graphql-tools/batch-execute@10.0.4':
-    resolution: {integrity: sha512-t8E0ILelbaIju0aNujMkKetUmbv3/07nxGSv0kEGLBk9GNtEmQ/Bjj8ZTo2WN35/Fy70zCHz2F/48Nx/Ec48cA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
   '@graphql-tools/batch-execute@10.0.8':
     resolution: {integrity: sha512-Kobt37qrVTFhX4HUK5/vPgMXFw/5f97AzmAlfmDBSRh/GnoAmLKCb48FrEI3gdeIwZB2fEhVHJyDqsojldnLQA==}
     engines: {node: '>=20.0.0'}
@@ -4649,12 +4643,6 @@ packages:
 
   '@graphql-tools/delegate@12.0.16':
     resolution: {integrity: sha512-WEJaFwWG82a0VzhfE4sRsaOPjxgCVfn4fOe3ho+r3uIbPYpc7qHpFdu1PLg6meikq6fuW9NJ1J88fEgnWuXDVg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@graphql-tools/delegate@12.0.2':
-    resolution: {integrity: sha512-1X93onxNgOzRvnZ8Xulwi6gNuBeuDxvGYOjUHEZyesPCsaWsyiVj1Wk6Pw/DTPGLy70sOFUKQGcaZbWnDORM2w==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -13489,8 +13477,8 @@ packages:
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
 
-  graphql-modules@3.1.1:
-    resolution: {integrity: sha512-T87Z7V99LG5KU+w15VJ+M8KwRAXMCMB6n7mv+iEBuJMiH6fC6snXr83yAPrcKCzSbiHstildq5SqUcvFfj7ymw==}
+  graphql-modules@3.1.2:
+    resolution: {integrity: sha512-3AQum1/IeDx+WV98mo4T0WrloAu3j/YlWPLcligkkxjJGJGjhbhBexAY43hQMFTR4+5SxPtCxn0h5StQ3AGNxQ==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
 
@@ -16719,8 +16707,8 @@ packages:
   railroad-diagrams@1.0.0:
     resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
 
-  ramda@0.30.1:
-    resolution: {integrity: sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==}
+  ramda@0.32.0:
+    resolution: {integrity: sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==}
 
   randexp@0.4.6:
     resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
@@ -21339,11 +21327,11 @@ snapshots:
       graphql-jit: 0.8.7(graphql@16.9.0)
       tslib: 2.8.1
 
-  '@envelop/graphql-modules@9.1.1(@envelop/core@5.5.1)(graphql-modules@3.1.1(graphql@16.9.0))(graphql@16.9.0)':
+  '@envelop/graphql-modules@9.1.1(@envelop/core@5.5.1)(graphql-modules@3.1.2(graphql@16.9.0))(graphql@16.9.0)':
     dependencies:
       '@envelop/core': 5.5.1
       graphql: 16.9.0
-      graphql-modules: 3.1.1(graphql@16.9.0)
+      graphql-modules: 3.1.2(graphql@16.9.0)
       tslib: 2.8.1
 
   '@envelop/instrumentation@1.0.0':
@@ -23526,14 +23514,6 @@ snapshots:
       graphql: 16.9.0
       tslib: 2.8.1
 
-  '@graphql-tools/batch-execute@10.0.4(graphql@16.12.0)':
-    dependencies:
-      '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
-      '@whatwg-node/promise-helpers': 1.3.2
-      dataloader: 2.2.3
-      graphql: 16.12.0
-      tslib: 2.8.1
-
   '@graphql-tools/batch-execute@10.0.8(graphql@16.12.0)':
     dependencies:
       '@graphql-tools/utils': 11.1.0(graphql@16.12.0)
@@ -23679,18 +23659,6 @@ snapshots:
       graphql: 16.9.0
       tslib: 2.8.1
 
-  '@graphql-tools/delegate@12.0.2(graphql@16.12.0)':
-    dependencies:
-      '@graphql-tools/batch-execute': 10.0.4(graphql@16.12.0)
-      '@graphql-tools/executor': 1.5.0(graphql@16.12.0)
-      '@graphql-tools/schema': 10.0.29(graphql@16.12.0)
-      '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
-      '@repeaterjs/repeater': 3.0.6
-      '@whatwg-node/promise-helpers': 1.3.2
-      dataloader: 2.2.3
-      graphql: 16.12.0
-      tslib: 2.8.1
-
   '@graphql-tools/delegate@9.0.31(graphql@16.9.0)':
     dependencies:
       '@graphql-tools/batch-execute': 8.5.19(graphql@16.9.0)
@@ -23729,13 +23697,13 @@ snapshots:
   '@graphql-tools/executor-common@1.0.6(graphql@16.12.0)':
     dependencies:
       '@envelop/core': 5.5.1
-      '@graphql-tools/utils': 11.0.0(graphql@16.12.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.12.0)
       graphql: 16.12.0
 
   '@graphql-tools/executor-common@1.0.6(graphql@16.9.0)':
     dependencies:
       '@envelop/core': 5.5.1
-      '@graphql-tools/utils': 11.0.0(graphql@16.9.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
       graphql: 16.9.0
 
   '@graphql-tools/executor-graphql-ws@0.0.14(graphql@16.9.0)':
@@ -23800,7 +23768,7 @@ snapshots:
   '@graphql-tools/executor-graphql-ws@3.1.5(graphql@16.12.0)':
     dependencies:
       '@graphql-tools/executor-common': 1.0.6(graphql@16.12.0)
-      '@graphql-tools/utils': 11.0.0(graphql@16.12.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.12.0)
       '@whatwg-node/disposablestack': 0.0.6
       graphql: 16.12.0
       graphql-ws: 6.0.6(graphql@16.12.0)(ws@8.18.0)
@@ -23875,7 +23843,7 @@ snapshots:
     dependencies:
       '@graphql-hive/signal': 2.0.0
       '@graphql-tools/executor-common': 1.0.6(graphql@16.12.0)
-      '@graphql-tools/utils': 11.0.0(graphql@16.12.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.12.0)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/disposablestack': 0.0.6
       '@whatwg-node/fetch': 0.10.13
@@ -23969,7 +23937,7 @@ snapshots:
 
   '@graphql-tools/executor-legacy-ws@1.1.26(graphql@16.12.0)':
     dependencies:
-      '@graphql-tools/utils': 11.0.0(graphql@16.12.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.12.0)
       '@types/ws': 8.5.3
       graphql: 16.12.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
@@ -24421,7 +24389,7 @@ snapshots:
   '@graphql-tools/relay-operation-optimizer@7.1.1(graphql@16.9.0)':
     dependencies:
       '@ardatan/relay-compiler': 13.0.0(graphql@16.9.0)
-      '@graphql-tools/utils': 11.0.0(graphql@16.9.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
       graphql: 16.9.0
       tslib: 2.8.1
 
@@ -24714,14 +24682,6 @@ snapshots:
       graphql: 16.12.0
       tslib: 2.8.1
 
-  '@graphql-tools/utils@11.0.0(graphql@16.9.0)':
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
-      '@whatwg-node/promise-helpers': 1.3.2
-      cross-inspect: 1.0.1
-      graphql: 16.9.0
-      tslib: 2.8.1
-
   '@graphql-tools/utils@11.1.0(graphql@16.12.0)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
@@ -24746,7 +24706,7 @@ snapshots:
 
   '@graphql-tools/wrap@10.0.16(graphql@16.9.0)':
     dependencies:
-      '@graphql-tools/delegate': 10.1.2(graphql@16.9.0)
+      '@graphql-tools/delegate': 10.2.23(graphql@16.9.0)
       '@graphql-tools/schema': 10.0.25(graphql@16.9.0)
       '@graphql-tools/utils': 10.9.1(graphql@16.9.0)
       graphql: 16.9.0
@@ -24782,7 +24742,7 @@ snapshots:
 
   '@graphql-tools/wrap@11.1.2(graphql@16.12.0)':
     dependencies:
-      '@graphql-tools/delegate': 12.0.2(graphql@16.12.0)
+      '@graphql-tools/delegate': 12.0.16(graphql@16.12.0)
       '@graphql-tools/schema': 10.0.29(graphql@16.12.0)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       '@whatwg-node/promise-helpers': 1.3.2
@@ -34985,13 +34945,13 @@ snapshots:
       nullthrows: 1.1.1
       vscode-languageserver-types: 3.17.5
 
-  graphql-modules@3.1.1(graphql@16.9.0):
+  graphql-modules@3.1.2(graphql@16.9.0):
     dependencies:
       '@graphql-tools/schema': 10.0.25(graphql@16.9.0)
-      '@graphql-tools/wrap': 10.1.4(graphql@16.9.0)
+      '@graphql-tools/wrap': 11.1.15(graphql@16.9.0)
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
       graphql: 16.9.0
-      ramda: 0.30.1
+      ramda: 0.32.0
 
   graphql-parse-resolve-info@4.13.0(graphql@16.9.0):
     dependencies:
@@ -38851,7 +38811,7 @@ snapshots:
 
   railroad-diagrams@1.0.0: {}
 
-  ramda@0.30.1: {}
+  ramda@0.32.0: {}
 
   randexp@0.4.6:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,3 +22,4 @@ minimumReleaseAgeExclude:
   - '@graphql-inspector/*'
   - '@graphql-tools/*'
   - '@theguild/federation-composition'
+  - graphql-modules


### PR DESCRIPTION
This PR reproduce and fix (by updating) a memory leak in GraphQL-Modules.

# The leak

The scenario is simple: an unexpected failure during `schema:check` call to the GraphQL API, causes the checked SDL to retain in memory forever, causing a memory leak. 
The unexpected failures can be any failing HTTP request within the execution context: either to an internal service (schema-service), or to external (clickhouse). 

Under the hood, the reason is because of NodeJS attaches a `kAsyncContextFrame` symbol when a Promise is rejected (in case of unexpected failure of schema check), this is also true in case of a global timer that uses data from within the execution scope/closure. This eventually captures the `AsyncLocalStorage` scope. 
GraphQL-Modules uses `AsyncLocalStorage` to track per-operation context. 
This combination leads to a full capture of the user-context in GraphQL-Modules, in our case, this context holds the GraphQL variables and the schema that was checked. If the checked scheam is 5MB, then 5MB will be retained and never released. 

The fix in GraphQL-Modules (https://github.com/graphql-hive/graphql-modules/pull/2681) invovles a better cleanup process, and uses referneces to point to the user-context, so cleanup process is cleaner and more safe, ensuring user-context is never captured, and is released when the operation completes.  

# How it was tested? 

To reproduce the leak, I've added an integration test that does the following:

1. Creates a full environment for testing 
2. Publishes a simple schema
3. `schema:check` a simple schema to warm up caches related to the target 
4. Creates a 5MB schema
5. Measures memory (`heapUsed`) of graphql-api service
6. Tries to `schema:check` the huge schema - this fails because the schema service worker will reject it due to size. This is the key point: in graphql-api, this will cause a rejection of the `fetch` promise. 
7. Measures memory (`heapUsed`) of graphql-api service
8. Diff and confirm that data is not retained. 

> Also, added a new CI config to run these memory leak tests in full isolation so other tests won't run against at the same time. This ensures the results are stable. 
