### PR TITLE
Add `manifest` method to `createHive(...).persistedDocuments` for fetching a persisted documents (app deployment) manifest

### DIFF
--- a/.changeset/rich-waves-trade.md
+++ b/.changeset/rich-waves-trade.md
@@ -8,8 +8,8 @@ Add `manifest` method to `createHive(...).persistedDocuments` for fetching a per
 const hive = createHive({
   persistedDocuments: {
     cdn: {
-      endpoint: 'https://cdn.graphql-hive.com',
-      accessToken: 'your-cdn-access-token',
+      endpoint: 'https://cdn.graphql-hive.com/artifacts/v1/<target_id>',
+      accessToken: '<cdn_access_token>',
     },
   },
   // ...

--- a/.changeset/rich-waves-trade.md
+++ b/.changeset/rich-waves-trade.md
@@ -15,7 +15,7 @@ const hive = createHive({
   // ...
 });
 
-const manifest = await hive.persistedDocuments?.manifest({
+const manifest = await hive.persistedDocuments!.manifest({
   appName: 'my-app',
   appVersion: '1.0.0',
 });

--- a/.changeset/rich-waves-trade.md
+++ b/.changeset/rich-waves-trade.md
@@ -2,7 +2,7 @@
 '@graphql-hive/core': patch
 ---
 
-Add `manifest` method to `createHive(...).persistedDocuments` for fetching a persisted documents manifests
+Add `manifest` method to `createHive(...).persistedDocuments` for fetching a persisted documents (app deployment) manifest
 
 ```ts
 const hive = createHive({
@@ -15,17 +15,20 @@ const hive = createHive({
   // ...
 });
 
-const manifest = await hive.persistedDocuments!.manifest({
+const manifest = await hive.persistedDocuments?.manifest({
   appName: 'my-app',
   appVersion: '1.0.0',
 });
 
-// manifest is null if not found, or:
+// null if the app version does not exist, otherwise:
 // {
-//   id: string
-//   appName: string
-//   appVersion: string
-//   isActive: boolean
-//   documentHashes: string[]
+//   id: 'some-uuid',          // unique identifier of the manifest
+//   appName: 'my-app',        // app name
+//   appVersion: '1.0.0',      // app version
+//   isActive: true,           // whether this app version is published/active in Hive
+//   documentHashes: [         // all persisted document hashes for this app version
+//     'abc123',
+//     'def456',
+//   ],
 // }
 ```

--- a/.changeset/rich-waves-trade.md
+++ b/.changeset/rich-waves-trade.md
@@ -2,4 +2,30 @@
 '@graphql-hive/core': patch
 ---
 
-TODO: manifest
+Add `manifest` method to `createHive(...).persistedDocuments` for fetching a persisted documents manifests
+
+```ts
+const hive = createHive({
+  persistedDocuments: {
+    cdn: {
+      endpoint: 'https://cdn.graphql-hive.com',
+      accessToken: 'your-cdn-access-token',
+    },
+  },
+  // ...
+});
+
+const manifest = await hive.persistedDocuments!.manifest({
+  appName: 'my-app',
+  appVersion: '1.0.0',
+});
+
+// manifest is null if not found, or:
+// {
+//   id: string
+//   appName: string
+//   appVersion: string
+//   isActive: boolean
+//   documentHashes: string[]
+// }
+```

--- a/.changeset/rich-waves-trade.md
+++ b/.changeset/rich-waves-trade.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/core': patch
+---
+
+TODO: manifest

--- a/packages/libraries/core/src/client/persisted-documents.ts
+++ b/packages/libraries/core/src/client/persisted-documents.ts
@@ -90,11 +90,20 @@ function createValidationError(
   return new PersistedDocumentValidationError(documentId, error);
 }
 
+/**
+ * The app deployment manifest as registered in Hive, containing metadata
+ * and the full list of persisted document hashes for a specific app version.
+ */
 export interface PersistedDocumentsManifest {
+  /** Unique identifier of the manifest. */
   id: string;
+  /** Name of the app this manifest belongs to. */
   appName: string;
+  /** Version of the app this manifest belongs to. */
   appVersion: string;
+  /** Whether this app version is published/active in Hive. */
   isActive: boolean;
+  /** All persisted document hashes registered for this app version. */
   documentHashes: string[];
 }
 

--- a/packages/libraries/core/src/client/persisted-documents.ts
+++ b/packages/libraries/core/src/client/persisted-documents.ts
@@ -90,7 +90,19 @@ function createValidationError(
   return new PersistedDocumentValidationError(documentId, error);
 }
 
-type PersistedDocuments = {
+export interface PersistedDocumentsManifest {
+  id: string;
+  appName: string;
+  appVersion: string;
+  isActive: boolean;
+  documentHashes: string[];
+}
+
+export type PersistedDocuments = {
+  manifest(
+    deployment: { appName: string; appVersion: string },
+    context?: { waitUntil?: (promise: Promise<void> | void) => void },
+  ): PromiseOrValue<PersistedDocumentsManifest | null>;
   resolve(
     documentId: string,
     context?: { waitUntil?: (promise: Promise<void> | void) => void },
@@ -107,9 +119,6 @@ export function createPersistedDocuments(
     timeout?: HttpCallConfig['retry'];
   },
 ): PersistedDocuments {
-  // L1
-  const persistedDocumentsCache = lru<string | null>(config.cache ?? 10_000);
-
   // L2
   const layer2Cache: PersistedDocumentsCache | undefined = config.layer2Cache?.cache;
   let layer2TtlSeconds = config.layer2Cache?.ttlSeconds;
@@ -144,8 +153,9 @@ export function createPersistedDocuments(
     allowArbitraryDocuments = () => false;
   }
 
-  /** if there is already a in-flight request for a document, we re-use it. */
-  const fetchCache = new Map<string, Promise<string | null>>();
+  /** if there is already a in-flight request for a document or manifest, we re-use it. */
+  const cdnCache = lru<string | null>(config.cache ?? 10_000);
+  const cdnFetchCache = new Map<string, Promise<string | null>>();
 
   const endpoints = Array.isArray(config.cdn.endpoint)
     ? config.cdn.endpoint
@@ -153,11 +163,11 @@ export function createPersistedDocuments(
 
   const circuitBreakers = endpoints.map(endpoint => {
     const circuitBreaker = new CircuitBreaker(
-      async function doFetch(cdnDocumentId: string) {
+      async function doFetch(pathname: string) {
         const signal = circuitBreaker.getSignal();
 
         return await http
-          .get(endpoint + '/apps/' + cdnDocumentId, {
+          .get(endpoint + '/apps/' + pathname, {
             headers: {
               'X-Hive-CDN-Key': config.cdn.accessToken,
             },
@@ -171,8 +181,7 @@ export function createPersistedDocuments(
             if (response.status !== 200) {
               return null;
             }
-            const text = await response.text();
-            return text;
+            return response.text();
           });
       },
       {
@@ -184,6 +193,51 @@ export function createPersistedDocuments(
 
     return circuitBreaker;
   });
+
+  function fetchFromCDN(
+    pathname: string,
+    context?: { waitUntil?: (promise: Promise<void> | void) => void },
+  ): Promise<string | null> {
+    const cached = cdnCache.get(pathname);
+    if (cached !== undefined) {
+      return Promise.resolve(cached);
+    }
+
+    let promise = cdnFetchCache.get(pathname);
+    if (promise) {
+      return promise;
+    }
+
+    promise = (async (): Promise<string | null> => {
+      const l2Result = await getFromLayer2Cache(pathname);
+      if (l2Result.hit) {
+        cdnCache.set(pathname, l2Result.value);
+        return l2Result.value;
+      }
+
+      let lastError: unknown = null;
+      for (const breaker of circuitBreakers) {
+        try {
+          const result = await breaker.fire(pathname);
+          cdnCache.set(pathname, result);
+          setInLayer2Cache(pathname, result, context?.waitUntil);
+          return result;
+        } catch (error: unknown) {
+          config.logger.debug({ error });
+          lastError = error;
+        }
+      }
+      if (lastError) {
+        config.logger.error({ error: lastError });
+      }
+      throw new Error(`Failed to fetch '${pathname}' from CDN.`);
+    })().finally(() => {
+      cdnFetchCache.delete(pathname);
+    });
+
+    cdnFetchCache.set(pathname, promise);
+    return promise;
+  }
 
   // Attempt to get document from L2 cache, returns: { hit: true, value: string | null } or { hit: false }
   async function getFromLayer2Cache(
@@ -270,82 +324,30 @@ export function createPersistedDocuments(
     documentId: string,
     context?: { waitUntil?: (promise: Promise<void> | void) => void },
   ) {
-    // Validate document ID format first
     const validationError = validateDocumentId(documentId);
     if (validationError) {
-      // Return a promise that will be rejected with a proper error
       return Promise.reject(createValidationError(documentId, validationError.error));
     }
+    return fetchFromCDN(documentId.replaceAll('~', '/'), context);
+  }
 
-    // L1 cache check (in-memory)
-    // Note: We need to distinguish between "not in cache" (undefined) and "cached as not found" (null)
-    const cachedDocument = persistedDocumentsCache.get(documentId);
-    if (cachedDocument !== undefined) {
-      // Cache hit, return the value
-      return cachedDocument;
-    }
-
-    // Check in-flight requests
-    let promise = fetchCache.get(documentId);
-    if (promise) {
-      return promise;
-    }
-
-    promise = Promise.resolve()
-      .then(async (): Promise<{ value: string | null; fromL2: boolean }> => {
-        // L2 cache check
-        const l2Result = await getFromLayer2Cache(documentId);
-        if (l2Result.hit) {
-          // L2 cache hit, store in L1 for faster subsequent access
-          persistedDocumentsCache.set(documentId, l2Result.value);
-          return { value: l2Result.value, fromL2: true };
-        }
-
-        // CDN fetch
-        const cdnDocumentId = documentId.replaceAll('~', '/');
-
-        let lastError: unknown = null;
-
-        for (const breaker of circuitBreakers) {
-          try {
-            const result = await breaker.fire(cdnDocumentId);
-            return { value: result, fromL2: false };
-          } catch (error: unknown) {
-            config.logger.debug({ error });
-            lastError = error;
-          }
-        }
-        if (lastError) {
-          config.logger.error({ error: lastError });
-        }
-        throw new Error('Failed to look up persisted operation.');
-      })
-      .then(({ value, fromL2 }) => {
-        // Store in L1 cache (in-memory), only if not already stored from L2 hit
-        if (!fromL2) {
-          persistedDocumentsCache.set(documentId, value);
-          // Store in L2 cache (async, non-blocking), only for CDN fetched data
-          setInLayer2Cache(documentId, value, context?.waitUntil);
-        }
-
-        return value;
-      })
-      .finally(() => {
-        fetchCache.delete(documentId);
-      });
-
-    fetchCache.set(documentId, promise);
-
-    return promise;
+  function loadManifest(
+    deployment: { appName: string; appVersion: string },
+    context?: { waitUntil?: (promise: Promise<void> | void) => void },
+  ): Promise<PersistedDocumentsManifest | null> {
+    return fetchFromCDN(`${deployment.appName}/${deployment.appVersion}`, context).then(result =>
+      result ? (JSON.parse(result) as PersistedDocumentsManifest) : null,
+    );
   }
 
   return {
     allowArbitraryDocuments,
     resolve: loadPersistedDocument,
+    manifest: loadManifest,
     dispose() {
       circuitBreakers.map(breaker => breaker.shutdown());
-      persistedDocumentsCache.clear();
-      fetchCache.clear();
+      cdnCache.clear();
+      cdnFetchCache.clear();
     },
   };
 }

--- a/packages/libraries/core/src/client/persisted-documents.ts
+++ b/packages/libraries/core/src/client/persisted-documents.ts
@@ -164,7 +164,7 @@ export function createPersistedDocuments(
 
   /** if there is already a in-flight request for a document or manifest, we re-use it. */
   const cdnCache = lru<string | null>(config.cache ?? 10_000);
-  const cdnFetchCache = new Map<string, Promise<string | null>>();
+  const fetchCache = new Map<string, Promise<string | null>>();
 
   const endpoints = Array.isArray(config.cdn.endpoint)
     ? config.cdn.endpoint
@@ -204,47 +204,64 @@ export function createPersistedDocuments(
   });
 
   function fetchFromCDN(
-    pathname: string,
+    documentIdOrPathname: string,
     context?: { waitUntil?: (promise: Promise<void> | void) => void },
   ): Promise<string | null> {
-    const cached = cdnCache.get(pathname);
+    const cached = cdnCache.get(documentIdOrPathname);
     if (cached !== undefined) {
       return Promise.resolve(cached);
     }
 
-    let promise = cdnFetchCache.get(pathname);
+    let promise = fetchCache.get(documentIdOrPathname);
     if (promise) {
       return promise;
     }
 
-    promise = (async (): Promise<string | null> => {
-      const l2Result = await getFromLayer2Cache(pathname);
-      if (l2Result.hit) {
-        cdnCache.set(pathname, l2Result.value);
-        return l2Result.value;
-      }
-
-      let lastError: unknown = null;
-      for (const breaker of circuitBreakers) {
-        try {
-          const result = await breaker.fire(pathname);
-          cdnCache.set(pathname, result);
-          setInLayer2Cache(pathname, result, context?.waitUntil);
-          return result;
-        } catch (error: unknown) {
-          config.logger.debug({ error });
-          lastError = error;
+    promise = Promise.resolve()
+      .then(async (): Promise<{ value: string | null; fromL2: boolean }> => {
+        // L2 cache check
+        const l2Result = await getFromLayer2Cache(documentIdOrPathname);
+        if (l2Result.hit) {
+          // L2 cache hit, store in L1 for faster subsequent access
+          cdnCache.set(documentIdOrPathname, l2Result.value);
+          return { value: l2Result.value, fromL2: true };
         }
-      }
-      if (lastError) {
-        config.logger.error({ error: lastError });
-      }
-      throw new Error(`Failed to fetch '${pathname}' from CDN.`);
-    })().finally(() => {
-      cdnFetchCache.delete(pathname);
-    });
 
-    cdnFetchCache.set(pathname, promise);
+        // CDN fetch
+        const pathname = documentIdOrPathname.replaceAll('~', '/');
+
+        let lastError: unknown = null;
+
+        for (const breaker of circuitBreakers) {
+          try {
+            const result = await breaker.fire(pathname);
+            return { value: result, fromL2: false };
+          } catch (error: unknown) {
+            config.logger.debug({ error });
+            lastError = error;
+          }
+        }
+        if (lastError) {
+          config.logger.error({ error: lastError });
+        }
+        throw new Error(`Failed to fetch "${pathname}" from CDN.`);
+      })
+      .then(({ value, fromL2 }) => {
+        // Store in L1 cache (in-memory), only if not already stored from L2 hit
+        if (!fromL2) {
+          cdnCache.set(documentIdOrPathname, value);
+          // Store in L2 cache (async, non-blocking), only for CDN fetched data
+          setInLayer2Cache(documentIdOrPathname, value, context?.waitUntil);
+        }
+
+        return value;
+      })
+      .finally(() => {
+        fetchCache.delete(documentIdOrPathname);
+      });
+
+    fetchCache.set(documentIdOrPathname, promise);
+
     return promise;
   }
 
@@ -337,16 +354,19 @@ export function createPersistedDocuments(
     if (validationError) {
       return Promise.reject(createValidationError(documentId, validationError.error));
     }
-    return fetchFromCDN(documentId.replaceAll('~', '/'), context);
+    return fetchFromCDN(documentId, context);
   }
 
   function loadManifest(
     deployment: { appName: string; appVersion: string },
     context?: { waitUntil?: (promise: Promise<void> | void) => void },
   ): Promise<PersistedDocumentsManifest | null> {
-    return fetchFromCDN(`${deployment.appName}/${deployment.appVersion}`, context).then(result =>
-      result ? (JSON.parse(result) as PersistedDocumentsManifest) : null,
-    );
+    return fetchFromCDN(`${deployment.appName}/${deployment.appVersion}`, context)
+      .then(result => (result ? (JSON.parse(result) as PersistedDocumentsManifest) : null))
+      .catch(err => {
+        config.logger.error({ err, deployment }, 'Failed to load persisted documents manifest');
+        throw err;
+      });
   }
 
   return {
@@ -356,7 +376,7 @@ export function createPersistedDocuments(
     dispose() {
       circuitBreakers.map(breaker => breaker.shutdown());
       cdnCache.clear();
-      cdnFetchCache.clear();
+      fetchCache.clear();
     },
   };
 }

--- a/packages/libraries/core/src/client/persisted-documents.ts
+++ b/packages/libraries/core/src/client/persisted-documents.ts
@@ -244,7 +244,13 @@ export function createPersistedDocuments(
         if (lastError) {
           config.logger.error({ error: lastError });
         }
-        throw new Error(`Failed to fetch "${pathname}" from CDN.`);
+        if (pathname === documentIdOrPathname) {
+          // manifest
+          throw new Error('Failed to look up persisted operations manifest.');
+        } else {
+          // persisted documents (because ~ was replaced)
+          throw new Error('Failed to look up persisted operation.');
+        }
       })
       .then(({ value, fromL2 }) => {
         // Store in L1 cache (in-memory), only if not already stored from L2 hit

--- a/packages/libraries/core/src/client/types.ts
+++ b/packages/libraries/core/src/client/types.ts
@@ -5,6 +5,7 @@ import { MaybePromise } from '@graphql-tools/utils';
 import type { AgentOptions } from './agent.js';
 import { CircuitBreakerConfiguration } from './circuit-breaker.js';
 import type { autoDisposeSymbol, hiveClientSymbol } from './client.js';
+import type { PersistedDocumentsManifest } from './persisted-documents.js';
 import type { SchemaReporter } from './reporting.js';
 
 type HeadersObject = {
@@ -42,6 +43,10 @@ export interface HiveClient {
   createInstrumentedSubscribe(executeImpl: any): any;
   dispose(): Promise<void>;
   persistedDocuments: null | {
+    manifest(
+      deployment: { appName: string; appVersion: string },
+      context?: { waitUntil?: (promise: Promise<void> | void) => void },
+    ): PromiseOrValue<PersistedDocumentsManifest | null>;
     resolve(
       documentId: string,
       context?: { waitUntil?: (promise: Promise<void> | void) => void },
@@ -49,6 +54,8 @@ export interface HiveClient {
     allowArbitraryDocuments(context: { headers?: HeadersObject }): PromiseOrValue<boolean>;
   };
 }
+
+export type { PersistedDocumentsManifest };
 
 export type AsyncIterableIteratorOrValue<T> = AsyncIterableIterator<T> | T;
 export type AsyncIterableOrValue<T> = AsyncIterable<T> | T;

--- a/packages/libraries/core/src/index.ts
+++ b/packages/libraries/core/src/index.ts
@@ -5,6 +5,7 @@ export type {
   HiveClient,
   CollectUsageCallback,
   LegacyLogger as Logger,
+  PersistedDocumentsManifest,
   PersistedDocumentsCache,
   Layer2CacheConfiguration,
 } from './client/types.js';


### PR DESCRIPTION
Following up on #8015

Uses the same technique as fetching persisted documents: caching, circuit breaker, retrying, multiple endpoints, timeouts, etc.

```ts
const hive = createHive({
  persistedDocuments: {
    cdn: {
      endpoint: 'https://cdn.graphql-hive.com/artifacts/v1/<target_id>',
      accessToken: '<cdn_access_token>',
    },
  },
  // ...
});

const manifest = await hive.persistedDocuments!.manifest({
  appName: 'my-app',
  appVersion: '1.0.0',
});
```

- no extra tests because the current one cover it all
- l2 cache keys didnt change

### TODO

- [ ] docs
