### PR TITLE
fix: make sure only one record is loaded at a time

### DIFF
--- a/packages/services/api/src/modules/auth/providers/email-verification.ts
+++ b/packages/services/api/src/modules/auth/providers/email-verification.ts
@@ -85,7 +85,7 @@ export class EmailVerification {
           WHERE
             "ev"."user_identity_id" = ${input.userIdentityId}
             AND lower("ev"."email") = lower(${input.email})
-            AND "verified_at" IS NOT NULL
+            AND "ev"."verified_at" IS NOT NULL
           LIMIT 1
         `,
       )

--- a/packages/services/api/src/modules/auth/providers/email-verification.ts
+++ b/packages/services/api/src/modules/auth/providers/email-verification.ts
@@ -85,6 +85,8 @@ export class EmailVerification {
           WHERE
             "ev"."user_identity_id" = ${input.userIdentityId}
             AND lower("ev"."email") = lower(${input.email})
+            AND "verified_at" IS NOT NULL
+          LIMIT 1
         `,
       )
       .then(v => EmailVerificationModel.nullable().parse(v));


### PR DESCRIPTION
### Background

Due to a bug we had lower case and non-lowercase email confirmations for the same identity and emails. This makes the check not throw in case multiple records exist.

### Description

This change is technically no longer needed as we fixed the database state manually. It is still useful to have this to avoid a future regression.
