### PR TITLE
fix: apply lower case to all email invitations

### DIFF
--- a/.changeset/real-dingos-punch.md
+++ b/.changeset/real-dingos-punch.md
@@ -4,7 +4,7 @@
 
 Fix issue where the organization invite email did not match the signed up user-accounts email.
 
-To cleanup your database ron the following command, to identify duplicate records and then manually fix them/clean them up.
+To cleanup your database, run the following command to identify duplicate records and then manually fix them/clean them up.
 
 ```sql
 SELECT

--- a/.changeset/real-dingos-punch.md
+++ b/.changeset/real-dingos-punch.md
@@ -2,9 +2,32 @@
 'hive': patch
 ---
 
-Fix issue where the organization invite email did not match the signed up user-accounts email.
+Fix issue where the user emails were not inserted in lower-case for OIDC providers returning non-lowercase emails.
 
-To cleanup your database, run the following command to identify duplicate records and then manually fix them/clean them up.
+If you are affected, you can manually fix you database state by running the following commands, to make account-linking from different login methods work smoothly.
+
+```sql
+UPDATE "users"
+SET
+  "email" = lower("email")
+WHERE
+  "email" <> lower("email")
+;
+```
+
+
+```sql
+UPDATE "supertokens_thirdparty_users"
+SET
+  "email" = lower("email")
+WHERE
+  "email" <> lower("email")
+;
+```
+
+
+Fix issue where user emails were not inserted into the database in lowercase for invites, resulting in a mismatch of user account email and invite email that could not be accespted.
+To cleanup your database of invites, run the following command to identify duplicate records and then manually fix them/clean them up.
 
 ```sql
 SELECT

--- a/.changeset/real-dingos-punch.md
+++ b/.changeset/real-dingos-punch.md
@@ -1,0 +1,20 @@
+---
+'hive': patch
+---
+
+Fix issue where the organization invite email did not match the signed up user-accounts email.
+
+To cleanup your database ron the following command, to identify duplicate records and then manually fix them/clean them up.
+
+```sql
+SELECT
+  "organization_id"
+  , lower(email) AS key
+  , array_agg(json_object(array['email', 'code', 'expires_at'], array["email", "code", to_json("expires_at")::text])) AS records
+  , COUNT(*)
+FROM
+  "organization_invitations"
+GROUP BY
+  "organization_id", lower("email")
+HAVING COUNT(*) > 1;
+```

--- a/integration-tests/tests/api/organization/members.spec.ts
+++ b/integration-tests/tests/api/organization/members.spec.ts
@@ -220,6 +220,31 @@ test.concurrent(
   },
 );
 
+test.concurrent(
+  'can join organization even if the input email is not lowercase',
+  async ({ expect }) => {
+    const seed = initSeed();
+    const { createOrg } = await seed.createOwner();
+    const { inviteMember, joinMemberUsingCode } = await createOrg();
+
+    // Invite
+    const extra = 'UPPERCASE-PREFIX-' + seed.generateEmail();
+    const invitationResult = await inviteMember(extra);
+    const inviteCode = invitationResult.ok!.createdOrganizationInvitation.code;
+    expect(inviteCode).toBeDefined();
+    const { access_token: member_access_token } = await seed.authenticate(extra);
+    const joinResult = await (
+      await joinMemberUsingCode(inviteCode, member_access_token)
+    ).expectNoGraphQLErrors();
+
+    expect(joinResult.joinOrganization.__typename).toBe('OrganizationPayload');
+
+    if (joinResult.joinOrganization.__typename !== 'OrganizationPayload') {
+      throw new Error('Join failed');
+    }
+  },
+);
+
 const OrganizationInvitationsQuery = graphql(`
   query OrganizationInvitationsQuery($organizationSlug: String!) {
     organization: organizationBySlug(organizationSlug: $organizationSlug) {

--- a/integration-tests/tests/api/organization/members.spec.ts
+++ b/integration-tests/tests/api/organization/members.spec.ts
@@ -220,31 +220,6 @@ test.concurrent(
   },
 );
 
-test.concurrent(
-  'can join organization even if the input email is not lowercase',
-  async ({ expect }) => {
-    const seed = initSeed();
-    const { createOrg } = await seed.createOwner();
-    const { inviteMember, joinMemberUsingCode } = await createOrg();
-
-    // Invite
-    const extra = 'UPPERCASE-PREFIX-' + seed.generateEmail();
-    const invitationResult = await inviteMember(extra);
-    const inviteCode = invitationResult.ok!.createdOrganizationInvitation.code;
-    expect(inviteCode).toBeDefined();
-    const { access_token: member_access_token } = await seed.authenticate(extra);
-    const joinResult = await (
-      await joinMemberUsingCode(inviteCode, member_access_token)
-    ).expectNoGraphQLErrors();
-
-    expect(joinResult.joinOrganization.__typename).toBe('OrganizationPayload');
-
-    if (joinResult.joinOrganization.__typename !== 'OrganizationPayload') {
-      throw new Error('Join failed');
-    }
-  },
-);
-
 const OrganizationInvitationsQuery = graphql(`
   query OrganizationInvitationsQuery($organizationSlug: String!) {
     organization: organizationBySlug(organizationSlug: $organizationSlug) {

--- a/packages/services/api/src/modules/auth/providers/email-verification.ts
+++ b/packages/services/api/src/modules/auth/providers/email-verification.ts
@@ -84,7 +84,7 @@ export class EmailVerification {
           FROM "email_verifications" "ev"
           WHERE
             "ev"."user_identity_id" = ${input.userIdentityId}
-            AND "ev"."email" = lower(${input.email})
+            AND lower("ev"."email") = lower(${input.email})
         `,
       )
       .then(v => EmailVerificationModel.nullable().parse(v));
@@ -143,7 +143,7 @@ export class EmailVerification {
           FROM "email_verifications" "ev"
           WHERE
             "ev"."user_identity_id" = ${input.userIdentityId}
-            AND "ev"."email" = lower(${superTokensUser.email})
+            AND lower("ev"."email") = lower(${superTokensUser.email})
         `,
       )
       .then(v => EmailVerificationModel.nullable().parse(v));

--- a/packages/services/api/src/modules/auth/providers/email-verification.ts
+++ b/packages/services/api/src/modules/auth/providers/email-verification.ts
@@ -216,7 +216,7 @@ export class EmailVerification {
           FROM "email_verifications" "ev"
           WHERE
             "user_identity_id" = ${input.userIdentityId}
-            AND "email" = lower(${input.email})
+            AND lower("email") = lower(${input.email})
             AND "expires_at" IS NOT NULL
             AND "verified_at" IS NULL
         `,

--- a/packages/services/api/src/modules/auth/providers/email-verification.ts
+++ b/packages/services/api/src/modules/auth/providers/email-verification.ts
@@ -84,7 +84,7 @@ export class EmailVerification {
           FROM "email_verifications" "ev"
           WHERE
             "ev"."user_identity_id" = ${input.userIdentityId}
-            AND "ev"."email" = ${input.email}
+            AND "ev"."email" = lower(${input.email})
         `,
       )
       .then(v => EmailVerificationModel.nullable().parse(v));
@@ -143,7 +143,7 @@ export class EmailVerification {
           FROM "email_verifications" "ev"
           WHERE
             "ev"."user_identity_id" = ${input.userIdentityId}
-            AND "ev"."email" = ${superTokensUser.email}
+            AND "ev"."email" = lower(${superTokensUser.email})
         `,
       )
       .then(v => EmailVerificationModel.nullable().parse(v));
@@ -216,7 +216,7 @@ export class EmailVerification {
           FROM "email_verifications" "ev"
           WHERE
             "user_identity_id" = ${input.userIdentityId}
-            AND "email" = ${input.email}
+            AND "email" = lower(${input.email})
             AND "expires_at" IS NOT NULL
             AND "verified_at" IS NULL
         `,

--- a/packages/services/api/src/modules/auth/providers/supertokens-store.ts
+++ b/packages/services/api/src/modules/auth/providers/supertokens-store.ts
@@ -329,7 +329,7 @@ export class SuperTokensStore {
       UPDATE
         "supertokens_thirdparty_users"
       SET
-        "email" = ${args.newEmail}
+        "email" = lower(${args.newEmail})
       WHERE
         "app_id" = 'public'
         AND "user_id" = ${args.userId}
@@ -387,7 +387,7 @@ export class SuperTokensStore {
         , ${args.thirdPartyId}
         , ${args.thirdPartyUserId}
         , ${userId}
-        , ${args.email}
+        , lower(${args.email})
         , ${now}
       )
       RETURNING
@@ -560,7 +560,7 @@ export class SuperTokensStore {
        'public'
        , ${args.user.userId}
        , ${args.token}
-       , ${args.user.email}
+       , lower(${args.user.email})
        , ${args.expiresAt}
       )
       RETURNING

--- a/packages/services/server/src/supertokens-at-home.ts
+++ b/packages/services/server/src/supertokens-at-home.ts
@@ -1411,7 +1411,13 @@ export async function registerSupertokensAtHome(
         const userInfoBody = z
           .object({
             sub: z.string(),
-            email: z.string().optional().nullable(),
+            email: z
+              .string()
+              // make sure the email is transformed to lower-case
+              // sometimes the OIDC provider love giving us custom formatted ones
+              .transform(email => email.toLowerCase())
+              .optional()
+              .nullable(),
           })
           .safeParse(userInfoBodyJSON.data);
 

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -958,7 +958,7 @@ export async function createStorage(
             )
             VALUES (
               ${args.organizationId}
-              , ${args.email}
+              , lower(${args.email})
               , ${args.roleId}
               , ${args.resourceAssignments === null ? null : psql.jsonb(args.resourceAssignments)}
             )
@@ -983,7 +983,9 @@ export async function createStorage(
           .maybeOne(
             psql`/* deleteOrganizationInvitationByEmail */
                 DELETE FROM organization_invitations
-                WHERE organization_id = ${organization} AND email = ${email}
+                WHERE
+                  organization_id = ${organization}
+                  AND email = lower(${email})
                 RETURNING
                   "organization_id" AS "organizationId"
                   , "code"
@@ -1210,7 +1212,7 @@ export async function createStorage(
           LEFT JOIN organization_invitations as i ON (i.organization_id = o.id)
           WHERE
             i.code = ${inviteCode}
-            AND i.email = ${email}
+            AND i.email = lower(${email})
             AND i.expires_at > NOW()
           GROUP BY o.id
           LIMIT 1

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -326,7 +326,7 @@ export async function createStorage(
                 psql`/* ensureUserExists */
                   SELECT ${userFields(psql`"users".`)}
                   FROM "users"
-                  WHERE "users"."email" = ${email}
+                  WHERE "users"."email" = lower(${email})
                   ORDER BY "users"."created_at";
                 `,
               )
@@ -358,7 +358,7 @@ export async function createStorage(
                     DELETE FROM "organization_invitations" AS "oi"
                     WHERE
                       "oi"."organization_id" = ${oidcConfig.linkedOrganizationId}
-                      AND "oi"."email" = ${email}
+                      AND "oi"."email" = lower(${email})
                       AND "oi"."expires_at" > now()
                     RETURNING
                       "oi"."organization_id" "organizationId"

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -427,10 +427,10 @@ export async function createStorage(
           if (internalUser.email !== email) {
             await t.query(psql`
               UPDATE "users"
-              SET "email" = ${email}
+              SET "email" = lower(${email})
               WHERE "id" = ${internalUser.id}
             `);
-            internalUser.email = email;
+            internalUser.email = email.toLowerCase();
           }
 
           if (oidcIntegration !== null) {

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -282,10 +282,10 @@ export async function createStorage(
     },
     async ensureUserExists({
       superTokensUserId,
-      email,
       oidcIntegration,
       firstName,
       lastName,
+      ...args
     }: {
       superTokensUserId: string;
       firstName: string | null;
@@ -295,6 +295,7 @@ export async function createStorage(
         id: string;
       };
     }) {
+      const email = args.email.toLowerCase();
       class EnsureUserExistsError extends Error {}
 
       try {
@@ -358,7 +359,7 @@ export async function createStorage(
                     DELETE FROM "organization_invitations" AS "oi"
                     WHERE
                       "oi"."organization_id" = ${oidcConfig.linkedOrganizationId}
-                      AND "oi"."email" = lower(${email})
+                      AND lower("oi"."email") = lower(${email})
                       AND "oi"."expires_at" > now()
                     RETURNING
                       "oi"."organization_id" "organizationId"


### PR DESCRIPTION
### Description

When someone used a non-lowercase email for sending an invite, we stored it as such within our database. Since we always lower case the emails of signed up users, this created a conflict where an invited users email does not match the signed up user email.

By always lower-casing the invitees user email, we avoid this from happening in the first place.

