### PR TITLE
use abort controller for stopping pending timers

### DIFF
--- a/packages/services/service-common/src/iam-aws.ts
+++ b/packages/services/service-common/src/iam-aws.ts
@@ -1,3 +1,4 @@
+import { setTimeout as sleep } from 'node:timers/promises';
 import { Sha256 } from '@aws-crypto/sha256-js';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { formatUrl } from '@aws-sdk/util-format-url';
@@ -114,45 +115,51 @@ export function startTokenRefreshTimer(
   const retryBackoffMs = options?.retryBackoffMs ?? 5_000;
 
   // Track shutdown state to prevent in-flight callbacks and retries during graceful shutdown
-  let isShuttingDown = false;
+  const abortController = new AbortController();
   let currentTimer: ReturnType<typeof setTimeout> | undefined;
 
   function scheduleNext() {
-    if (isShuttingDown) return;
-
+    if (abortController.signal.aborted) return;
     const jitterMs = Math.floor(Math.random() * maxJitterMs);
+
     currentTimer = setTimeout(() => {
-      if (isShuttingDown) return;
+      if (abortController.signal.aborted) return;
 
       void (async () => {
         for (let attempt = 1; attempt <= maxRetries; attempt++) {
-          if (isShuttingDown) return;
+          if (abortController.signal.aborted) return;
 
           try {
             await refreshFn(attempt, maxRetries);
             break;
           } catch {
-            if (attempt < maxRetries) {
-              await new Promise(r => setTimeout(r, attempt * retryBackoffMs));
+            if (attempt >= maxRetries) {
+              return;
             }
+          }
+
+          try {
+            await sleep(attempt * retryBackoffMs, {
+              signal: abortController.signal,
+            });
+          } catch (err) {
+            if (abortController.signal.aborted) {
+              return;
+            }
+            throw err;
           }
         }
         // Schedule next cycle only after current refresh (including retries) completes
         scheduleNext();
       })();
     }, intervalMs + jitterMs);
-
-    // Allow clean process shutdown even if the refresh timer is still active.
-    if (typeof currentTimer.unref === 'function') {
-      currentTimer.unref();
-    }
   }
 
   scheduleNext();
 
   // Return a cleanup function that sets shutdown flag and clears the pending timer
   return () => {
-    isShuttingDown = true;
+    abortController.abort();
     if (currentTimer !== undefined) {
       clearTimeout(currentTimer);
     }

--- a/packages/services/service-common/src/redis-client.ts
+++ b/packages/services/service-common/src/redis-client.ts
@@ -94,7 +94,8 @@ export async function createRedisClient(
   // Start IAM token refresh if enabled
   // Each client gets its own independent token lifecycle
   if (redisIamConfig) {
-    startIamTokenRefresh(redis, redisIamConfig, options.logger);
+    const stopTokenRefresh = startIamTokenRefresh(redis, redisIamConfig, options.logger);
+    redis.on('end', stopTokenRefresh);
   }
 
   return redis;

--- a/packages/services/workflows/src/index.ts
+++ b/packages/services/workflows/src/index.ts
@@ -215,7 +215,7 @@ registerShutdown({
       await pg.end();
       logger.info('Shutdown postgres connection successful.');
       logger.info('Shutdown redis connection.');
-      redis.disconnect(false);
+      await Promise.all([redis.quit(), await redisSubscriber.quit()]);
       if (shutdownMetrics) {
         logger.info('Stopping prometheus endpoint');
         await shutdownMetrics();

--- a/packages/services/workflows/src/index.ts
+++ b/packages/services/workflows/src/index.ts
@@ -215,7 +215,7 @@ registerShutdown({
       await pg.end();
       logger.info('Shutdown postgres connection successful.');
       logger.info('Shutdown redis connection.');
-      await Promise.all([redis.quit(), await redisSubscriber.quit()]);
+      await Promise.all([redis.quit(), redisSubscriber.quit()]);
       if (shutdownMetrics) {
         logger.info('Stopping prometheus endpoint');
         await shutdownMetrics();


### PR DESCRIPTION
- Use an abort controller to stop a retry timer halting graceful process exit.
- Lift timer cleanup and handle it gracefully instead of using `unref`