### PR TITLE
fix(tokens,usage): in case of redis hiccup

### DIFF
--- a/packages/services/tokens/src/index.ts
+++ b/packages/services/tokens/src/index.ts
@@ -77,6 +77,10 @@ export async function main() {
     maxRetriesPerRequest: 20,
     db: 0,
     enableReadyCheck: false,
+    // Reject any command that doesn't get a reply within this window. Without it, a
+    // command sent on a half-open "ready" socket (e.g. after Redis becomes unavailable) can
+    // hang forever.
+    commandTimeout: 5_000,
     tls: env.redis.tlsEnabled ? {} : undefined,
   });
 

--- a/packages/services/usage/src/index.ts
+++ b/packages/services/usage/src/index.ts
@@ -59,6 +59,10 @@ async function main() {
     maxRetriesPerRequest: 20,
     db: 0,
     enableReadyCheck: false,
+    // Reject any command that doesn't get a reply within this window. Without it, a
+    // command sent on a half-open "ready" socket (e.g. after Redis becomes unavailable) can
+    // hang forever.
+    commandTimeout: 5_000,
     tls: env.redis.tlsEnabled ? {} : undefined,
   });
 


### PR DESCRIPTION
### Background

If Redis becomes unavailable for a short moment for whatever reason, the `tokens` service can get stuck returning *"token not found"* for valid tokens until it is manually restarted. `usage` then returns 401s and usage ingestion stops, and the service does not self-recover.



### Description
Adds `commandTimeout` to the ioredis client in two services:
  - `packages/services/tokens`
  - `packages/services/usage`


This MR does not structurally fix the core issue that a redis connection can get into a broken state, it however does throw an error on no response, throwing an error, triggering the backup path of using postgres (in case of the tokens service). Which in turn should fix it functionally but does leave the redis connection broken. 

These are the only two services whose Redis client is constructed without any timeout/retry options (others set `retryStrategy`/`reconnectOnError` through `createRedisClient`). I didnt opt to rewrite usage/tokens to this mechanism as i couldnt fully oversee the consequences.

Longer term it may be worth unifying tokens/usage onto the shared createRedisClient for consistency, though note that alone wouldn't fully resolve this, since it also doesn't set commandTimeout/keepAlive.

  ### Checklist
  - [x] Error handling and logging
  - [x] System configuration
