### PR TITLE
fix: conditional schema check selections for changes and sdl

### DIFF
--- a/.changeset/brave-laws-cut.md
+++ b/.changeset/brave-laws-cut.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+add eviction policy to redis

--- a/deployment/grafana-dashboards/Performance-Traces.json
+++ b/deployment/grafana-dashboards/Performance-Traces.json
@@ -213,14 +213,14 @@
             }
           ],
           "limit": 100,
-          "query": "{name=~\"SchemaPublisher.check\" && duration>$schemaCheckThreshold}",
+          "query": "{name=\"SchemaPublisher.internalCheck\" && duration>$schemaCheckThreshold}",
           "queryType": "traceql",
           "refId": "A",
           "spss": 20,
           "tableType": "traces"
         }
       ],
-      "title": "Slow SchemaPublisher.check",
+      "title": "Slow SchemaPublisher.internalCheck",
       "type": "table"
     },
     {

--- a/deployment/services/graphql.ts
+++ b/deployment/services/graphql.ts
@@ -107,13 +107,19 @@ export function deployGraphQL({
         replicas: environment.podsConfig.general.replicas,
         pdb: true,
         readinessProbe: '/_readiness',
-        livenessProbe: '/_health',
+        livenessProbe: {
+          endpoint: '/_health',
+          initialDelaySeconds: 10,
+          timeoutSeconds: 5,
+          periodSeconds: 30,
+          failureThreshold: 10,
+        },
         startupProbe: {
           endpoint: '/_health',
-          initialDelaySeconds: 60,
-          failureThreshold: 10,
+          initialDelaySeconds: 5,
+          failureThreshold: 4,
           periodSeconds: 15,
-          timeoutSeconds: 15,
+          timeoutSeconds: 10,
         },
         availabilityOnEveryNode: true,
         env: {

--- a/deployment/utils/redis.ts
+++ b/deployment/utils/redis.ts
@@ -120,6 +120,12 @@ export class Redis {
           args: [
             '/opt/bitnami/scripts/redis/run.sh',
             `--maxmemory ${memoryInMegabytes}mb`,
+            // Once Redis reaches maxmemory (90% of the container limit, see above),
+            // evict the least-recently-used keys instead of failing writes with OOM
+            // errors (the default `noeviction` behaviour). Everything Hive stores in
+            // this Redis is a cache / lock / rate-limit entry with a TTL, so evicting
+            // cold keys is safe and LRU keeps hot keys (locks, fresh counters) around.
+            '--maxmemory-policy allkeys-lru',
             // This disables snapshotting to save cpu and reduce latency spikes
             '--save ""',
           ],

--- a/deployment/utils/service-deployment.ts
+++ b/deployment/utils/service-deployment.ts
@@ -170,8 +170,8 @@ export class ServiceDeployment {
       startupProbe =
         typeof this.options.startupProbe === 'string'
           ? {
-              initialDelaySeconds: 20,
-              periodSeconds: 30,
+              initialDelaySeconds: 10,
+              periodSeconds: 15,
               failureThreshold: 10,
               timeoutSeconds: 10,
               httpGet: {

--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -712,7 +712,8 @@ export class SchemaManager {
       cursor: string | null;
       transformNode: (check: SchemaCheck) => TransformedSchemaCheck;
       filters: SchemaChecksFilter | null;
-      withSDL: boolean | null;
+      withSDL: boolean;
+      withChanges: boolean;
     },
   ) {
     const paginatedResult = await this.storage.getPaginatedSchemaChecksForTarget({
@@ -721,7 +722,7 @@ export class SchemaManager {
       cursor: args.cursor,
       transformNode: node => args.transformNode(node),
       filters: args.filters,
-      withSDL: args.withSDL ?? true,
+      withChanges: args.withChanges,
     });
 
     return paginatedResult;

--- a/packages/services/api/src/modules/schema/resolvers/Target.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Target.ts
@@ -73,6 +73,13 @@ export const Target: Pick<
       ['FailedSchemaCheck', 'schemaSDL'],
     ]);
 
+    const isSchemaChangesSelected = isFieldRequestedDeep(info, [
+      ['SuccessfulSchemaCheck', 'safeSchemaChanges'],
+      ['SuccessfulSchemaCheck', 'breakingSchemaChanges'],
+      ['FailedSchemaCheck', 'safeSchemaChanges'],
+      ['FailedSchemaCheck', 'breakingSchemaChanges'],
+    ]);
+
     const result = await injector.get(SchemaManager).getPaginatedSchemaChecksForTarget(target, {
       first: args.first ?? null,
       cursor: args.after ?? null,
@@ -82,6 +89,7 @@ export const Target: Pick<
         projectId: target.projectId,
       }),
       withSDL: operationSelectsSDL,
+      withChanges: isSchemaChangesSelected,
     });
 
     return {

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -651,10 +651,10 @@ export interface Storage {
      */
     filters?: SchemaChecksFilter | null;
     /**
-     * Optionally include the SDLs (composite, service, and supergraph) in the result.
-     * This is separated for performance reasons.
+     * Optionally include changes (safe; breaking) in the result.
+     * This is seperated for performance reasons.
      */
-    withSDL?: boolean | null;
+    withChanges?: boolean;
   }): Promise<
     Readonly<{
       items: ReadonlyArray<{

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -651,6 +651,11 @@ export interface Storage {
      */
     filters?: SchemaChecksFilter | null;
     /**
+     * Optionally include the SDLs (composite, service, and supergraph) in the result.
+     * This is separated for performance reasons.
+     */
+    withSDL?: boolean | null;
+    /**
      * Optionally include changes (safe; breaking) in the result.
      * This is seperated for performance reasons.
      */

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -3382,16 +3382,19 @@ export async function createStorage(
 
       const result = await pool.any(psql`/* getPaginatedSchemaChecksForTarget */
         SELECT
-          ${schemaCheckSQLFields(!!args.withSDL)}
+          ${schemaCheckSQLFields({
+            sdl: !!args.withSDL,
+            changes: !!args.withChanges,
+          })}
         FROM
           "schema_checks" as c
           ${
             args.withSDL
               ? psql`
-          LEFT JOIN "sdl_store" as s_schema            ON s_schema."id" = c."schema_sdl_store_id"
-          LEFT JOIN "sdl_store" as s_composite_schema  ON s_composite_schema."id" = c."composite_schema_sdl_store_id"
-          LEFT JOIN "sdl_store" as s_supergraph        ON s_supergraph."id" = c."supergraph_sdl_store_id"  
-            `
+                  LEFT JOIN "sdl_store" as s_schema            ON s_schema."id" = c."schema_sdl_store_id"
+                  LEFT JOIN "sdl_store" as s_composite_schema  ON s_composite_schema."id" = c."composite_schema_sdl_store_id"
+                  LEFT JOIN "sdl_store" as s_supergraph        ON s_supergraph."id" = c."supergraph_sdl_store_id"
+                `
               : psql``
           }
         WHERE
@@ -3437,15 +3440,6 @@ export async function createStorage(
       `);
 
       let items = result.map(row => {
-        if (!args.withSDL && typeof row === 'object') {
-          // append the sdl strings to the object just to pass validation
-          row = {
-            ...row,
-            schemaSDL: '',
-            compositeSchemaSDL: '',
-            supergraphSDL: '',
-          };
-        }
         const node = SchemaCheckModel.parse(row);
 
         return {
@@ -4159,18 +4153,22 @@ export function toSerializableSchemaChange(change: SchemaChangeType): {
   };
 }
 
-const schemaCheckSQLFields = (withSDL = true) => psql`
+const schemaCheckSQLFields = (include?: { sdl?: boolean; changes?: boolean }) => psql`
     c."id"
   , to_json(c."created_at") as "createdAt"
   , to_json(c."updated_at") as "updatedAt"
   ${
-    withSDL
+    (include?.sdl ?? true)
       ? psql`
-  , coalesce(c."schema_sdl", s_schema."sdl") as "schemaSDL"
-  , coalesce(c."composite_schema_sdl", s_composite_schema."sdl") as "compositeSchemaSDL"
-  , coalesce(c."supergraph_sdl", s_supergraph."sdl") as "supergraphSDL"
-    `
-      : psql``
+        , coalesce(c."schema_sdl", s_schema."sdl") as "schemaSDL"
+        , coalesce(c."composite_schema_sdl", s_composite_schema."sdl") as "compositeSchemaSDL"
+        , coalesce(c."supergraph_sdl", s_supergraph."sdl") as "supergraphSDL"
+      `
+      : psql`
+        , '' as "schemaSDL"
+        , null as "compositeSchemaSDL"
+        , null as "supergraphSDL"
+      `
   }
   , c."service_name" as "serviceName"
   , c."service_url" as "serviceUrl"
@@ -4179,8 +4177,17 @@ const schemaCheckSQLFields = (withSDL = true) => psql`
   , c."schema_version_id" as "schemaVersionId"
   , c."is_success" as "isSuccess"
   , c."schema_composition_errors" as "schemaCompositionErrors"
-  , c."breaking_schema_changes" as "breakingSchemaChanges"
-  , c."safe_schema_changes" as "safeSchemaChanges"
+  ${
+    (include?.changes ?? true)
+      ? psql`
+        , c."breaking_schema_changes" as "breakingSchemaChanges"
+        , c."safe_schema_changes" as "safeSchemaChanges"
+      `
+      : psql`
+        , null as "breakingSchemaChanges"
+        , null as "safeSchemaChanges"
+      `
+  }
   , c."schema_policy_warnings" as "schemaPolicyWarnings"
   , c."schema_policy_errors" as "schemaPolicyErrors"
   , c."github_check_run_id" as "githubCheckRunId"

--- a/packages/services/storage/src/schema-change-model.ts
+++ b/packages/services/storage/src/schema-change-model.ts
@@ -1142,7 +1142,7 @@ export const RegistryServiceUrlChangeModel =
 
 // TODO: figure out a way to make sure that all the changes are included in the union
 // Similar to implement().with() but for unions
-export const SchemaChangeModel = z.union([
+export const SchemaChangeModel = z.discriminatedUnion('type', [
   FieldArgumentDescriptionChangedModel,
   FieldArgumentDefaultChangedModel,
   FieldArgumentTypeChangedModel,
@@ -1188,7 +1188,6 @@ export const SchemaChangeModel = z.union([
   EnumValueAddedModel,
   EnumValueDescriptionChangedModel,
   EnumValueDeprecationReasonChangedModel,
-  DirectiveArgumentTypeChangedModel,
   EnumValueDeprecationReasonAddedModel,
   EnumValueDeprecationReasonRemovedModel,
   FieldRemovedModel,

--- a/packages/services/storage/src/schema-change-model.ts
+++ b/packages/services/storage/src/schema-change-model.ts
@@ -1412,7 +1412,10 @@ const FailedSchemaCompositionInputFields = {
 
 const SuccessfulSchemaCompositionOutputFields = {
   schemaCompositionErrors: z.null(),
-  compositeSchemaSDL: z.string(),
+  compositeSchemaSDL: z
+    .string()
+    .nullable()
+    .transform(value => value ?? ''),
   supergraphSDL: z.string().nullable(),
 };
 


### PR DESCRIPTION
### Background

The loading of unnecessary fields here is slowing down the schema checks overview page. See https://github.com/graphql-hive/console/pull/8067 and thx to @jdolle for the previous work in spotting this.

### Description

Load schema changes and sdl for schema checks conditionally.

**Note 1:** This is only a temporary workaround. The real question is whether we should store the changes and sdl within postgres in the first place and/or if schema checks should be stored somewhere else.

**Note 2:** I do not like the fact that we introspect schema info directly and then pass it through to business logic. It is the wrong abstraction. We should probably solve this via something like https://grafast.org/ instead.

### Testing

I inspected local traces to confirm the behaviour. For the pagination query we no longer see the expensive fields selected.

<img width="1182" height="611" alt="image" src="https://github.com/user-attachments/assets/926d2021-62f0-4f6d-aeb2-0813e8bff4a7" />
<img width="1136" height="549" alt="image" src="https://github.com/user-attachments/assets/2aeec69b-d18a-4c3d-b7f9-27ea3f0b6b40" />


For the detail view query we see the expensive fields included:

<img width="1139" height="688" alt="image" src="https://github.com/user-attachments/assets/94d1e238-01d4-45fe-a481-771b2184be25" />
<img width="1069" height="267" alt="image" src="https://github.com/user-attachments/assets/a3274571-d364-44dc-9f44-a9739a42410f" />
