### PR TITLE
Improve clickhouse query in metric alert evaluator

### DIFF
--- a/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
+++ b/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
@@ -1,0 +1,89 @@
+import type { Action } from '../clickhouse';
+
+// Target-keyed rollups for the metric-alert evaluator. The existing
+// `operations_minutely` / `operations_hourly` tables are ordered
+// `(target, hash, client_name, client_version, timestamp)`, so an unfiltered
+// alert window query (sum across all hashes/clients for a target over a time
+// range) can't use timestamp for index/partition pruning...`operations_minutely`
+// in particular is `PARTITION BY tuple()`, so a 5-minute alert scans the
+// target's whole 24h slice.
+//
+// These two views re-aggregate the same source (`default.operations`) keyed on
+// `(target, timestamp)` only, day-partitioned, so the same window query reads
+// just the window's granules. The alert evaluator routes unfiltered rules here
+// behind a feature flag; filtered rules keep using the existing tables (where
+// the hash/client predicate already exploits the sort-key prefix).
+//
+// The SELECTs intentionally mirror `createSelectStatementForOperationsMinutely`
+// / `...Hourly` in 004-version-2 (same aggregate-state functions) minus the
+// hash/client dimensions, so `avgMerge` / `quantilesMerge` at read time stay
+// correct.
+const createByTargetSelect = (bucket: 'toStartOfMinute' | 'toStartOfHour', where: string) => `
+  SELECT
+    target,
+    ${bucket}(timestamp) AS timestamp,
+    count() AS total,
+    sum(ok) AS total_ok,
+    avgState(duration) AS duration_avg,
+    quantilesState(0.75, 0.9, 0.95, 0.99)(duration) AS duration_quantiles
+  FROM default.operations
+  ${where}
+  GROUP BY
+    target,
+    timestamp
+`;
+
+export const action: Action = async (exec, _query, hiveCloudEnvironment) => {
+  // No historical backfill (start-fresh): the views capture inserts going
+  // forward. In prod, begin aggregating from the next UTC day boundary so the
+  // view starts on a clean partition rather than mid-minute during deploy
+  // ...same convention as 007-james-bond-aggregates-hourly-and-minutely.
+  let where = '';
+
+  if (hiveCloudEnvironment === 'prod') {
+    const tomorrow = new Date();
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+    const startOfTomorrow = tomorrow.toISOString().split('T')[0];
+
+    where = `WHERE toDate(timestamp) >= toDate('${startOfTomorrow}')`;
+  }
+
+  await Promise.all([
+    exec(`
+      CREATE MATERIALIZED VIEW IF NOT EXISTS default.operations_minutely_by_target
+      (
+        target LowCardinality(String) CODEC(ZSTD(1)),
+        timestamp DateTime('UTC') CODEC(DoubleDelta, LZ4),
+        total UInt32 CODEC(T64, ZSTD(1)),
+        total_ok UInt32 CODEC(T64, ZSTD(1)),
+        duration_avg AggregateFunction(avg, UInt64) CODEC(ZSTD(1)),
+        duration_quantiles AggregateFunction(quantiles(0.75, 0.9, 0.95, 0.99), UInt64) CODEC(ZSTD(1))
+      )
+      ENGINE = SummingMergeTree
+      PARTITION BY toYYYYMMDD(timestamp)
+      PRIMARY KEY (target, timestamp)
+      ORDER BY (target, timestamp)
+      TTL timestamp + INTERVAL 24 HOUR
+      SETTINGS index_granularity = 8192 AS
+      ${createByTargetSelect('toStartOfMinute', where)}
+    `),
+    exec(`
+      CREATE MATERIALIZED VIEW IF NOT EXISTS default.operations_hourly_by_target
+      (
+        target LowCardinality(String) CODEC(ZSTD(1)),
+        timestamp DateTime('UTC') CODEC(DoubleDelta, LZ4),
+        total UInt32 CODEC(T64, ZSTD(1)),
+        total_ok UInt32 CODEC(T64, ZSTD(1)),
+        duration_avg AggregateFunction(avg, UInt64) CODEC(ZSTD(1)),
+        duration_quantiles AggregateFunction(quantiles(0.75, 0.9, 0.95, 0.99), UInt64) CODEC(ZSTD(1))
+      )
+      ENGINE = SummingMergeTree
+      PARTITION BY toYYYYMMDD(timestamp)
+      PRIMARY KEY (target, timestamp)
+      ORDER BY (target, timestamp)
+      TTL timestamp + INTERVAL 30 DAY
+      SETTINGS index_granularity = 8192 AS
+      ${createByTargetSelect('toStartOfHour', where)}
+    `),
+  ]);
+};

--- a/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
+++ b/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
@@ -19,14 +19,18 @@ import type { Action } from '../clickhouse';
 // the older operations_* tables use. Splitting them lets the view and the table
 // be migrated independently.
 
-// Data table columns, with storage codecs.
+// Data table columns, with storage codecs. Percentiles use `quantilesTDigest`
+// rather than the older `quantiles` the legacy operations_* rollups use:
+// t-digest is deterministic and more accurate in the tails (what P95/P99 latency
+// alerting needs) and merges better across the MV's partial states. The reader
+// must match it with `quantilesTDigestMerge` (see `queryClickHouseWindows`).
 const tableColumns = `
   target LowCardinality(String) CODEC(ZSTD(1)),
   timestamp DateTime('UTC') CODEC(DoubleDelta, LZ4),
   total UInt32 CODEC(T64, ZSTD(1)),
   total_ok UInt32 CODEC(T64, ZSTD(1)),
   duration_avg AggregateFunction(avg, UInt64) CODEC(ZSTD(1)),
-  duration_quantiles AggregateFunction(quantiles(0.75, 0.9, 0.95, 0.99), UInt64) CODEC(ZSTD(1))
+  duration_quantiles AggregateFunction(quantilesTDigest(0.75, 0.9, 0.95, 0.99), UInt64) CODEC(ZSTD(1))
 `;
 
 // Same columns as the data table, types only — the MV's output projection.
@@ -36,7 +40,7 @@ const mvColumns = `
   total UInt32,
   total_ok UInt32,
   duration_avg AggregateFunction(avg, UInt64),
-  duration_quantiles AggregateFunction(quantiles(0.75, 0.9, 0.95, 0.99), UInt64)
+  duration_quantiles AggregateFunction(quantilesTDigest(0.75, 0.9, 0.95, 0.99), UInt64)
 `;
 
 const selectByTarget = (bucket: 'toStartOfMinute' | 'toStartOfHour') => `
@@ -46,7 +50,7 @@ const selectByTarget = (bucket: 'toStartOfMinute' | 'toStartOfHour') => `
     count() AS total,
     sum(ok) AS total_ok,
     avgState(duration) AS duration_avg,
-    quantilesState(0.75, 0.9, 0.95, 0.99)(duration) AS duration_quantiles
+    quantilesTDigestState(0.75, 0.9, 0.95, 0.99)(duration) AS duration_quantiles
   FROM default.operations
   GROUP BY
     target,

--- a/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
+++ b/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
@@ -9,7 +9,7 @@ import type { Action } from '../clickhouse';
 // target's whole 24h slice.
 //
 // These rollups re-aggregate the same source (`default.operations`) keyed on
-// `(target, timestamp)` only, day-partitioned, so the same window query reads
+// `(target, timestamp)` only and time-partitioned, so the same window query reads
 // just the window's granules. The alert evaluator routes unfiltered rules here;
 // filtered rules keep using the existing tables (where the hash/client predicate
 // already exploits the sort-key prefix).
@@ -57,6 +57,7 @@ const createRollup = async (
   exec: (query: string) => Promise<void>,
   table: string,
   bucket: 'toStartOfMinute' | 'toStartOfHour',
+  partitionBy: string,
   ttlInterval: string,
 ) => {
   await exec(`
@@ -65,11 +66,11 @@ const createRollup = async (
       ${tableColumns}
     )
     ENGINE = SummingMergeTree
-    PARTITION BY toYYYYMMDD(timestamp)
+    PARTITION BY ${partitionBy}
     PRIMARY KEY (target, timestamp)
     ORDER BY (target, timestamp)
     TTL timestamp + INTERVAL ${ttlInterval}
-    SETTINGS index_granularity = 8192
+    SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
   `);
 
   await exec(`
@@ -86,6 +87,24 @@ const createRollup = async (
 export const action: Action = async exec => {
   // No historical backfill (start-fresh): the views capture inserts going
   // forward, starting the moment they're created.
-  await createRollup(exec, 'operations_minutely_by_target', 'toStartOfMinute', '24 HOUR');
-  await createRollup(exec, 'operations_hourly_by_target', 'toStartOfHour', '30 DAY');
+  //
+  // Partition granularity is matched to each TTL, and `ttl_only_drop_parts = 1`
+  // (set in createRollup) makes cleanup drop whole expired partitions instead of
+  // rewriting parts to strip rows: the 24h minutely rollup partitions by hour
+  // (~25 partitions, one ages out each hour), the 30-day hourly rollup by day
+  // (~31 partitions, one ages out each day, same as operations_hourly).
+  await createRollup(
+    exec,
+    'operations_minutely_by_target',
+    'toStartOfMinute',
+    'toStartOfHour(timestamp)',
+    '24 HOUR',
+  );
+  await createRollup(
+    exec,
+    'operations_hourly_by_target',
+    'toStartOfHour',
+    'toYYYYMMDD(timestamp)',
+    '30 DAY',
+  );
 };

--- a/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
+++ b/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
@@ -10,9 +10,9 @@ import type { Action } from '../clickhouse';
 //
 // These two views re-aggregate the same source (`default.operations`) keyed on
 // `(target, timestamp)` only, day-partitioned, so the same window query reads
-// just the window's granules. The alert evaluator routes unfiltered rules here
-// behind a feature flag; filtered rules keep using the existing tables (where
-// the hash/client predicate already exploits the sort-key prefix).
+// just the window's granules. The alert evaluator routes unfiltered rules here;
+// filtered rules keep using the existing tables (where the hash/client predicate
+// already exploits the sort-key prefix).
 //
 // The SELECTs intentionally mirror `createSelectStatementForOperationsMinutely`
 // / `...Hourly` in 004-version-2 (same aggregate-state functions) minus the

--- a/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
+++ b/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
@@ -54,14 +54,14 @@ const createRollup = async (
 export const action: Action = async exec => {
   await createRollup(
     exec,
-    'operations_minutely_by_target',
+    'operations_by_target_minutely',
     'toStartOfMinute',
     'toStartOfHour(timestamp)',
     '24 HOUR',
   );
   await createRollup(
     exec,
-    'operations_hourly_by_target',
+    'operations_by_target_hourly',
     'toStartOfHour',
     'toYYYYMMDD(timestamp)',
     '30 DAY',

--- a/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
+++ b/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
@@ -8,17 +8,38 @@ import type { Action } from '../clickhouse';
 // in particular is `PARTITION BY tuple()`, so a 5-minute alert scans the
 // target's whole 24h slice.
 //
-// These two views re-aggregate the same source (`default.operations`) keyed on
+// These rollups re-aggregate the same source (`default.operations`) keyed on
 // `(target, timestamp)` only, day-partitioned, so the same window query reads
 // just the window's granules. The alert evaluator routes unfiltered rules here;
 // filtered rules keep using the existing tables (where the hash/client predicate
 // already exploits the sort-key prefix).
 //
-// The SELECTs intentionally mirror `createSelectStatementForOperationsMinutely`
-// / `...Hourly` in 004-version-2 (same aggregate-state functions) minus the
-// hash/client dimensions, so `avgMerge` / `quantilesMerge` at read time stay
-// correct.
-const createByTargetSelect = (bucket: 'toStartOfMinute' | 'toStartOfHour') => `
+// Each rollup is a data table + a separate `TO`-table materialized view (the
+// `_mv` suffix), rather than the combined `CREATE MATERIALIZED VIEW ... AS` form
+// the older operations_* tables use. Splitting them lets the view and the table
+// be migrated independently.
+
+// Data table columns, with storage codecs.
+const tableColumns = `
+  target LowCardinality(String) CODEC(ZSTD(1)),
+  timestamp DateTime('UTC') CODEC(DoubleDelta, LZ4),
+  total UInt32 CODEC(T64, ZSTD(1)),
+  total_ok UInt32 CODEC(T64, ZSTD(1)),
+  duration_avg AggregateFunction(avg, UInt64) CODEC(ZSTD(1)),
+  duration_quantiles AggregateFunction(quantiles(0.75, 0.9, 0.95, 0.99), UInt64) CODEC(ZSTD(1))
+`;
+
+// Same columns as the data table, types only — the MV's output projection.
+const mvColumns = `
+  target LowCardinality(String),
+  timestamp DateTime('UTC'),
+  total UInt32,
+  total_ok UInt32,
+  duration_avg AggregateFunction(avg, UInt64),
+  duration_quantiles AggregateFunction(quantiles(0.75, 0.9, 0.95, 0.99), UInt64)
+`;
+
+const selectByTarget = (bucket: 'toStartOfMinute' | 'toStartOfHour') => `
   SELECT
     target,
     ${bucket}(timestamp) AS timestamp,
@@ -32,45 +53,39 @@ const createByTargetSelect = (bucket: 'toStartOfMinute' | 'toStartOfHour') => `
     timestamp
 `;
 
+const createRollup = async (
+  exec: (query: string) => Promise<void>,
+  table: string,
+  bucket: 'toStartOfMinute' | 'toStartOfHour',
+  ttlInterval: string,
+) => {
+  await exec(`
+    CREATE TABLE IF NOT EXISTS default.${table}
+    (
+      ${tableColumns}
+    )
+    ENGINE = SummingMergeTree
+    PARTITION BY toYYYYMMDD(timestamp)
+    PRIMARY KEY (target, timestamp)
+    ORDER BY (target, timestamp)
+    TTL timestamp + INTERVAL ${ttlInterval}
+    SETTINGS index_granularity = 8192
+  `);
+
+  await exec(`
+    CREATE MATERIALIZED VIEW IF NOT EXISTS default.${table}_mv TO default.${table}
+    (
+      ${mvColumns}
+    )
+    AS (
+      ${selectByTarget(bucket)}
+    )
+  `);
+};
+
 export const action: Action = async exec => {
   // No historical backfill (start-fresh): the views capture inserts going
   // forward, starting the moment they're created.
-  await Promise.all([
-    exec(`
-      CREATE MATERIALIZED VIEW IF NOT EXISTS default.operations_minutely_by_target
-      (
-        target LowCardinality(String) CODEC(ZSTD(1)),
-        timestamp DateTime('UTC') CODEC(DoubleDelta, LZ4),
-        total UInt32 CODEC(T64, ZSTD(1)),
-        total_ok UInt32 CODEC(T64, ZSTD(1)),
-        duration_avg AggregateFunction(avg, UInt64) CODEC(ZSTD(1)),
-        duration_quantiles AggregateFunction(quantiles(0.75, 0.9, 0.95, 0.99), UInt64) CODEC(ZSTD(1))
-      )
-      ENGINE = SummingMergeTree
-      PARTITION BY toYYYYMMDD(timestamp)
-      PRIMARY KEY (target, timestamp)
-      ORDER BY (target, timestamp)
-      TTL timestamp + INTERVAL 24 HOUR
-      SETTINGS index_granularity = 8192 AS
-      ${createByTargetSelect('toStartOfMinute')}
-    `),
-    exec(`
-      CREATE MATERIALIZED VIEW IF NOT EXISTS default.operations_hourly_by_target
-      (
-        target LowCardinality(String) CODEC(ZSTD(1)),
-        timestamp DateTime('UTC') CODEC(DoubleDelta, LZ4),
-        total UInt32 CODEC(T64, ZSTD(1)),
-        total_ok UInt32 CODEC(T64, ZSTD(1)),
-        duration_avg AggregateFunction(avg, UInt64) CODEC(ZSTD(1)),
-        duration_quantiles AggregateFunction(quantiles(0.75, 0.9, 0.95, 0.99), UInt64) CODEC(ZSTD(1))
-      )
-      ENGINE = SummingMergeTree
-      PARTITION BY toYYYYMMDD(timestamp)
-      PRIMARY KEY (target, timestamp)
-      ORDER BY (target, timestamp)
-      TTL timestamp + INTERVAL 30 DAY
-      SETTINGS index_granularity = 8192 AS
-      ${createByTargetSelect('toStartOfHour')}
-    `),
-  ]);
+  await createRollup(exec, 'operations_minutely_by_target', 'toStartOfMinute', '24 HOUR');
+  await createRollup(exec, 'operations_hourly_by_target', 'toStartOfHour', '30 DAY');
 };

--- a/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
+++ b/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
@@ -1,29 +1,5 @@
 import type { Action } from '../clickhouse';
 
-// Target-keyed rollups for the metric-alert evaluator. The existing
-// `operations_minutely` / `operations_hourly` tables are ordered
-// `(target, hash, client_name, client_version, timestamp)`, so an unfiltered
-// alert window query (sum across all hashes/clients for a target over a time
-// range) can't use timestamp for index/partition pruning...`operations_minutely`
-// in particular is `PARTITION BY tuple()`, so a 5-minute alert scans the
-// target's whole 24h slice.
-//
-// These rollups re-aggregate the same source (`default.operations`) keyed on
-// `(target, timestamp)` only and time-partitioned, so the same window query reads
-// just the window's granules. The alert evaluator routes unfiltered rules here;
-// filtered rules keep using the existing tables (where the hash/client predicate
-// already exploits the sort-key prefix).
-//
-// Each rollup is a data table + a separate `TO`-table materialized view (the
-// `_mv` suffix), rather than the combined `CREATE MATERIALIZED VIEW ... AS` form
-// the older operations_* tables use. Splitting them lets the view and the table
-// be migrated independently.
-
-// Data table columns, with storage codecs. Percentiles use `quantilesTDigest`
-// rather than the older `quantiles` the legacy operations_* rollups use:
-// t-digest is deterministic and more accurate in the tails (what P95/P99 latency
-// alerting needs) and merges better across the MV's partial states. The reader
-// must match it with `quantilesTDigestMerge` (see `queryClickHouseWindows`).
 const tableColumns = `
   target LowCardinality(String) CODEC(ZSTD(1)),
   timestamp DateTime('UTC') CODEC(DoubleDelta, LZ4),
@@ -33,22 +9,12 @@ const tableColumns = `
   duration_quantiles AggregateFunction(quantilesTDigest(0.75, 0.9, 0.95, 0.99), UInt64) CODEC(ZSTD(1))
 `;
 
-// Same columns as the data table, types only — the MV's output projection.
-const mvColumns = `
-  target LowCardinality(String),
-  timestamp DateTime('UTC'),
-  total UInt32,
-  total_ok UInt32,
-  duration_avg AggregateFunction(avg, UInt64),
-  duration_quantiles AggregateFunction(quantilesTDigest(0.75, 0.9, 0.95, 0.99), UInt64)
-`;
-
 const selectByTarget = (bucket: 'toStartOfMinute' | 'toStartOfHour') => `
   SELECT
     target,
     ${bucket}(timestamp) AS timestamp,
-    count() AS total,
-    sum(ok) AS total_ok,
+    CAST(count() AS UInt32) AS total,
+    CAST(sum(ok) AS UInt32) AS total_ok,
     avgState(duration) AS duration_avg,
     quantilesTDigestState(0.75, 0.9, 0.95, 0.99)(duration) AS duration_quantiles
   FROM default.operations
@@ -79,9 +45,6 @@ const createRollup = async (
 
   await exec(`
     CREATE MATERIALIZED VIEW IF NOT EXISTS default.${table}_mv TO default.${table}
-    (
-      ${mvColumns}
-    )
     AS (
       ${selectByTarget(bucket)}
     )
@@ -89,14 +52,6 @@ const createRollup = async (
 };
 
 export const action: Action = async exec => {
-  // No historical backfill (start-fresh): the views capture inserts going
-  // forward, starting the moment they're created.
-  //
-  // Partition granularity is matched to each TTL, and `ttl_only_drop_parts = 1`
-  // (set in createRollup) makes cleanup drop whole expired partitions instead of
-  // rewriting parts to strip rows: the 24h minutely rollup partitions by hour
-  // (~25 partitions, one ages out each hour), the 30-day hourly rollup by day
-  // (~31 partitions, one ages out each day, same as operations_hourly).
   await createRollup(
     exec,
     'operations_minutely_by_target',

--- a/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
+++ b/packages/migrations/src/clickhouse-actions/018-metric-alert-target-rollups.ts
@@ -18,7 +18,7 @@ import type { Action } from '../clickhouse';
 // / `...Hourly` in 004-version-2 (same aggregate-state functions) minus the
 // hash/client dimensions, so `avgMerge` / `quantilesMerge` at read time stay
 // correct.
-const createByTargetSelect = (bucket: 'toStartOfMinute' | 'toStartOfHour', where: string) => `
+const createByTargetSelect = (bucket: 'toStartOfMinute' | 'toStartOfHour') => `
   SELECT
     target,
     ${bucket}(timestamp) AS timestamp,
@@ -27,27 +27,14 @@ const createByTargetSelect = (bucket: 'toStartOfMinute' | 'toStartOfHour', where
     avgState(duration) AS duration_avg,
     quantilesState(0.75, 0.9, 0.95, 0.99)(duration) AS duration_quantiles
   FROM default.operations
-  ${where}
   GROUP BY
     target,
     timestamp
 `;
 
-export const action: Action = async (exec, _query, hiveCloudEnvironment) => {
+export const action: Action = async exec => {
   // No historical backfill (start-fresh): the views capture inserts going
-  // forward. In prod, begin aggregating from the next UTC day boundary so the
-  // view starts on a clean partition rather than mid-minute during deploy
-  // ...same convention as 007-james-bond-aggregates-hourly-and-minutely.
-  let where = '';
-
-  if (hiveCloudEnvironment === 'prod') {
-    const tomorrow = new Date();
-    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-    const startOfTomorrow = tomorrow.toISOString().split('T')[0];
-
-    where = `WHERE toDate(timestamp) >= toDate('${startOfTomorrow}')`;
-  }
-
+  // forward, starting the moment they're created.
   await Promise.all([
     exec(`
       CREATE MATERIALIZED VIEW IF NOT EXISTS default.operations_minutely_by_target
@@ -65,7 +52,7 @@ export const action: Action = async (exec, _query, hiveCloudEnvironment) => {
       ORDER BY (target, timestamp)
       TTL timestamp + INTERVAL 24 HOUR
       SETTINGS index_granularity = 8192 AS
-      ${createByTargetSelect('toStartOfMinute', where)}
+      ${createByTargetSelect('toStartOfMinute')}
     `),
     exec(`
       CREATE MATERIALIZED VIEW IF NOT EXISTS default.operations_hourly_by_target
@@ -83,7 +70,7 @@ export const action: Action = async (exec, _query, hiveCloudEnvironment) => {
       ORDER BY (target, timestamp)
       TTL timestamp + INTERVAL 30 DAY
       SETTINGS index_granularity = 8192 AS
-      ${createByTargetSelect('toStartOfHour', where)}
+      ${createByTargetSelect('toStartOfHour')}
     `),
   ]);
 };

--- a/packages/migrations/src/clickhouse.ts
+++ b/packages/migrations/src/clickhouse.ts
@@ -178,6 +178,7 @@ export async function migrateClickHouse(
     import('./clickhouse-actions/015-otel-trace'),
     import('./clickhouse-actions/016-subgraph-otel-traces-cleanup'),
     import('./clickhouse-actions/017-affected-app-deployments-performance'),
+    import('./clickhouse-actions/018-metric-alert-target-rollups'),
   ]);
 
   async function actionRunner(action: Action, index: number) {

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.spec.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.spec.ts
@@ -151,6 +151,8 @@ describe('queryClickHouseWindows', () => {
     expect(sql).toContain('target = {p1: String}');
     expect(sql).not.toContain('client_name');
     expect(sql).not.toContain('hash');
+    // The rollup stores percentiles as quantilesTDigest states.
+    expect(sql).toContain('quantilesTDigestMerge(');
     expect(params).toEqual({ param_p1: target });
   });
 
@@ -166,6 +168,9 @@ describe('queryClickHouseWindows', () => {
     // hash/client columns to predicate on.
     expect(sql).toContain('FROM operations_minutely');
     expect(sql).not.toContain('_by_target');
+    // The legacy table stores percentiles as the older quantiles states.
+    expect(sql).toContain('quantilesMerge(');
+    expect(sql).not.toContain('TDigest');
     // renumbered after the target param (p1)
     expect(sql).toContain('client_name = {p2: String}');
     expect(sql).not.toContain(`'web'`);

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.spec.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.spec.ts
@@ -141,17 +141,20 @@ describe('queryClickHouseWindows', () => {
   const evalTime = new Date('2024-06-01T12:00:00.000Z');
   const target = '11111111-1111-1111-1111-111111111111';
 
-  test('no filter -> target + timestamp only, no filter predicate, only target bound', async () => {
+  test('no filter -> target-keyed minutely rollup, no hash/client predicate, only target bound', async () => {
     const { clickhouse, calls } = captureClient();
     await queryClickHouseWindows(clickhouse, target, 60, [], evalTime);
     const { sql, params } = calls[0];
-    expect(sql).toContain('FROM operations_minutely');
+    // Unfiltered -> the target-keyed rollup. It dropped the hash/client
+    // dimensions, so the query must emit no hash/client predicate.
+    expect(sql).toContain('FROM operations_minutely_by_target');
     expect(sql).toContain('target = {p1: String}');
     expect(sql).not.toContain('client_name');
+    expect(sql).not.toContain('hash');
     expect(params).toEqual({ param_p1: target });
   });
 
-  test('with a client filter -> predicate composed and value bound as a param (not interpolated)', async () => {
+  test('with a client filter -> legacy table, predicate composed and bound as a param (not interpolated)', async () => {
     const { clickhouse, calls } = captureClient();
     const conds = buildSavedFilterConditions(
       { clientFilters: [{ name: 'web', versions: null }] },
@@ -159,6 +162,10 @@ describe('queryClickHouseWindows', () => {
     );
     await queryClickHouseWindows(clickhouse, target, 60, conds, evalTime);
     const { sql, params } = calls[0];
+    // A filtered query MUST stay on the legacy table — the rollup has no
+    // hash/client columns to predicate on.
+    expect(sql).toContain('FROM operations_minutely');
+    expect(sql).not.toContain('_by_target');
     // renumbered after the target param (p1)
     expect(sql).toContain('client_name = {p2: String}');
     expect(sql).not.toContain(`'web'`);
@@ -168,17 +175,6 @@ describe('queryClickHouseWindows', () => {
   test('window > 360 minutes reads the hourly rollup', async () => {
     const { clickhouse, calls } = captureClient();
     await queryClickHouseWindows(clickhouse, target, 720, [], evalTime);
-    expect(calls[0].sql).toContain('FROM operations_hourly');
-  });
-
-  test('useTargetRollup -> reads the target-keyed rollup with no hash/client predicate', async () => {
-    const { clickhouse, calls } = captureClient();
-    await queryClickHouseWindows(clickhouse, target, 60, [], evalTime, true);
-    const { sql } = calls[0];
-    expect(sql).toContain('FROM operations_minutely_by_target');
-    // The rollup dropped the hash/client dimensions, so the rollup path must
-    // never emit a hash/client predicate.
-    expect(sql).not.toContain('client_name');
-    expect(sql).not.toContain('hash');
+    expect(calls[0].sql).toContain('FROM operations_hourly_by_target');
   });
 });

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.spec.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.spec.ts
@@ -147,7 +147,7 @@ describe('queryClickHouseWindows', () => {
     const { sql, params } = calls[0];
     // Unfiltered -> the target-keyed rollup. It dropped the hash/client
     // dimensions, so the query must emit no hash/client predicate.
-    expect(sql).toContain('FROM operations_minutely_by_target');
+    expect(sql).toContain('FROM operations_by_target_minutely');
     expect(sql).toContain('target = {p1: String}');
     expect(sql).not.toContain('client_name');
     expect(sql).not.toContain('hash');
@@ -180,6 +180,6 @@ describe('queryClickHouseWindows', () => {
   test('window > 360 minutes reads the hourly rollup', async () => {
     const { clickhouse, calls } = captureClient();
     await queryClickHouseWindows(clickhouse, target, 720, [], evalTime);
-    expect(calls[0].sql).toContain('FROM operations_hourly_by_target');
+    expect(calls[0].sql).toContain('FROM operations_by_target_hourly');
   });
 });

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.spec.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.spec.ts
@@ -170,4 +170,15 @@ describe('queryClickHouseWindows', () => {
     await queryClickHouseWindows(clickhouse, target, 720, [], evalTime);
     expect(calls[0].sql).toContain('FROM operations_hourly');
   });
+
+  test('useTargetRollup -> reads the target-keyed rollup with no hash/client predicate', async () => {
+    const { clickhouse, calls } = captureClient();
+    await queryClickHouseWindows(clickhouse, target, 60, [], evalTime, true);
+    const { sql } = calls[0];
+    expect(sql).toContain('FROM operations_minutely_by_target');
+    // The rollup dropped the hash/client dimensions, so the rollup path must
+    // never emit a hash/client predicate.
+    expect(sql).not.toContain('client_name');
+    expect(sql).not.toContain('hash');
+  });
 });

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.ts
@@ -273,11 +273,17 @@ export async function queryClickHouseWindows(
   // hash/client dimensions a filter predicates on, so routing one there would
   // reference columns that don't exist. Deriving this from `filterConditions`
   // (rather than a separate flag/param) makes the filtered-query-on-rollup
-  // combination unrepresentable. Both rollups carry the same total/total_ok/
-  // duration_* columns the SELECT below reads, so only the table name changes.
+  // combination unrepresentable.
   const useTargetRollup = filterConditions.length === 0;
   const baseTable = timeWindowMinutes <= 360 ? 'operations_minutely' : 'operations_hourly';
   const tableName = useTargetRollup ? `${baseTable}_by_target` : baseTable;
+
+  // The two table families store the percentile column with different aggregate
+  // functions: the `_by_target` rollups use quantilesTDigest (more accurate in
+  // the tails, merges better), the legacy tables the older quantiles. A merge
+  // function must match the state function it reads, so pick it alongside the
+  // table. `total`/`total_ok`/`duration_avg` are identical across both.
+  const percentilesMerge = useTargetRollup ? 'quantilesTDigestMerge' : 'quantilesMerge';
 
   // The window timestamps are computed numbers, inlined safely via sql.raw. Every
   // string value (`target` and the saved-filter conditions' arbitrary client/
@@ -295,7 +301,7 @@ export async function queryClickHouseWindows(
       sum(total) as total,
       sum(total_ok) as total_ok,
       avgMerge(duration_avg) as average,
-      quantilesMerge(0.75, 0.90, 0.95, 0.99)(duration_quantiles) as percentiles
+      ${sql.raw(percentilesMerge)}(0.75, 0.90, 0.95, 0.99)(duration_quantiles) as percentiles
     FROM ${sql.raw(tableName)}
     WHERE target = ${targetId}
       AND timestamp >= fromUnixTimestamp64Milli(${sql.raw(String(previousWindowStart.getTime()))})

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.ts
@@ -257,12 +257,6 @@ export async function queryClickHouseWindows(
   // this job up late, using wall-clock would shift the queried window
   // forward and could miss the spike that should have fired the alert.
   evaluationTime: Date,
-  // When true, read the target-keyed rollups (operations_*_by_target) instead
-  // of the full per-hash/client tables. The caller only sets this for unfiltered
-  // rules (no `filterConditions`), since those rollups have dropped the
-  // hash/client dimensions a filter would predicate on. Defaults to false so
-  // existing callers/tests keep hitting the legacy tables.
-  useTargetRollup = false,
 ): Promise<{ current: ClickHouseWindowRow | null; previous: ClickHouseWindowRow | null }> {
   const anchorMs = evaluationTime.getTime();
   const offsetMs = 60_000;
@@ -272,11 +266,16 @@ export async function queryClickHouseWindows(
   const currentWindowStart = new Date(anchorMs - offsetMs - windowMs);
   const previousWindowStart = new Date(anchorMs - offsetMs - 2 * windowMs);
 
-  // Pick the resolution table by window size, then optionally its target-keyed
-  // rollup variant. Both rollups carry the same total/total_ok/duration_*
-  // aggregate columns the SELECT below reads, so only the table name changes...
-  // and `_by_target` is day-partitioned and ordered (target, timestamp), so this
-  // window query prunes by time instead of scanning the target's whole slice.
+  // Unfiltered queries read the target-keyed rollups (operations_*_by_target):
+  // they sum across all hashes/clients, exactly what those rollups pre-aggregate,
+  // so the query prunes by time instead of scanning the target's whole slice.
+  // Filtered queries MUST stay on the legacy tables...the rollups dropped the
+  // hash/client dimensions a filter predicates on, so routing one there would
+  // reference columns that don't exist. Deriving this from `filterConditions`
+  // (rather than a separate flag/param) makes the filtered-query-on-rollup
+  // combination unrepresentable. Both rollups carry the same total/total_ok/
+  // duration_* columns the SELECT below reads, so only the table name changes.
+  const useTargetRollup = filterConditions.length === 0;
   const baseTable = timeWindowMinutes <= 360 ? 'operations_minutely' : 'operations_hourly';
   const tableName = useTargetRollup ? `${baseTable}_by_target` : baseTable;
 

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.ts
@@ -257,6 +257,12 @@ export async function queryClickHouseWindows(
   // this job up late, using wall-clock would shift the queried window
   // forward and could miss the spike that should have fired the alert.
   evaluationTime: Date,
+  // When true, read the target-keyed rollups (operations_*_by_target) instead
+  // of the full per-hash/client tables. The caller only sets this for unfiltered
+  // rules (no `filterConditions`), since those rollups have dropped the
+  // hash/client dimensions a filter would predicate on. Defaults to false so
+  // existing callers/tests keep hitting the legacy tables.
+  useTargetRollup = false,
 ): Promise<{ current: ClickHouseWindowRow | null; previous: ClickHouseWindowRow | null }> {
   const anchorMs = evaluationTime.getTime();
   const offsetMs = 60_000;
@@ -266,7 +272,13 @@ export async function queryClickHouseWindows(
   const currentWindowStart = new Date(anchorMs - offsetMs - windowMs);
   const previousWindowStart = new Date(anchorMs - offsetMs - 2 * windowMs);
 
-  const tableName = timeWindowMinutes <= 360 ? 'operations_minutely' : 'operations_hourly';
+  // Pick the resolution table by window size, then optionally its target-keyed
+  // rollup variant. Both rollups carry the same total/total_ok/duration_*
+  // aggregate columns the SELECT below reads, so only the table name changes...
+  // and `_by_target` is day-partitioned and ordered (target, timestamp), so this
+  // window query prunes by time instead of scanning the target's whole slice.
+  const baseTable = timeWindowMinutes <= 360 ? 'operations_minutely' : 'operations_hourly';
+  const tableName = useTargetRollup ? `${baseTable}_by_target` : baseTable;
 
   // The window timestamps are computed numbers, inlined safely via sql.raw. Every
   // string value (`target` and the saved-filter conditions' arbitrary client/

--- a/packages/services/workflows/src/lib/metric-alert-evaluator.ts
+++ b/packages/services/workflows/src/lib/metric-alert-evaluator.ts
@@ -266,7 +266,7 @@ export async function queryClickHouseWindows(
   const currentWindowStart = new Date(anchorMs - offsetMs - windowMs);
   const previousWindowStart = new Date(anchorMs - offsetMs - 2 * windowMs);
 
-  // Unfiltered queries read the target-keyed rollups (operations_*_by_target):
+  // Unfiltered queries read the target-keyed rollups (operations_by_target_*):
   // they sum across all hashes/clients, exactly what those rollups pre-aggregate,
   // so the query prunes by time instead of scanning the target's whole slice.
   // Filtered queries MUST stay on the legacy tables...the rollups dropped the
@@ -275,12 +275,14 @@ export async function queryClickHouseWindows(
   // (rather than a separate flag/param) makes the filtered-query-on-rollup
   // combination unrepresentable.
   const useTargetRollup = filterConditions.length === 0;
-  const baseTable = timeWindowMinutes <= 360 ? 'operations_minutely' : 'operations_hourly';
-  const tableName = useTargetRollup ? `${baseTable}_by_target` : baseTable;
+  const resolution = timeWindowMinutes <= 360 ? 'minutely' : 'hourly';
+  const tableName = useTargetRollup
+    ? `operations_by_target_${resolution}`
+    : `operations_${resolution}`;
 
   // The two table families store the percentile column with different aggregate
-  // functions: the `_by_target` rollups use quantilesTDigest (more accurate in
-  // the tails, merges better), the legacy tables the older quantiles. A merge
+  // functions: the by_target rollups use quantilesTDigest (more accurate in the
+  // tails, merges better), the legacy tables the older quantiles. A merge
   // function must match the state function it reads, so pick it alongside the
   // table. `total`/`total_ok`/`duration_avg` are identical across both.
   const percentilesMerge = useTargetRollup ? 'quantilesTDigestMerge' : 'quantilesMerge';

--- a/packages/services/workflows/src/tasks/evaluate-metric-alert-rules.ts
+++ b/packages/services/workflows/src/tasks/evaluate-metric-alert-rules.ts
@@ -79,6 +79,12 @@ export const task = implementTask(EvaluateMetricAlertRulesTask, async args => {
     // isolating the failure to this group.
     const filterConditions = buildSavedFilterConditions(representative.savedFilterFilters, logger);
 
+    // Only unfiltered groups can use the target-keyed rollups — they've dropped
+    // the hash/client dimensions, so a saved filter would have nothing to
+    // predicate on. Filtered groups keep their fast index-prefix path on the
+    // legacy tables.
+    const useTargetRollup = filterConditions.length === 0;
+
     // startActiveSpan makes this span the current OTel context for the
     // duration of the callback, so the slonik PG interceptor and the
     // fetch instrumentation parent their auto-spans under this one. That's
@@ -104,6 +110,7 @@ export const task = implementTask(EvaluateMetricAlertRulesTask, async args => {
               representative.timeWindowMinutes,
               filterConditions,
               evaluationTime,
+              useTargetRollup,
             );
           } catch (error) {
             logger.error(

--- a/packages/services/workflows/src/tasks/evaluate-metric-alert-rules.ts
+++ b/packages/services/workflows/src/tasks/evaluate-metric-alert-rules.ts
@@ -79,12 +79,6 @@ export const task = implementTask(EvaluateMetricAlertRulesTask, async args => {
     // isolating the failure to this group.
     const filterConditions = buildSavedFilterConditions(representative.savedFilterFilters, logger);
 
-    // Only unfiltered groups can use the target-keyed rollups — they've dropped
-    // the hash/client dimensions, so a saved filter would have nothing to
-    // predicate on. Filtered groups keep their fast index-prefix path on the
-    // legacy tables.
-    const useTargetRollup = filterConditions.length === 0;
-
     // startActiveSpan makes this span the current OTel context for the
     // duration of the callback, so the slonik PG interceptor and the
     // fetch instrumentation parent their auto-spans under this one. That's
@@ -110,7 +104,6 @@ export const task = implementTask(EvaluateMetricAlertRulesTask, async args => {
               representative.timeWindowMinutes,
               filterConditions,
               evaluationTime,
-              useTargetRollup,
             );
           } catch (error) {
             logger.error(


### PR DESCRIPTION
This PR speeds up the metric-alert evaluator's ClickHouse query for unfiltered rules by reading from new target-keyed rollups instead of the full per-hash/client tables.

The evaluator's window query sums across all operations for a target over a time range. The existing `operations_minutely` / `operations_hourly` tables are ordered (target, hash, client_name, client_version, timestamp) (timestamp is last) and `operations_minutely` is `PARTITION BY tuple()`, so that query can't prune by time and ends up scanning the target's entire slice (up to 24h of per-hash/client rows for a 5-minute alert).

This adds two tables fed by materialized views, `operations_minutely_by_target` and `operations_hourly_by_target`, that re-aggregate default.operations keyed on (target, timestamp) only, partitioned by hour (minutely) / by day (hourly), ordered (target, timestamp).

Routing is keyed on `filterConditions.length === 0`...rules with a saved filter keep using the existing tables, where the hash/client predicate already exploits the sort-key prefix and the rollups (which drop those dimensions) wouldn't be usable. 
