### PR TITLE
Use discriminatedUnion for SchemaChangeModel

### DIFF
--- a/packages/services/storage/src/schema-change-model.ts
+++ b/packages/services/storage/src/schema-change-model.ts
@@ -1142,7 +1142,7 @@ export const RegistryServiceUrlChangeModel =
 
 // TODO: figure out a way to make sure that all the changes are included in the union
 // Similar to implement().with() but for unions
-export const SchemaChangeModel = z.union([
+export const SchemaChangeModel = z.discriminatedUnion('type', [
   FieldArgumentDescriptionChangedModel,
   FieldArgumentDefaultChangedModel,
   FieldArgumentTypeChangedModel,
@@ -1188,7 +1188,6 @@ export const SchemaChangeModel = z.union([
   EnumValueAddedModel,
   EnumValueDescriptionChangedModel,
   EnumValueDeprecationReasonChangedModel,
-  DirectiveArgumentTypeChangedModel,
   EnumValueDeprecationReasonAddedModel,
   EnumValueDeprecationReasonRemovedModel,
   FieldRemovedModel,


### PR DESCRIPTION
Improves performance for 12k changes: **2500ms -> 100ms**

Removes also the duplicated `DirectiveArgumentTypeChangedModel` from the union.

---

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/dcbce041-6c81-4e40-85f0-72c620179be4" />