### PR TITLE
Metric alerts feature - follow-up UI + grafana updates 

### DIFF
--- a/deployment/services/grafana-alerts.ts
+++ b/deployment/services/grafana-alerts.ts
@@ -35,7 +35,7 @@ export function deployGrafanaAlerts(envName: string) {
       {
         name: 'MetricAlertEvaluatorClickHouseSlow',
         for: '5m',
-        condition: 'B',
+        condition: 'C',
         noDataState: 'OK',
         execErrState: 'Alerting',
         annotations: {
@@ -63,20 +63,39 @@ export function deployGrafanaAlerts(envName: string) {
             }),
           },
           {
+            // Reduce the range-query time series (A) to a single value (its
+            // last point) so the threshold below receives "reduced" data.
+            // Without this, the `threshold` expression rejects the series with
+            // "looks like time series data, only reduced data can be alerted
+            // on", and because execErrState is Alerting the rule then fires on
+            // the eval error itself rather than on real slowness.
             refId: 'B',
             queryType: '',
             relativeTimeRange: { from: 0, to: 0 },
             datasourceUid: '__expr__',
             model: JSON.stringify({
               refId: 'B',
-              type: 'threshold',
+              type: 'reduce',
+              reducer: 'last',
               expression: 'A',
+              datasource: { type: '__expr__', uid: '__expr__' },
+            }),
+          },
+          {
+            refId: 'C',
+            queryType: '',
+            relativeTimeRange: { from: 0, to: 0 },
+            datasourceUid: '__expr__',
+            model: JSON.stringify({
+              refId: 'C',
+              type: 'threshold',
+              expression: 'B',
               conditions: [
                 {
                   type: 'query',
                   evaluator: { type: 'gt', params: [5] },
                   operator: { type: 'and' },
-                  query: { params: ['A'] },
+                  query: { params: ['B'] },
                   reducer: { type: 'last', params: [] },
                 },
               ],
@@ -88,7 +107,7 @@ export function deployGrafanaAlerts(envName: string) {
       {
         name: 'MetricAlertEvaluatorClickHouseErrors',
         for: '5m',
-        condition: 'B',
+        condition: 'C',
         noDataState: 'OK',
         execErrState: 'Alerting',
         annotations: {
@@ -118,20 +137,39 @@ export function deployGrafanaAlerts(envName: string) {
             }),
           },
           {
+            // Reduce the range-query time series (A) to a single value (its
+            // last point) so the threshold below receives "reduced" data.
+            // Without this, the `threshold` expression rejects the series with
+            // "looks like time series data, only reduced data can be alerted
+            // on", and because execErrState is Alerting the rule then fires on
+            // the eval error itself rather than on a real error-rate spike.
             refId: 'B',
             queryType: '',
             relativeTimeRange: { from: 0, to: 0 },
             datasourceUid: '__expr__',
             model: JSON.stringify({
               refId: 'B',
-              type: 'threshold',
+              type: 'reduce',
+              reducer: 'last',
               expression: 'A',
+              datasource: { type: '__expr__', uid: '__expr__' },
+            }),
+          },
+          {
+            refId: 'C',
+            queryType: '',
+            relativeTimeRange: { from: 0, to: 0 },
+            datasourceUid: '__expr__',
+            model: JSON.stringify({
+              refId: 'C',
+              type: 'threshold',
+              expression: 'B',
               conditions: [
                 {
                   type: 'query',
                   evaluator: { type: 'gt', params: [0.05] },
                   operator: { type: 'and' },
-                  query: { params: ['A'] },
+                  query: { params: ['B'] },
                   reducer: { type: 'last', params: [] },
                 },
               ],

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.ts
@@ -89,7 +89,7 @@ function extractMetricValue(row: ClickHouseWindowRow, rule: MetricAlertRuleRow):
       // value are in milliseconds and consistent with all of them. Without this,
       // a ns value (~1.2e9) is compared against a ms threshold (e.g. 4000),
       // so any non-trivial latency trips the rule.
-      return (metricMap[rule.metric!] ?? 0) / NS_TO_MS;
+      return (rule.metric ? metricMap[rule.metric] : 0) / NS_TO_MS;
     }
   }
 }

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.ts
@@ -62,6 +62,10 @@ function makeGroupKey(rule: MetricAlertRuleRow): GroupKey {
   return `${rule.targetId}:${rule.timeWindowMinutes}:${rule.savedFilterId ?? ''}`;
 }
 
+// Nanoseconds per millisecond. ClickHouse stores operation durations in
+// nanoseconds; latency rule thresholds and all display surfaces use ms.
+const NS_TO_MS = 1e6;
+
 function extractMetricValue(row: ClickHouseWindowRow, rule: MetricAlertRuleRow): number {
   const total = Number(row.total);
   const totalOk = Number(row.total_ok);
@@ -79,7 +83,13 @@ function extractMetricValue(row: ClickHouseWindowRow, rule: MetricAlertRuleRow):
         P95: row.percentiles[2],
         P99: row.percentiles[3],
       };
-      return metricMap[rule.metric!] ?? 0;
+      // ClickHouse stores `duration` in nanoseconds, but rule thresholds (the
+      // form input) and every display surface are in
+      // milliseconds. Convert here so the threshold comparison and the persisted
+      // value are in milliseconds and consistent with all of them. Without this,
+      // a ns value (~1.2e9) is compared against a ms threshold (e.g. 4000),
+      // so any non-trivial latency trips the rule.
+      return (metricMap[rule.metric!] ?? 0) / NS_TO_MS;
     }
   }
 }

--- a/packages/web/app/src/components/target/alerts/alert-conditions-panel.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-conditions-panel.tsx
@@ -39,7 +39,7 @@ const METRIC_LABEL_BY_TYPE: Record<MetricAlertRuleType, string> = {
 
 const THRESHOLD_TYPE_LABEL: Record<MetricAlertRuleThresholdType, string> = {
   [MetricAlertRuleThresholdType.FixedValue]: 'Fixed value',
-  [MetricAlertRuleThresholdType.PercentageChange]: 'Relative (%)',
+  [MetricAlertRuleThresholdType.PercentageChange]: '% change vs. previous',
 };
 
 const SEVERITY_DOT_COLOR: Record<MetricAlertRuleSeverity, 'critical' | 'warning' | 'info'> = {

--- a/packages/web/app/src/components/target/alerts/alert-conditions-panel.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-conditions-panel.tsx
@@ -21,6 +21,7 @@ import {
   MetricAlertRuleThresholdType,
   MetricAlertRuleType,
 } from '@/gql/graphql';
+import { formatDuration } from '@/lib/hooks/use-formatted-duration';
 import { Link } from '@tanstack/react-router';
 import { AlertForm, ruleToFormDefaults } from './alert-form';
 import { DeleteRuleConfirmationDialog } from './delete-rule-confirmation-dialog';
@@ -169,10 +170,17 @@ export function AlertConditionsPanel({
       ? `${rule.metric.toLowerCase()} latency`
       : METRIC_LABEL_BY_TYPE[rule.type];
 
+  // A PERCENTAGE_CHANGE threshold is always a percent. A fixed value carries the
+  // metric's own unit: ms for latency (rendered via formatDuration, e.g.
+  // "4.00s"), percent for error rate, and a bare count for traffic.
   const thresholdDisplay =
     rule.thresholdType === MetricAlertRuleThresholdType.PercentageChange
       ? `${rule.thresholdValue}%`
-      : String(rule.thresholdValue);
+      : rule.type === MetricAlertRuleType.Latency
+        ? formatDuration(rule.thresholdValue, true)
+        : rule.type === MetricAlertRuleType.ErrorRate
+          ? `${rule.thresholdValue}%`
+          : String(rule.thresholdValue);
 
   const destination = destinationLabel(rule.channels);
 

--- a/packages/web/app/src/components/target/alerts/alert-form.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-form.tsx
@@ -207,7 +207,11 @@ const CONDITION_OPTIONS = [
 
 const THRESHOLD_TYPE_OPTIONS = [
   { value: 'FIXED_VALUE', label: 'Fixed value' },
-  { value: 'PERCENTAGE_CHANGE', label: 'Relative (%)' },
+  // "% change vs. previous" names the behavior (window-over-window comparison)
+  // rather than the unit. The old "Relative (%)" label leaned on "(%)" to set
+  // itself apart, but for the error-rate metric a Fixed value is also a percent,
+  // so the unit didn't actually distinguish the two options.
+  { value: 'PERCENTAGE_CHANGE', label: '% change vs. previous' },
 ] as const;
 
 const SEVERITIES = [
@@ -480,6 +484,9 @@ export function AlertForm(props: AlertFormProps) {
 
   const watchedValues = form.watch();
   const metricOption = METRIC_OPTIONS.find(o => o.value === watchedValues.metricSelection);
+  // Human-readable window label (e.g. "15m") for the threshold-type helper text.
+  const thresholdRangeLabel =
+    RANGE_OPTIONS.find(o => o.value === watchedValues.timeWindowMinutes)?.label ?? 'selected';
 
   // Parse once at the form boundary so downstream components don't need to
   // re-decode the colon-encoded Select value.
@@ -720,6 +727,12 @@ export function AlertForm(props: AlertFormProps) {
                     )}
                   />
                 </div>
+
+                <p className="text-neutral-10 text-[13px]">
+                  {watchedValues.thresholdType === 'PERCENTAGE_CHANGE'
+                    ? `"% change vs. previous" compares this ${thresholdRangeLabel} window to the one before it. Your value is the percent change between them, e.g. 75 fires on a +75% change rather than an absolute level.`
+                    : `"Fixed value" compares the metric over the ${thresholdRangeLabel} window directly against your value, in the metric's own unit (% for error rate, ms for latency, requests for total requests).`}
+                </p>
 
                 <AlertMetricChart
                   organizationSlug={organizationSlug}

--- a/packages/web/app/src/components/target/alerts/alert-form.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-form.tsx
@@ -310,7 +310,11 @@ export type AlertFormRuleSeed = {
 export function ruleToFormDefaults(rule: AlertFormRuleSeed): AlertFormValues {
   let metricSelection: string;
   if (rule.type === MetricAlertRuleType.Latency && rule.metric) {
-    metricSelection = `LATENCY:${rule.metric.toLowerCase()}`;
+    // METRIC_OPTIONS encodes the percentile uppercase (e.g. `LATENCY:P95`),
+    // matching the `MetricAlertRuleMetric` enum values. Lowercasing here would
+    // produce `LATENCY:p95`, which matches no option (Select shows "Select…")
+    // and fails `parseMetricSelection`'s `METRIC_MAP` lookup on submit.
+    metricSelection = `LATENCY:${rule.metric.toUpperCase()}`;
   } else if (rule.type === MetricAlertRuleType.ErrorRate) {
     metricSelection = 'ERROR_RATE';
   } else {
@@ -327,10 +331,7 @@ export function ruleToFormDefaults(rule: AlertFormRuleSeed): AlertFormValues {
     thresholdValue: String(rule.thresholdValue),
     savedFilterId: rule.savedFilter?.id ?? '',
     confirmationMinutes: String(rule.confirmationMinutes),
-    channels:
-      rule.channels.length > 0
-        ? rule.channels.map(c => ({ channelId: c.id }))
-        : [{ channelId: '' }],
+    channels: rule.channels.map(c => ({ channelId: c.id })),
   };
 }
 

--- a/packages/web/app/src/components/target/alerts/alert-metric-chart.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-metric-chart.tsx
@@ -226,6 +226,10 @@ export function AlertMetricChart({
               backgroundColor: colors.overlayBg,
               borderColor: colors.overlayBorder,
               textStyle: { color: colors.overlayText, fontSize: 12 },
+              // Reuse the y-axis formatter so the hovered value carries its unit
+              // (e.g. "1.86s" for latency, "2%" for error rate) instead of a
+              // bare number like "1,862".
+              valueFormatter: (value: number) => yAxisFormatter(value),
             },
             xAxis: [
               {

--- a/packages/web/app/src/components/target/alerts/alert-notification-preview.stories.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-notification-preview.stories.tsx
@@ -199,7 +199,7 @@ export const Interactive: Story = () => {
             onChange={e => setThresholdType(e.target.value)}
           >
             <option value="FIXED_VALUE">Fixed value</option>
-            <option value="PERCENTAGE_CHANGE">Relative (%)</option>
+            <option value="PERCENTAGE_CHANGE">% change vs. previous</option>
           </select>
         </div>
       </div>

--- a/packages/web/app/src/components/target/alerts/alert-notification-preview.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-notification-preview.tsx
@@ -83,19 +83,52 @@ const SEVERITY_COLORS = {
   INFO: { bar: 'bg-blue-400', text: 'text-blue-400' },
 } as const;
 
-function formatThreshold(direction: string, thresholdValue: string, thresholdType: string) {
+function formatThreshold(
+  alertType: string,
+  direction: string,
+  thresholdValue: string,
+  thresholdType: string,
+) {
   const val = thresholdValue || '-';
   const dir = direction === 'ABOVE' ? 'above' : 'below';
-  const suffix = thresholdType === 'PERCENTAGE_CHANGE' ? '%' : '';
+  // Mirror the unit logic in formatChangeText() in
+  // packages/services/workflows/src/lib/metric-alert-notifier.ts so the preview
+  // matches the real notification. A PERCENTAGE_CHANGE threshold is always a
+  // percent, regardless of the underlying metric.
+  const unit =
+    thresholdType === 'PERCENTAGE_CHANGE'
+      ? '%'
+      : alertType === 'LATENCY'
+        ? 'ms'
+        : alertType === 'ERROR_RATE'
+          ? '%'
+          : ' requests';
   return thresholdType === 'PERCENTAGE_CHANGE'
-    ? `${direction === 'ABOVE' ? 'increased' : 'decreased'} by ${val}%`
-    : `${dir} ${val}${suffix}`;
+    ? `${direction === 'ABOVE' ? 'increased' : 'decreased'} by ${val}${unit}`
+    : `${dir} ${val}${unit}`;
+}
+
+/**
+ * The notification message labels a TRAFFIC alert as "Traffic" (see
+ * formatChangeText in packages/services/workflows/src/lib/metric-alert-notifier.ts),
+ * while the form's metric dropdown calls it "Total requests". Use the
+ * notification's wording in the preview so it matches the real message and so
+ * it doesn't read redundantly as "Total requests ... 150 requests". Error-rate
+ * and latency labels already match the notifier, so they pass through unchanged.
+ */
+function notificationMetricLabel(alertType: string, metricLabel: string) {
+  return alertType === 'TRAFFIC' ? 'Traffic' : metricLabel;
 }
 
 function SlackPreview(props: PreviewProps) {
   const colors =
     SEVERITY_COLORS[props.severity as keyof typeof SEVERITY_COLORS] ?? SEVERITY_COLORS.WARNING;
-  const threshold = formatThreshold(props.direction, props.thresholdValue, props.thresholdType);
+  const threshold = formatThreshold(
+    props.alertType,
+    props.direction,
+    props.thresholdValue,
+    props.thresholdType,
+  );
 
   return (
     <div className="space-y-1">
@@ -118,7 +151,7 @@ function SlackPreview(props: PreviewProps) {
               🚨 {props.alertName || 'Untitled alert'}
             </div>
             <div className="text-neutral-10 mt-1">
-              {props.metricLabel} {threshold}
+              {notificationMetricLabel(props.alertType, props.metricLabel)} {threshold}
             </div>
             <div className="text-neutral-10 mt-1">
               Target:{' '}
@@ -136,7 +169,6 @@ function SlackPreview(props: PreviewProps) {
  * Builds a representative webhook payload for the preview.
  * The shape must match `buildWebhookPayload` in
  * packages/services/workflows/src/lib/metric-alert-notifier.ts
- * — see alert-notification-preview.spec.ts for the sync test.
  */
 export function buildPreviewWebhookPayload(props: PreviewProps) {
   return {
@@ -192,7 +224,12 @@ function WebhookPreview(props: PreviewProps) {
 function TeamsPreview(props: PreviewProps) {
   const colors =
     SEVERITY_COLORS[props.severity as keyof typeof SEVERITY_COLORS] ?? SEVERITY_COLORS.WARNING;
-  const threshold = formatThreshold(props.direction, props.thresholdValue, props.thresholdType);
+  const threshold = formatThreshold(
+    props.alertType,
+    props.direction,
+    props.thresholdValue,
+    props.thresholdType,
+  );
 
   return (
     <div className="space-y-1">
@@ -206,7 +243,7 @@ function TeamsPreview(props: PreviewProps) {
             <div className="flex">
               <span className="text-neutral-10 w-20">Condition</span>
               <span className="text-neutral-11">
-                {props.metricLabel} {threshold}
+                {notificationMetricLabel(props.alertType, props.metricLabel)} {threshold}
               </span>
             </div>
             <div className="flex">

--- a/packages/web/app/src/components/target/alerts/alert-state-transitions-bar.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-state-transitions-bar.tsx
@@ -63,16 +63,18 @@ function labelForSegment(state: SegmentState): string {
 const TICK_COUNT = 7;
 
 function formatTick(date: Date, rangeMs: number): string {
+  // 12-hour clock to match the Latency/metric chart's axis (which renders
+  // "6:25 PM"); the two sit next to each other on the rule-detail page.
   const options: Intl.DateTimeFormatOptions =
     rangeMs < 24 * 60 * 60 * 1000
-      ? { hour: '2-digit', minute: '2-digit', hour12: false }
+      ? { hour: 'numeric', minute: '2-digit' }
       : { month: 'short', day: 'numeric' };
   return new Intl.DateTimeFormat('en-US', options).format(date);
 }
 
 function formatTimestamp(iso: string): string {
   return new Date(iso).toLocaleString('en-US', {
-    hour12: false,
+    hour12: true,
   });
 }
 

--- a/packages/web/app/src/pages/target-alerts-detail.tsx
+++ b/packages/web/app/src/pages/target-alerts-detail.tsx
@@ -19,6 +19,7 @@ import {
   MetricAlertRuleThresholdType,
   MetricAlertRuleType,
 } from '@/gql/graphql';
+import { formatDuration } from '@/lib/hooks/use-formatted-duration';
 import { useTickCounter } from '@/lib/hooks/use-tick-counter';
 import { useNavigate } from '@tanstack/react-router';
 
@@ -168,8 +169,16 @@ function buildDescription(rule: {
       : METRIC_LABEL_BY_TYPE[rule.type];
   const dir = rule.direction === MetricAlertRuleDirection.Above ? 'above' : 'below';
   const isRelative = rule.thresholdType === MetricAlertRuleThresholdType.PercentageChange;
-  const valueDisplay = isRelative ? `${rule.thresholdValue}% (relative)` : `${rule.thresholdValue}`;
-  return `Fires when ${metricLabel} is ${dir} ${valueDisplay} over the ${formatWindowHuman(
+  // Fixed-value thresholds carry the metric's unit: ms for latency (rendered as
+  // "4.00s" via formatDuration), percent for error rate, bare count for traffic.
+  const valueDisplay = isRelative
+    ? `${rule.thresholdValue}% (relative)`
+    : rule.type === MetricAlertRuleType.Latency
+      ? formatDuration(rule.thresholdValue, true)
+      : rule.type === MetricAlertRuleType.ErrorRate
+        ? `${rule.thresholdValue}%`
+        : `${rule.thresholdValue}`;
+  return `Fires when ${metricLabel} is ${dir} ${valueDisplay} over the last ${formatWindowHuman(
     rule.timeWindowMinutes,
   )}.`;
 }

--- a/packages/web/app/src/pages/target-alerts-detail.tsx
+++ b/packages/web/app/src/pages/target-alerts-detail.tsx
@@ -193,6 +193,18 @@ export function TargetAlertsDetailPage(props: {
 
   const rule = result.data?.target?.metricAlertRule;
 
+  // Only surface the error when there's nothing cached to fall back on; if a
+  // cache-and-network refetch errors but we still hold data, we keep showing it.
+  if (result.error && !result.data) {
+    return (
+      <div className="flex h-fit flex-1 items-center justify-center py-28">
+        <div className="text-sm text-red-500">
+          Failed to load alert rule: {result.error.message}
+        </div>
+      </div>
+    );
+  }
+
   if (result.fetching || result.stale || !result.data) {
     return (
       <div className="flex h-fit flex-1 items-center justify-center py-28">
@@ -309,30 +321,48 @@ function RuleStateLogSection(props: {
   });
 
   // urql retains the previous `data` across the variable change each poll, so
-  // these sections keep showing the last state-log while the next one loads
+  // these sections keep showing the last state-log while the next one loads.
+  // We only fall back to loading/error UI when there's nothing cached to show
+  // (initial load), a transient error on a later poll keeps the last good
+  // data on screen rather than blanking it.
   const stateLog = result.data?.target?.metricAlertRule?.stateLog ?? [];
+  const hasNoData = !result.data;
+  const stateLogStatus =
+    result.error && hasNoData ? (
+      <div className="py-4 text-sm text-red-500">
+        Failed to load status transitions: {result.error.message}
+      </div>
+    ) : result.fetching && hasNoData ? (
+      <div className="flex justify-center py-6">
+        <Spinner />
+      </div>
+    ) : null;
 
   return (
     <>
       <section className="space-y-2">
         <h2 className="text-neutral-12 m-0 mb-2 text-sm font-medium">Status transitions</h2>
-        <AlertStateTransitionsBar
-          stateLog={stateLog}
-          from={from}
-          to={to}
-          ruleCreatedAt={rule.createdAt}
-        />
+        {stateLogStatus ?? (
+          <AlertStateTransitionsBar
+            stateLog={stateLog}
+            from={from}
+            to={to}
+            ruleCreatedAt={rule.createdAt}
+          />
+        )}
       </section>
 
       {chart}
 
-      <AlertEventsTable
-        stateLog={stateLog}
-        rule={rule}
-        organizationSlug={organizationSlug}
-        projectSlug={projectSlug}
-        targetSlug={targetSlug}
-      />
+      {stateLogStatus ? null : (
+        <AlertEventsTable
+          stateLog={stateLog}
+          rule={rule}
+          organizationSlug={organizationSlug}
+          projectSlug={projectSlug}
+          targetSlug={targetSlug}
+        />
+      )}
     </>
   );
 }

--- a/packages/web/app/src/pages/target-alerts-detail.tsx
+++ b/packages/web/app/src/pages/target-alerts-detail.tsx
@@ -214,7 +214,7 @@ export function TargetAlertsDetailPage(props: {
     );
   }
 
-  if (result.fetching || result.stale || !result.data) {
+  if (!result.data) {
     return (
       <div className="flex h-fit flex-1 items-center justify-center py-28">
         <Spinner />

--- a/packages/web/app/src/pages/target-alerts-detail.tsx
+++ b/packages/web/app/src/pages/target-alerts-detail.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 import { subMinutes } from 'date-fns';
 import { useQuery } from 'urql';
 import { Select } from '@/components/base/floating/select/select';
@@ -6,7 +6,10 @@ import { PageLead } from '@/components/base/page-lead';
 import { BackLink } from '@/components/navigation/back-link';
 import { ResourceNotFoundComponent } from '@/components/resource-not-found';
 import { AlertConditionsPanel } from '@/components/target/alerts/alert-conditions-panel';
-import { AlertEventsTable } from '@/components/target/alerts/alert-events-table';
+import {
+  AlertEventsTable,
+  type AlertEventsTableRule,
+} from '@/components/target/alerts/alert-events-table';
 import { AlertMetricChart } from '@/components/target/alerts/alert-metric-chart';
 import { AlertStateTransitionsBar } from '@/components/target/alerts/alert-state-transitions-bar';
 import { Spinner } from '@/components/ui/spinner';
@@ -19,14 +22,16 @@ import {
 import { useTickCounter } from '@/lib/hooks/use-tick-counter';
 import { useNavigate } from '@tanstack/react-router';
 
-const TargetAlertsDetailPage_Query = graphql(`
-  query TargetAlertsDetailPage_Query(
+// Static rule configuration. Fetched once with no polling — the Modify-alert
+// sheet (and everything else in the page chrome) lives under this query, so it
+// is never torn down by a background refetch. The live, time-windowed
+// `stateLog` is fetched separately by `RuleStateLogSection` below.
+const TargetAlertsDetailPage_RuleConfigQuery = graphql(`
+  query TargetAlertsDetailPage_RuleConfigQuery(
     $organizationSlug: String!
     $projectSlug: String!
     $targetSlug: String!
     $ruleId: ID!
-    $from: DateTime!
-    $to: DateTime!
   ) {
     target(
       reference: {
@@ -83,6 +88,32 @@ const TargetAlertsDetailPage_Query = graphql(`
           id
           displayName
         }
+      }
+    }
+  }
+`);
+
+const TargetAlertsDetailPage_StateLogQuery = graphql(`
+  query TargetAlertsDetailPage_StateLogQuery(
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
+    $ruleId: ID!
+    $from: DateTime!
+    $to: DateTime!
+  ) {
+    target(
+      reference: {
+        bySelector: {
+          organizationSlug: $organizationSlug
+          projectSlug: $projectSlug
+          targetSlug: $targetSlug
+        }
+      }
+    ) {
+      id
+      metricAlertRule(id: $ruleId) {
+        id
         stateLog(from: $from, to: $to) {
           id
           fromState
@@ -154,32 +185,14 @@ export function TargetAlertsDetailPage(props: {
 
   const [viewRangeMinutes, setViewRangeMinutes] = useState('60');
 
-  // Advance the rolling window every 15s so the state-transitions bar,
-  // events table, and metric snapshots reflect transitions the workflows
-  // evaluator drives on its 60s cron cadence. Including `tick` in the
-  // useMemo deps recomputes `now`, which changes the variables, which
-  // urql treats as a new query and refires automatically.
-  const tick = useTickCounter(15_000);
-  const { from, to } = useMemo(() => {
-    const now = new Date();
-    const minutes = parseInt(viewRangeMinutes, 10) || 60;
-    return {
-      from: subMinutes(now, minutes).toISOString(),
-      to: now.toISOString(),
-    };
-  }, [viewRangeMinutes, tick]);
-
   const [result] = useQuery({
-    query: TargetAlertsDetailPage_Query,
-    variables: { organizationSlug, projectSlug, targetSlug, ruleId, from, to },
+    query: TargetAlertsDetailPage_RuleConfigQuery,
+    variables: { organizationSlug, projectSlug, targetSlug, ruleId },
     requestPolicy: 'cache-and-network',
   });
 
   const rule = result.data?.target?.metricAlertRule;
 
-  // Spinner while loading (initial fetch, or revalidation after navigation
-  // where urql briefly serves stale `metricAlertRule: null`). Only render
-  // not-found once the network has confirmed it.
   if (result.fetching || result.stale || !result.data) {
     return (
       <div className="flex h-fit flex-1 items-center justify-center py-28">
@@ -217,43 +230,35 @@ export function TargetAlertsDetailPage(props: {
           />
         </div>
 
-        <section className="space-y-2">
-          <h2 className="text-neutral-12 m-0 mb-2 text-sm font-medium">Status transitions</h2>
-          <AlertStateTransitionsBar
-            stateLog={rule.stateLog}
-            from={from}
-            to={to}
-            ruleCreatedAt={rule.createdAt}
-          />
-        </section>
-
-        <section className="space-y-2">
-          <h2 className="text-neutral-12 m-0 text-sm font-medium">
-            {rule.type === MetricAlertRuleType.ErrorRate
-              ? 'Error rate over time'
-              : rule.type === MetricAlertRuleType.Latency
-                ? 'Latency over time'
-                : 'Traffic over time'}
-          </h2>
-          <AlertMetricChart
-            organizationSlug={organizationSlug}
-            projectSlug={projectSlug}
-            targetSlug={targetSlug}
-            type={rule.type}
-            metric={rule.metric}
-            timeWindowMinutes={parseInt(viewRangeMinutes, 10) || 60}
-            thresholdValue={rule.thresholdValue}
-            direction={rule.direction}
-            thresholdType={rule.thresholdType}
-          />
-        </section>
-
-        <AlertEventsTable
-          stateLog={rule.stateLog}
-          rule={rule}
+        <RuleStateLogSection
           organizationSlug={organizationSlug}
           projectSlug={projectSlug}
           targetSlug={targetSlug}
+          ruleId={rule.id}
+          viewRangeMinutes={viewRangeMinutes}
+          rule={rule}
+          chart={
+            <section className="space-y-2">
+              <h2 className="text-neutral-12 m-0 text-sm font-medium">
+                {rule.type === MetricAlertRuleType.ErrorRate
+                  ? 'Error rate over time'
+                  : rule.type === MetricAlertRuleType.Latency
+                    ? 'Latency over time'
+                    : 'Traffic over time'}
+              </h2>
+              <AlertMetricChart
+                organizationSlug={organizationSlug}
+                projectSlug={projectSlug}
+                targetSlug={targetSlug}
+                type={rule.type}
+                metric={rule.metric}
+                timeWindowMinutes={parseInt(viewRangeMinutes, 10) || 60}
+                thresholdValue={rule.thresholdValue}
+                direction={rule.direction}
+                thresholdType={rule.thresholdType}
+              />
+            </section>
+          }
         />
       </div>
 
@@ -272,5 +277,62 @@ export function TargetAlertsDetailPage(props: {
         />
       </aside>
     </div>
+  );
+}
+
+function RuleStateLogSection(props: {
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
+  ruleId: string;
+  viewRangeMinutes: string;
+  rule: AlertEventsTableRule & { createdAt: string };
+  chart: ReactNode;
+}) {
+  const { organizationSlug, projectSlug, targetSlug, ruleId, viewRangeMinutes, rule, chart } =
+    props;
+
+  const tick = useTickCounter(15_000);
+  const { from, to } = useMemo(() => {
+    const now = new Date();
+    const minutes = parseInt(viewRangeMinutes, 10) || 60;
+    return {
+      from: subMinutes(now, minutes).toISOString(),
+      to: now.toISOString(),
+    };
+  }, [viewRangeMinutes, tick]);
+
+  const [result] = useQuery({
+    query: TargetAlertsDetailPage_StateLogQuery,
+    variables: { organizationSlug, projectSlug, targetSlug, ruleId, from, to },
+    requestPolicy: 'cache-and-network',
+  });
+
+  // urql retains the previous `data` across the variable change each poll, so
+  // these sections keep showing the last state-log while the next one loads
+  const stateLog = result.data?.target?.metricAlertRule?.stateLog ?? [];
+
+  return (
+    <>
+      <section className="space-y-2">
+        <h2 className="text-neutral-12 m-0 mb-2 text-sm font-medium">Status transitions</h2>
+        <AlertStateTransitionsBar
+          stateLog={stateLog}
+          from={from}
+          to={to}
+          ruleCreatedAt={rule.createdAt}
+        />
+      </section>
+
+      {chart}
+
+      <AlertEventsTable
+        stateLog={stateLog}
+        rule={rule}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
+      />
+    </>
   );
 }


### PR DESCRIPTION
This PR fixes non-critical UI issues that were shipped as part of the recently-merged metric alerts feature.

- Updates the query/polling config such that the entire page query doesn't "refetch"
- Fixes form issues inside the "modify alert" sheet 
- Makes clear the threshold type 
- Fixes an issues with one of the metric alerts Grafana alerts
