### PR TITLE
feat: bump clickhouse-server docker image

### DIFF
--- a/.changeset/loose-teams-clap.md
+++ b/.changeset/loose-teams-clap.md
@@ -2,6 +2,11 @@
 'hive': minor
 ---
 
-Bump recommended clickhouse version for self-hosting to `26.3.12.3`. Pass
-`output_format_json_quote_64bit_integers=1` search parameter to clickhouse database queries
+Bump recommended clickhouse version for self-hosting to `26.3.12.3`.
+
+Pass `output_format_json_quote_64bit_integers=1` search parameter to clickhouse database queries
 expecting `JSON` responses to ensure consistent response output for different cloud providers.
+
+**Note:** Please ensure you are properly backing up your database and follow the Clickhouse changelog before using a newer ClickHouse version.
+We use `clickhouse/clickhouse-server` only for local development and integration testing.
+For production workloads, we recommend using a managed cloud service or having dedicated staff responsible for operating ClickHouse and planning upgrades.

--- a/.changeset/loose-teams-clap.md
+++ b/.changeset/loose-teams-clap.md
@@ -1,0 +1,7 @@
+---
+'hive': minor
+---
+
+Bump recommended clickhouse version for self-hosting to `26.3.12.3`. Pass
+`output_format_json_quote_64bit_integers=1` search parameter to clickhouse database queries
+expecting `JSON` responses to ensure consistent response output for different cloud providers.

--- a/docker/docker-compose.community.yml
+++ b/docker/docker-compose.community.yml
@@ -23,7 +23,7 @@ services:
       - ./.hive/postgres:/var/lib/postgresql/data
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.8-alpine
+    image: clickhouse/clickhouse-server:26.3.12.3-alpine
     healthcheck:
       test: ['CMD', 'wget', '--spider', '-q', 'http://0.0.0.0:8123/ping']
       interval: 5s

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -73,7 +73,7 @@ services:
       ls myminio/artifacts >/dev/null 2>&1 || /usr/bin/mc mb myminio/artifacts; exit 0"
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.8-alpine
+    image: clickhouse/clickhouse-server:26.3.12.3-alpine
     mem_limit: 4096m
     environment:
       CLICKHOUSE_USER: test

--- a/integration-tests/testkit/clickhouse.ts
+++ b/integration-tests/testkit/clickhouse.ts
@@ -11,16 +11,16 @@ export async function clickHouseQuery<T>(query: string): Promise<{
   rows: number;
 }> {
   const clickhouseAddress = await getServiceHost('clickhouse', 8123);
-  const endpoint = `http://${clickhouseAddress}/?default_format=JSON`;
-  const response = await fetch(endpoint, {
+  const url = new URL(`http://${clickhouseAddress}`);
+  url.searchParams.set('default_format', 'JSON');
+  url.searchParams.set('output_format_json_quote_64bit_integers', '1');
+  const response = await fetch(url, {
     method: 'POST',
     body: query,
     headers: {
       Accept: 'application/json',
       'Accept-Encoding': 'gzip',
       Authorization: `Basic ${credentials}`,
-      default_format: 'JSON',
-      output_format_json_quote_64bit_integers: '1',
     },
   });
 
@@ -35,8 +35,10 @@ export async function clickHouseQuery<T>(query: string): Promise<{
 
 export async function clickHouseInsert<T>(query: string): Promise<void> {
   const clickhouseAddress = await getServiceHost('clickhouse', 8123);
-  const endpoint = `http://${clickhouseAddress}/?default_format=JSON`;
-  const response = await fetch(endpoint, {
+  const url = new URL(`http://${clickhouseAddress}`);
+  url.searchParams.set('default_format', 'JSON');
+  url.searchParams.set('output_format_json_quote_64bit_integers', '1');
+  const response = await fetch(url, {
     method: 'POST',
     body: query,
     headers: {

--- a/integration-tests/testkit/clickhouse.ts
+++ b/integration-tests/testkit/clickhouse.ts
@@ -19,6 +19,7 @@ export async function clickHouseQuery<T>(query: string): Promise<{
       Accept: 'application/json',
       'Accept-Encoding': 'gzip',
       Authorization: `Basic ${credentials}`,
+      output_format_json_quote_64bit_integers: '1',
     },
   });
 

--- a/integration-tests/testkit/clickhouse.ts
+++ b/integration-tests/testkit/clickhouse.ts
@@ -19,6 +19,7 @@ export async function clickHouseQuery<T>(query: string): Promise<{
       Accept: 'application/json',
       'Accept-Encoding': 'gzip',
       Authorization: `Basic ${credentials}`,
+      default_format: 'JSON',
       output_format_json_quote_64bit_integers: '1',
     },
   });

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -1262,14 +1262,12 @@ test.concurrent('number of produced and collected operations should match', asyn
 
   await waitForRequestsCollected(totalAmount);
 
-  const result = await clickHouseQuery<{
-    target: string;
-    client_name: string | null;
-    hash: string;
-    total: number;
-  }>(`
+  const result = await clickHouseQuery(`
     SELECT
-      target, client_name, hash, sum(total) as total
+      target
+      , client_name
+      , hash
+      , sum(total) as total
     FROM clients_daily
     WHERE
       timestamp >= subtractDays(now(), 30)
@@ -3106,14 +3104,10 @@ test.concurrent('ensure percentage precision up to 2 decimal places', async ({ e
 
   await waitForRequestsCollected(9801 + 199);
 
-  const result = await clickHouseQuery<{
-    target: string;
-    client_name: string | null;
-    hash: string;
-    total: number;
-  }>(`
+  const result = await clickHouseQuery(`
     SELECT
-      target, sum(total) as total
+      target
+      , sum(total) as total
     FROM clients_daily
     WHERE
       timestamp >= subtractDays(now(), 30)

--- a/packages/migrations/src/clickhouse-actions/001-initial.ts
+++ b/packages/migrations/src/clickhouse-actions/001-initial.ts
@@ -182,6 +182,10 @@ const statements = [
   `,
 ];
 
-const action: Action = exec => Promise.all(statements.map(q => exec(q))).then(() => {});
+const action: Action = async exec => {
+  for (const query of statements) {
+    await exec(query);
+  }
+};
 
 export { action };

--- a/packages/migrations/src/clickhouse-actions/001-initial.ts
+++ b/packages/migrations/src/clickhouse-actions/001-initial.ts
@@ -63,8 +63,8 @@ const statements = [
     SETTINGS index_granularity = 8192 AS
     SELECT
       target,
-      toStartOfHour(timestamp) AS timestamp,
-      toStartOfHour(expires_at) AS expires_at,
+      toStartOfHour(timestamp) AS "timestamp",
+      toStartOfHour(expires_at) AS "expires_at",
       hash,
       count() AS total,
       sum(ok) AS total_ok,
@@ -98,8 +98,8 @@ const statements = [
     SETTINGS index_granularity = 8192 AS
     SELECT
       target,
-      toStartOfDay(timestamp) AS timestamp,
-      toStartOfDay(expires_at) AS expires_at,
+      toStartOfDay(timestamp) AS "timestamp",
+      toStartOfDay(expires_at) AS "expires_at",
       hash,
       count() AS total,
       sum(ok) AS total_ok,
@@ -116,7 +116,7 @@ const statements = [
     CREATE MATERIALIZED VIEW IF NOT EXISTS default.coordinates_daily
     (
       target LowCardinality(String) CODEC(ZSTD(1)),
-      hash String CODEC(ZSTD(1)), 
+      hash String CODEC(ZSTD(1)),
       timestamp DateTime('UTC'),
       expires_at DateTime('UTC'),
       total UInt32 CODEC(ZSTD(1)),
@@ -131,8 +131,8 @@ const statements = [
     SELECT
       target,
       hash,
-      toStartOfDay(timestamp) AS timestamp,
-      toStartOfDay(expires_at) AS expires_at,
+      toStartOfDay(timestamp) AS "timestamp",
+      toStartOfDay(expires_at) AS "expires_at",
       sum(total) AS total,
       coordinate
     FROM default.operation_collection
@@ -150,7 +150,7 @@ const statements = [
       target LowCardinality(String) CODEC(ZSTD(1)),
       client_name String CODEC(ZSTD(1)),
       client_version String CODEC(ZSTD(1)),
-      hash String CODEC(ZSTD(1)), 
+      hash String CODEC(ZSTD(1)),
       timestamp DateTime('UTC'),
       expires_at DateTime('UTC'),
       total UInt32 CODEC(ZSTD(1)),
@@ -168,8 +168,8 @@ const statements = [
       client_name,
       client_version,
       hash,
-      toStartOfDay(timestamp) AS timestamp,
-      toStartOfDay(expires_at) AS expires_at,
+      toStartOfDay(timestamp) AS "timestamp",
+      toStartOfDay(expires_at) AS "expires_at",
       count() AS total
     FROM default.operations
     GROUP BY

--- a/packages/migrations/src/clickhouse.ts
+++ b/packages/migrations/src/clickhouse.ts
@@ -60,6 +60,7 @@ export async function migrateClickHouse(
     searchParams: {
       query: 'SELECT 1',
       default_format: 'JSON',
+      output_format_json_quote_64bit_integers: '1',
       wait_end_of_query: '1',
     },
     timeout: {
@@ -94,6 +95,7 @@ export async function migrateClickHouse(
         searchParams: {
           default_format: 'JSON',
           wait_end_of_query: '1',
+          output_format_json_quote_64bit_integers: '1',
           ...settings,
         },
         headers: {
@@ -118,6 +120,7 @@ export async function migrateClickHouse(
         body: queryString,
         searchParams: {
           default_format: 'JSON',
+          output_format_json_quote_64bit_integers: '1',
           wait_end_of_query: '1',
         },
         headers: {

--- a/packages/migrations/src/scripts/003-cloud.ts
+++ b/packages/migrations/src/scripts/003-cloud.ts
@@ -27,6 +27,7 @@ async function main() {
         body: query,
         searchParams: {
           default_format: 'JSON',
+          output_format_json_quote_64bit_integers: '1',
           wait_end_of_query: '1',
         },
         headers: {
@@ -129,7 +130,7 @@ async function main() {
         SELECT
             fromUnixTimestamp(
               if(
-                minMerge(timestamp) > 0, 
+                minMerge(timestamp) > 0,
                 minMerge(timestamp),
                 toUnixTimestamp(now())
               )
@@ -229,7 +230,7 @@ async function main() {
         SELECT
             fromUnixTimestamp(
               if(
-                minMerge(timestamp) > 0, 
+                minMerge(timestamp) > 0,
                 minMerge(timestamp),
                 toUnixTimestamp(now())
               )

--- a/packages/migrations/src/scripts/004-cloud.ts
+++ b/packages/migrations/src/scripts/004-cloud.ts
@@ -57,6 +57,7 @@ async function main() {
         body: query,
         searchParams: {
           default_format: 'JSON',
+          output_format_json_quote_64bit_integers: '1',
           wait_end_of_query: '1',
           ...options?.settings,
         },

--- a/packages/migrations/src/scripts/006-cloud.ts
+++ b/packages/migrations/src/scripts/006-cloud.ts
@@ -82,6 +82,7 @@ async function main() {
         body: query,
         searchParams: {
           default_format: 'JSON',
+          output_format_json_quote_64bit_integers: '1',
           wait_end_of_query: '1',
           ...options?.settings,
         },

--- a/packages/migrations/src/scripts/008-cloud.ts
+++ b/packages/migrations/src/scripts/008-cloud.ts
@@ -113,6 +113,7 @@ async function main() {
         body: query,
         searchParams: {
           default_format: 'JSON',
+          output_format_json_quote_64bit_integers: '1',
           wait_end_of_query: '1',
           ...options?.settings,
         },

--- a/packages/migrations/src/scripts/update-retention.ts
+++ b/packages/migrations/src/scripts/update-retention.ts
@@ -135,6 +135,7 @@ function createClickHouseHelpers(endpoint: string, username: string, password: s
         body: queryString,
         searchParams: {
           default_format: 'JSON',
+          output_format_json_quote_64bit_integers: '1',
           wait_end_of_query: '1',
           ...settings,
         },
@@ -158,6 +159,7 @@ function createClickHouseHelpers(endpoint: string, username: string, password: s
         body: queryString,
         searchParams: {
           default_format: 'JSON',
+          output_format_json_quote_64bit_integers: '1',
           wait_end_of_query: '1',
         },
         headers: {

--- a/packages/services/api/src/modules/operations/providers/clickhouse-client.ts
+++ b/packages/services/api/src/modules/operations/providers/clickhouse-client.ts
@@ -103,6 +103,7 @@ export class ClickHouse {
           },
           searchParams: {
             default_format: 'JSON',
+            output_format_json_quote_64bit_integers: '1',
             // Max execution time in seconds
             max_execution_time: (this.config.requestTimeout ?? timeout) / 1000,
             query_id: executionId,
@@ -280,6 +281,7 @@ export class ClickHouse {
           },
           searchParams: {
             default_format: 'JSON',
+            output_format_json_quote_64bit_integers: '1',
             // Max execution time in seconds
             max_execution_time: (this.config.requestTimeout ?? args.timeout) / 1000,
             query_id: executionId,

--- a/packages/services/workflows/src/lib/clickhouse-client.ts
+++ b/packages/services/workflows/src/lib/clickhouse-client.ts
@@ -60,6 +60,7 @@ export class ClickHouseClient {
         searchParams: {
           database: 'default',
           default_format: 'JSON',
+          output_format_json_quote_64bit_integers: '1',
           ...params,
         },
         headers: {


### PR DESCRIPTION
### Background

Bump `clickhouse/clickhouse-server:24.8-alpine` to `clickhouse/clickhouse-server:26.3.12.3-alpine`.

The main breaking change is the quoting of integers, this is handled gracefully by using the `output_format_json_quote_64bit_integers` option for clickhouse client queries.
