### PR TITLE
make "schema.log"."target_id" column optional

### DIFF
--- a/packages/migrations/src/actions/2026.05.29T00-00-00.schema-log-target-id-nullability.ts
+++ b/packages/migrations/src/actions/2026.05.29T00-00-00.schema-log-target-id-nullability.ts
@@ -1,0 +1,11 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+export default {
+  name: '2026.05.29T00-00-00.schema-log-target-id-nullability.ts',
+  run: ({ psql }) => psql`
+    ALTER TABLE "schema_log"
+      ALTER COLUMN "target_id" DROP NOT NULL
+      , DROP CONSTRAINT "commits_target_id_fkey"
+    ;
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -186,5 +186,6 @@ export const runPGMigrations = async (args: { slonik: PostgresDatabasePool; runT
       await import('./actions/2026.03.25T00-00-00.access-token-expiration'),
       await import('./actions/2026.05.25T00-00-00.drop-sdl-store-unique-id'),
       await import('./actions/2026.05.27T00-00-00.access-tokens-description-nullability'),
+      await import('./actions/2026.05.29T00-00-00.schema-log-target-id-nullability'),
     ],
   });

--- a/packages/services/api/src/modules/proposals/resolvers/SchemaProposal.ts
+++ b/packages/services/api/src/modules/proposals/resolvers/SchemaProposal.ts
@@ -51,7 +51,6 @@ export const SchemaProposal: SchemaProposalResolvers = {
             sdl: node.schemaSDL ?? '', // @todo patch schema changes onto latest
             id: node.id,
             service_name: node.serviceName ?? '',
-            target: node.targetId ?? schema?.target,
             service_url:
               node.serviceUrl ?? (schema?.kind === 'composite' ? schema.service_url : '') ?? '',
             author: node.meta?.author ?? '',

--- a/packages/services/api/src/modules/schema/providers/schema-version-store.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-store.ts
@@ -143,7 +143,6 @@ export class SchemaVersionStore {
       commit: string;
       schema: string;
       projectId: string;
-      targetId: string;
       metadata: string | null;
     },
   ) {
@@ -156,7 +155,6 @@ export class SchemaVersionStore {
           "commit",
           "sdl",
           "project_id",
-          "target_id",
           "metadata",
           "action"
         )
@@ -168,7 +166,6 @@ export class SchemaVersionStore {
         ${args.commit}::text,
         ${args.schema}::text,
         ${args.projectId},
-        ${args.targetId},
         ${args.metadata},
         'PUSH'
       )
@@ -432,7 +429,6 @@ export class SchemaVersionStore {
               "commit",
               "service_name",
               "project_id",
-              "target_id",
               "action"
             )
           VALUES
@@ -441,7 +437,6 @@ export class SchemaVersionStore {
               ${'system'}::text,
               lower(${args.serviceName}::text),
               ${target.projectId},
-              ${target.id},
               'DELETE'
             )
           RETURNING
@@ -527,7 +522,6 @@ export class SchemaVersionStore {
         id: deleteActionResult.id,
         date: deleteActionResult.createdAt as any,
         service_name: deleteActionResult.serviceName,
-        target: deleteActionResult.targetId,
         action: 'DELETE',
         versionId: newVersion.id,
       } satisfies CompositeDeletedSchemaLog & {
@@ -983,7 +977,6 @@ const schemaLogFields = (prefix = psql``) => psql`
   , ${prefix}"commit"
   , ${prefix}"sdl"
   , ${prefix}"created_at" AS "date"
-  , ${prefix}"target_id" AS "target"
   , ${prefix}"metadata"
   , lower(${prefix}"service_name") AS "service_name"
   , ${prefix}"service_url"
@@ -1002,7 +995,6 @@ type CreateContractVersionInput = {
 const SchemaLogBase = z.object({
   id: z.string(),
   date: z.number(),
-  target: z.string().uuid(),
 });
 
 const SchemaPushLogBase = SchemaLogBase.extend({

--- a/packages/services/api/src/modules/schema/providers/schema-version-store.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-store.ts
@@ -443,7 +443,6 @@ export class SchemaVersionStore {
             id
             , to_json("created_at") AS "createdAt"
             , "service_name" AS "serviceName"
-            , "target_id" AS "targetId"
         `,
         )
         .then(
@@ -451,7 +450,6 @@ export class SchemaVersionStore {
             id: z.string(),
             createdAt: z.string(),
             serviceName: z.string(),
-            targetId: z.string(),
           }).parse,
         );
 

--- a/packages/services/api/src/modules/schema/providers/schema-version-store.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-store.ts
@@ -301,7 +301,6 @@ export class SchemaVersionStore {
         commit: args.commit,
         metadata: args.metadata,
         projectId: args.projectId,
-        targetId: args.targetId,
         schema: args.schema,
         service,
         url,

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -358,7 +358,7 @@ export interface schema_log {
   sdl: string | null;
   service_name: string | null;
   service_url: string | null;
-  target_id: string;
+  target_id: string | null;
 }
 
 export interface schema_policy_config {


### PR DESCRIPTION
### Background

Prerequisite for https://github.com/graphql-hive/console/pull/8031; Continuation of efforts from https://github.com/graphql-hive/console/pull/8082

### Description

https://github.com/graphql-hive/console/pull/8031 will introduce that a `schema_log` can be associated with ANY schema version within the same project.

With the current database schema, deleting a target triggers a cascade delete of its associated schema versions and schema_logs. Since schema logs can be shared across multiple schema versions, this may unintentionally remove references that are still required by other versions (which will be introduced in https://github.com/graphql-hive/console/pull/8031), leaving the remaining schema version relationships inconsistent.

To prevent this, this PR introduces the following changes:

- Update the insert logic to stop persisting `target_id` on `schema_log`, as it is no longer used by any relevant business logic.
- Make `schema_log.target_id` nullable and remove its foreign key constraint to prevent cascade deletions when a target is deleted

### Drawback / Consideration

This change introduces a minor concern.

A target can have multiple schema versions, and each schema version can reference multiple schema log entries through the schema_version_to_log relation. In addition, a project directly owns many schema log entries.

When a target is deleted, all associated schema versions are removed via cascade deletion. However, the related schema_log records are not automatically deleted, since they may also be referenced independently at the project level.

As a result, this can lead to orphaned schema_log entries that are no longer associated with any schema version.

To mitigate this, we could introduce a periodic cleanup process (for example, a cron job) in the future to identify and remove unreferenced schema log records.

I added this to a follow up issue https://github.com/graphql-hive/console/issues/8052
