### PR TITLE
Fix server-side sentry sourcemaps

### DIFF
--- a/.github/workflows/build-and-dockerize.yaml
+++ b/.github/workflows/build-and-dockerize.yaml
@@ -76,6 +76,14 @@ jobs:
         if: ${{ inputs.build }}
         run: pnpm turbo check:build
 
+      # Must run before the docker bake below: the bake copies the host dist/
+      # into the image, so debug ids have to be in those files for Sentry to
+      # match deployed bundles to the maps uploaded later. (inject is offline; no
+      # auth needed.)
+      - name: inject sentry debug ids into service bundles
+        if: ${{ inputs.publishSourceMaps }}
+        run: pnpm sourcemaps:inject
+
       - uses: vimtor/action-zip@5f1c4aa587ea41db1110df6a99981dbe19cee310 # v1
         name: archive javascript artifacts
         if: ${{ inputs.uploadJavaScriptArtifacts }}
@@ -198,7 +206,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_RELEASE: ${{ inputs.imageTag }}
-        run: pnpm upload-sourcemaps
+        run: pnpm sourcemaps:upload
 
   publish_docker_manifest:
     needs: build-and-dockerize

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "seed:org": "tsx scripts/seed-organization.mts",
     "seed:schemas": "tsx scripts/seed-schemas.ts",
     "seed:usage": "tsx scripts/seed-usage.ts",
+    "sourcemaps:inject": "./scripts/sourcemaps-inject.sh",
+    "sourcemaps:upload": "./scripts/sourcemaps-upload.sh",
     "start": "pnpm run local:setup",
     "test": "vitest",
     "test:e2e": "playwright test",
@@ -59,7 +61,6 @@
     "test:e2e:open": "playwright test --ui",
     "test:integration": "cd integration-tests && pnpm test:integration",
     "typecheck": "pnpm run -r --filter '!hive' typecheck",
-    "upload-sourcemaps": "./scripts/upload-sourcemaps.sh",
     "workspace": "pnpm run --filter $1 $2"
   },
   "devDependencies": {

--- a/scripts/sourcemaps-inject.sh
+++ b/scripts/sourcemaps-inject.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+# Inject Sentry debug ids into the built service bundles.
+#
+# This MUST run before the Docker image is baked (see the "inject sentry debug
+# ids" step in .github/workflows/build-and-dockerize.yaml). The bake copies the
+# host `dist/` into the image, so the debug ids have to already be in those
+# files; otherwise the deployed bundle has no debug id and Sentry can't match it
+# to the uploaded source maps -> minified stack traces. Uploading the maps
+# happens later, in sourcemaps-upload.sh, after the bake.
+#
+# web/app is intentionally excluded: its client + SSR bundles get debug ids from
+# @sentry/vite-plugin during the build. Only the runify/esbuild-built services
+# need CLI injection.
+for dir in packages/services/*/dist; do
+  pnpm sentry-cli sourcemaps inject "$dir"
+done
+
+# Smoke alarm: confirm injection actually wrote a debug id into each service
+# entrypoint, and fail the build loudly if not. Without this, a broken inject
+# (e.g. a sentry-cli upgrade or missing .map files) would silently ship
+# un-instrumented bundles and we'd only notice via minified stack traces in
+# Sentry weeks later.
+# NOTE: this proves inject ran on the host dist; it does NOT prove the Docker
+# image bakes these files (that ordering is enforced structurally by running
+# this script before the bake in build-and-dockerize.yaml).
+for f in packages/services/*/dist/index.js; do
+  grep -q "sentryDebugIds" "$f" || {
+    echo "::error::no debug id injected in $f"
+    exit 1
+  }
+done

--- a/scripts/sourcemaps-inject.sh
+++ b/scripts/sourcemaps-inject.sh
@@ -16,18 +16,3 @@ set -euo pipefail
 for dir in packages/services/*/dist; do
   pnpm sentry-cli sourcemaps inject "$dir"
 done
-
-# Smoke alarm: confirm injection actually wrote a debug id into each service
-# entrypoint, and fail the build loudly if not. Without this, a broken inject
-# (e.g. a sentry-cli upgrade or missing .map files) would silently ship
-# un-instrumented bundles and we'd only notice via minified stack traces in
-# Sentry weeks later.
-# NOTE: this proves inject ran on the host dist; it does NOT prove the Docker
-# image bakes these files (that ordering is enforced structurally by running
-# this script before the bake in build-and-dockerize.yaml).
-for f in packages/services/*/dist/index.js; do
-  grep -q "sentryDebugIds" "$f" || {
-    echo "::error::no debug id injected in $f"
-    exit 1
-  }
-done

--- a/scripts/sourcemaps-upload.sh
+++ b/scripts/sourcemaps-upload.sh
@@ -2,11 +2,11 @@
 
 pnpm sentry-cli releases new $SENTRY_RELEASE
 
+# Debug ids are injected earlier (scripts/sourcemaps-inject.sh, before the Docker
+# bake) so the deployed bundle carries them. Here we only upload the maps.
 for dir in packages/services/*/dist; do
   name=$(echo $dir | awk -F / '{print $3}')
   echo $name
-
-  pnpm sentry-cli sourcemaps inject $dir
 
   if [[ $name == *-worker ]]; then
     pnpm sentry-cli sourcemaps upload --release=$SENTRY_RELEASE $dir --dist $name


### PR DESCRIPTION
This PR fixes server-side Sentry errors showing minified stack traces (e.g. `@hive/server/index.js:616678`) despite backend source maps being uploaded on every release. The cause was ordering: `sentry-cli sourcemaps inject` (which writes Debug IDs into the bundles) ran *after* the Docker image was baked, so the deployed code had no Debug ID for Sentry to match against the uploaded maps...the browser bundle was unaffected because `@sentry/vite-plugin` injects at build time. 

- Splits injection into its own CI step that runs before the bake (upload still runs after), via a new `scripts/sourcemaps-inject.sh`
- `upload-sourcemaps.sh` is renamed to `sourcemaps-upload.sh` with inject removed
- pnpm scripts are now `sourcemaps:inject` / `sourcemaps:upload`. 

