### PR TITLE
Reconcile grafana metric alert panels and improve ch tracing

### DIFF
--- a/deployment/grafana-dashboards/Metric-Alerts.json
+++ b/deployment/grafana-dashboards/Metric-Alerts.json
@@ -346,11 +346,11 @@
           "datasource": { "type": "tempo", "uid": "TEMPO_DATASOURCE_UID" },
           "filters": [{ "id": "slow-groups-filter", "operator": "=", "scope": "span" }],
           "limit": 100,
-          "query": "{name=\"evaluate-group\" && duration>$slowGroupThreshold}",
+          "query": "{name=\"evaluate-group\" && duration>$slowGroupThreshold} | select(.target.id, .rules.in_group, .time_window_minutes)",
           "queryType": "traceql",
           "refId": "A",
           "spss": 20,
-          "tableType": "traces"
+          "tableType": "spans"
         }
       ],
       "title": "Slow target groups",

--- a/packages/services/workflows/src/lib/clickhouse-client.ts
+++ b/packages/services/workflows/src/lib/clickhouse-client.ts
@@ -1,5 +1,6 @@
 import got from 'got';
 import type { Logger } from '@graphql-hive/logger';
+import { SpanKind, SpanStatusCode, trace } from '@hive/service-common';
 
 export type ClickHouseConfig = {
   host: string;
@@ -8,6 +9,8 @@ export type ClickHouseConfig = {
   password: string;
   protocol?: string;
 };
+
+const tracer = trace.getTracer('clickhouse-client');
 
 export class ClickHouseClient {
   private baseUrl: string;
@@ -20,31 +23,53 @@ export class ClickHouseClient {
     this.baseUrl = `${protocol}://${config.host}:${config.port}`;
   }
 
-  async query<T extends Record<string, unknown>>(sql: string): Promise<T[]> {
-    this.logger.debug('Executing ClickHouse query');
-
-    const response = await got.post(this.baseUrl, {
-      searchParams: {
-        database: 'default',
-        default_format: 'JSON',
-      },
-      headers: {
-        'Content-Type': 'text/plain',
-      },
-      username: this.config.username,
-      password: this.config.password,
-      body: sql,
-      timeout: {
-        request: 10_000,
-      },
-      retry: {
-        limit: 3,
-        methods: ['POST'],
-        statusCodes: [502, 503, 504],
+  // `queryId` names the span (e.g. `ClickHouse: metric-alert-windows`) so the
+  // round-trip is identifiable in the flame chart rather than an unattributed
+  // gap. Because callers run inside an active span (e.g. `evaluate-group`),
+  // startSpan parents this CLIENT span under it automatically...giving the
+  // trace the per-query ClickHouse detail the API-side client already emits.
+  async query<T extends Record<string, unknown>>(sql: string, queryId = 'query'): Promise<T[]> {
+    const span = tracer.startSpan(`ClickHouse: ${queryId}`, {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        'db.type': 'ClickHouse',
+        'db.query': sql,
+        'db.query.id': queryId,
       },
     });
+    this.logger.debug('Executing ClickHouse query');
 
-    const result = JSON.parse(response.body) as { data: T[] };
-    return result.data;
+    try {
+      const response = await got.post(this.baseUrl, {
+        searchParams: {
+          database: 'default',
+          default_format: 'JSON',
+        },
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+        username: this.config.username,
+        password: this.config.password,
+        body: sql,
+        timeout: {
+          request: 10_000,
+        },
+        retry: {
+          limit: 3,
+          methods: ['POST'],
+          statusCodes: [502, 503, 504],
+        },
+      });
+
+      const result = JSON.parse(response.body) as { data: T[]; rows?: number };
+      span.setAttribute('db.response.rows', result.rows ?? result.data.length);
+      return result.data;
+    } catch (error) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: 'clickhouse query failed' });
+      span.setAttribute('error.type', error instanceof Error ? error.name : 'unknown');
+      throw error;
+    } finally {
+      span.end();
+    }
   }
 }

--- a/packages/services/workflows/src/lib/clickhouse-client.ts
+++ b/packages/services/workflows/src/lib/clickhouse-client.ts
@@ -1,6 +1,15 @@
 import got from 'got';
+import { z } from 'zod';
 import type { Logger } from '@graphql-hive/logger';
 import { SpanKind, SpanStatusCode, trace } from '@hive/service-common';
+
+// Validate the response envelope only. Row-level shape is the caller's concern
+// (e.g. queryClickHouseWindows parses `data` with its own Zod schema), so the
+// generic `query<T>` just guarantees `data` is an array before handing it back.
+const ClickHouseResponseSchema = z.object({
+  data: z.array(z.unknown()),
+  rows: z.number().optional(),
+});
 
 export type ClickHouseConfig = {
   host: string;
@@ -61,9 +70,9 @@ export class ClickHouseClient {
         },
       });
 
-      const result = JSON.parse(response.body) as { data: T[]; rows?: number };
+      const result = ClickHouseResponseSchema.parse(JSON.parse(response.body));
       span.setAttribute('db.response.rows', result.rows ?? result.data.length);
-      return result.data;
+      return result.data as T[];
     } catch (error) {
       span.setStatus({ code: SpanStatusCode.ERROR, message: 'clickhouse query failed' });
       span.setAttribute('error.type', error instanceof Error ? error.name : 'unknown');

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.ts
@@ -240,7 +240,7 @@ export async function queryClickHouseWindows(
   const startMs = Date.now();
   let rows: ClickHouseWindowRow[];
   try {
-    const raw = await clickhouse.query(sql);
+    const raw = await clickhouse.query(sql, 'metric-alert-windows');
     rows = z.array(ClickHouseWindowRowSchema).parse(raw);
   } catch (error) {
     metricAlertClickHouseQueryDuration.observe({ outcome: 'error' }, (Date.now() - startMs) / 1000);


### PR DESCRIPTION
This PR fixes an issue with the new metric alert tracing panels in the Grafana dashboard and also ensures that workflows' `clickhouse-client.ts` is reporting trace spans.