### PR TITLE
unlock metric alerts across orgs for admins

### DIFF
--- a/packages/services/api/src/modules/alerts/providers/metric-alert-rules-manager.ts
+++ b/packages/services/api/src/modules/alerts/providers/metric-alert-rules-manager.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import type { MetricAlertRule } from '../../../shared/entities';
+import { AccessError } from '../../../shared/errors';
 import { Session } from '../../auth/lib/authz';
 import {
   METRIC_ALERT_RULE_TIME_WINDOW_MAX_MINUTES,
@@ -103,8 +104,19 @@ export class MetricAlertRulesManager {
     if (await this.isEnabled(organizationId)) {
       return true;
     }
-    const actor = await this.session.getActor();
-    return actor.type === 'user' && actor.user.isAdmin === true;
+    // `getActor` throws an `AccessError` for an unauthenticated/invalid session.
+    // Since this runs on read-path resolvers, treat that as "not an admin" and
+    // return false rather than failing the whole query. Other (unexpected)
+    // errors still propagate. Mirrors `Session.canPerformAction`.
+    try {
+      const actor = await this.session.getActor();
+      return actor.type === 'user' && actor.user.isAdmin === true;
+    } catch (error) {
+      if (error instanceof AccessError) {
+        return false;
+      }
+      throw error;
+    }
   }
 
   /**

--- a/packages/services/api/src/modules/alerts/providers/metric-alert-rules-manager.ts
+++ b/packages/services/api/src/modules/alerts/providers/metric-alert-rules-manager.ts
@@ -96,13 +96,25 @@ export class MetricAlertRulesManager {
   }
 
   /**
-   * Mutation-side counterpart to `isEnabled`. Throws if the feature is
-   * disabled so the resolver can return the structured error response. The
-   * existing `isEnabled` check inside the resolver gate path is reused so
-   * both paths share one source of truth for the gate semantics.
+   * Viewer-aware counterpart to `isEnabled`: the org has the feature, OR the
+   * current viewer is a Hive admin.
+   */
+  async canViewerUseMetricAlertRules(organizationId: string): Promise<boolean> {
+    if (await this.isEnabled(organizationId)) {
+      return true;
+    }
+    const actor = await this.session.getActor();
+    return actor.type === 'user' && actor.user.isAdmin === true;
+  }
+
+  /**
+   * Mutation-side counterpart to `canViewerUseMetricAlertRules`. Throws if the
+   * feature is unavailable to the viewer so the resolver can return the
+   * structured error response. Sharing `canViewerUseMetricAlertRules` keeps the
+   * read and write paths on one source of truth for the gate semantics.
    */
   async assertEnabled(organizationId: string): Promise<void> {
-    if (!(await this.isEnabled(organizationId))) {
+    if (!(await this.canViewerUseMetricAlertRules(organizationId))) {
       throw new MetricAlertRulesDisabledError();
     }
   }

--- a/packages/services/api/src/modules/alerts/resolvers/Target.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Target.ts
@@ -17,9 +17,7 @@ export const Target: Pick<
   | 'viewerCanUseMetricAlertRules'
 > = {
   metricAlertRules: async (target, _, { injector }) => {
-    if (
-      !(await injector.get(MetricAlertRulesManager).canViewerUseMetricAlertRules(target.orgId))
-    ) {
+    if (!(await injector.get(MetricAlertRulesManager).canViewerUseMetricAlertRules(target.orgId))) {
       return [];
     }
     return injector.get(MetricAlertRulesStorage).getMetricAlertRulesByTarget({
@@ -27,9 +25,7 @@ export const Target: Pick<
     });
   },
   metricAlertRule: async (target, { id }, { injector }) => {
-    if (
-      !(await injector.get(MetricAlertRulesManager).canViewerUseMetricAlertRules(target.orgId))
-    ) {
+    if (!(await injector.get(MetricAlertRulesManager).canViewerUseMetricAlertRules(target.orgId))) {
       return null;
     }
     const rule = await injector.get(MetricAlertRulesStorage).getMetricAlertRule({ id });
@@ -39,9 +35,7 @@ export const Target: Pick<
     return rule;
   },
   metricAlertRuleStateLog: async (target, { from, to }, { injector }) => {
-    if (
-      !(await injector.get(MetricAlertRulesManager).canViewerUseMetricAlertRules(target.orgId))
-    ) {
+    if (!(await injector.get(MetricAlertRulesManager).canViewerUseMetricAlertRules(target.orgId))) {
       return [];
     }
     return injector.get(MetricAlertRulesStorage).getStateLogByTarget({

--- a/packages/services/api/src/modules/alerts/resolvers/Target.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Target.ts
@@ -17,7 +17,9 @@ export const Target: Pick<
   | 'viewerCanUseMetricAlertRules'
 > = {
   metricAlertRules: async (target, _, { injector }) => {
-    if (!(await injector.get(MetricAlertRulesManager).isEnabled(target.orgId))) {
+    if (
+      !(await injector.get(MetricAlertRulesManager).canViewerUseMetricAlertRules(target.orgId))
+    ) {
       return [];
     }
     return injector.get(MetricAlertRulesStorage).getMetricAlertRulesByTarget({
@@ -25,7 +27,9 @@ export const Target: Pick<
     });
   },
   metricAlertRule: async (target, { id }, { injector }) => {
-    if (!(await injector.get(MetricAlertRulesManager).isEnabled(target.orgId))) {
+    if (
+      !(await injector.get(MetricAlertRulesManager).canViewerUseMetricAlertRules(target.orgId))
+    ) {
       return null;
     }
     const rule = await injector.get(MetricAlertRulesStorage).getMetricAlertRule({ id });
@@ -35,7 +39,9 @@ export const Target: Pick<
     return rule;
   },
   metricAlertRuleStateLog: async (target, { from, to }, { injector }) => {
-    if (!(await injector.get(MetricAlertRulesManager).isEnabled(target.orgId))) {
+    if (
+      !(await injector.get(MetricAlertRulesManager).canViewerUseMetricAlertRules(target.orgId))
+    ) {
       return [];
     }
     return injector.get(MetricAlertRulesStorage).getStateLogByTarget({
@@ -45,7 +51,7 @@ export const Target: Pick<
     });
   },
   viewerCanUseMetricAlertRules: (target, _args, { injector }) => {
-    return injector.get(MetricAlertRulesManager).isEnabled(target.orgId);
+    return injector.get(MetricAlertRulesManager).canViewerUseMetricAlertRules(target.orgId);
   },
   metricAlertStateLogRetentionDays: async (target, _args, { injector }) => {
     const organization = await injector

--- a/packages/services/api/src/modules/auth/lib/supertokens-strategy.ts
+++ b/packages/services/api/src/modules/auth/lib/supertokens-strategy.ts
@@ -105,6 +105,11 @@ export class SuperTokensCookieBasedSession extends Session {
             effect: 'allow',
             resource: `hrn:${organizationId}:organization/${organizationId}`,
           },
+          {
+            action: 'alert:modify',
+            effect: 'allow',
+            resource: `hrn:${organizationId}:organization/${organizationId}`,
+          },
         ];
       }
 

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.ts
@@ -146,14 +146,11 @@ function hasElapsed(stateChangedAt: string | null, minutes: number, evaluationTi
   return evaluationTime.getTime() - changedAt >= minutes * 60_000;
 }
 
-export async function fetchEnabledRules(
-  pg: PostgresDatabasePool,
-  clusterFlagEnabled: boolean,
-): Promise<MetricAlertRuleRow[]> {
-  // OR-style feature gate: when the cluster env-var is on, evaluate every
-  // enabled rule. When it's off, only evaluate rules whose organization has
-  // opted in via the per-org JSONB feature flag. Mirrors the resolver-side
-  // OR gate at alerts/resolvers/Target.ts.
+export async function fetchEnabledRules(pg: PostgresDatabasePool): Promise<MetricAlertRuleRow[]> {
+  // Evaluate every enabled rule. The org-level `metricAlertRules` feature flag
+  // is a rollout enabler for *creating/seeing* rules in the API, not a gate on
+  // evaluation — a rule only exists if someone was authorized to create it.
+  // The real per-rule off-switches are the `enabled` column and deleting the rule.
   const result = await pg.any(psql`
     SELECT
       r."id"
@@ -178,11 +175,6 @@ export async function fetchEnabledRules(
     INNER JOIN "organizations" o ON o."id" = r."organization_id"
     LEFT JOIN "saved_filters" sf ON sf."id" = r."saved_filter_id"
     WHERE r."enabled" = true
-      ${
-        clusterFlagEnabled
-          ? psql``
-          : psql`AND COALESCE((o."feature_flags"->>'metricAlertRules')::boolean, false) IS TRUE`
-      }
   `);
 
   return z.array(MetricAlertRuleRowSchema).parse(result);

--- a/packages/services/workflows/src/tasks/evaluate-metric-alert-rules.ts
+++ b/packages/services/workflows/src/tasks/evaluate-metric-alert-rules.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { psql } from '@hive/postgres';
 import { SpanKind, SpanStatusCode, trace } from '@hive/service-common';
-import { env } from '../environment.js';
 import { defineTask, implementTask } from '../kit.js';
 import {
   buildSavedFilterConditions,
@@ -54,10 +53,9 @@ export const task = implementTask(EvaluateMetricAlertRulesTask, async args => {
   const evaluationTime =
     rawRunAt instanceof Date ? rawRunAt : rawRunAt ? new Date(rawRunAt) : new Date();
 
-  // OR-style gate: when cluster flag is on, evaluate every rule; when off,
-  // fetchEnabledRules filters to rules belonging to opted-in orgs only.
-  const clusterFlagEnabled = env.featureFlags.metricAlertRulesEnabled;
-  const rules = await fetchEnabledRules(context.pg, clusterFlagEnabled);
+  // Evaluate every enabled rule. The org feature flag gates rule creation in
+  // the API, not evaluation here; the per-rule `enabled` column is the gate.
+  const rules = await fetchEnabledRules(context.pg);
 
   if (rules.length === 0) {
     logger.debug('No enabled metric alert rules found');


### PR DESCRIPTION
This PR ensures that the metric alerts feature is unlocked across orgs for Hive admins. 