### PR TITLE
fix: apply OS security updates to base images at build time

### DIFF
--- a/.changeset/patch-base-image-os-packages.md
+++ b/.changeset/patch-base-image-os-packages.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Apply OS security updates to the base image at build time by adding `apt-get upgrade` to the service, migrations, and CLI Dockerfiles. Previously these only ran `apt-get update` followed by `apt-get install` of a few specific packages, so Debian security patches inherited from the pinned `node:*-slim` base were never applied — leaving published images with known-fixed CVEs. Bumping the base image tag alone does not fix this, since the latest `node` tag can still lag behind Debian's security updates.

--- a/docker/cli.dockerfile
+++ b/docker/cli.dockerfile
@@ -1,6 +1,6 @@
 FROM node:24.14.1-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends ca-certificates git && rm -rf /var/lib/apt/lists/*
 
 ARG CLI_VERSION
 

--- a/docker/cli.dockerfile
+++ b/docker/cli.dockerfile
@@ -1,6 +1,6 @@
 FROM node:24.14.1-slim
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends ca-certificates git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y --no-install-recommends ca-certificates git && rm -rf /var/lib/apt/lists/*
 
 ARG CLI_VERSION
 

--- a/docker/migrations.dockerfile
+++ b/docker/migrations.dockerfile
@@ -1,6 +1,6 @@
 FROM node:24.14.1-slim
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
 

--- a/docker/migrations.dockerfile
+++ b/docker/migrations.dockerfile
@@ -1,6 +1,6 @@
 FROM node:24.14.1-slim
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
 

--- a/docker/services.dockerfile
+++ b/docker/services.dockerfile
@@ -1,6 +1,6 @@
 FROM node:24.14.1-slim
 
-RUN apt-get update && apt-get install -y wget ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y wget ca-certificates && rm -rf /var/lib/apt/lists/*
 
 ARG SERVICE_DIR_NAME
 WORKDIR /usr/src/app/$SERVICE_DIR_NAME

--- a/docker/services.dockerfile
+++ b/docker/services.dockerfile
@@ -1,6 +1,6 @@
 FROM node:24.14.1-slim
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y wget ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y --no-install-recommends wget ca-certificates && rm -rf /var/lib/apt/lists/*
 
 ARG SERVICE_DIR_NAME
 WORKDIR /usr/src/app/$SERVICE_DIR_NAME


### PR DESCRIPTION
### Background

The `node:*-slim` based Dockerfiles run `apt-get update` followed only by `apt-get install` of a few specific packages — they never run `apt-get upgrade`. Combined with a pinned base tag, this means OS packages inherited from the base image are frozen at its snapshot and never receive Debian security updates, so published images ship known-fixed CVEs in the base layer.

Bumping the base image tag alone doesn't reliably fix this, since the latest tag can still lag behind Debian's security patches.

### Description

Add `apt-get upgrade -y` to the existing `apt-get` step in the service, migrations and CLI Dockerfiles so OS packages are patched at build time. Also adds the missing `rm -rf /var/lib/apt/lists/*` cleanup to `migrations.dockerfile` for consistency.

No application code changes — affects the published Docker images only.

### Checklist

- [x] System configuration
