### PR TITLE
Stop the propagation on lab when clicking run script

### DIFF
--- a/packages/web/app/src/lib/preflight/graphiql-plugin.tsx
+++ b/packages/web/app/src/lib/preflight/graphiql-plugin.tsx
@@ -747,13 +747,13 @@ function PreflightModal({
                 size="icon-sm"
                 className="size-auto gap-1"
                 onClick={e => {
+                  e.stopPropagation();
                   if (state === PreflightWorkerState.running) {
                     abortExecution();
                     return;
                   }
 
                   execute(scriptEditorRef.current?.getValue() ?? '');
-                  e.stopPropagation();
                 }}
                 data-cy="run-preflight"
               >

--- a/packages/web/app/src/lib/preflight/graphiql-plugin.tsx
+++ b/packages/web/app/src/lib/preflight/graphiql-plugin.tsx
@@ -746,13 +746,14 @@ function PreflightModal({
                 variant="orangeLink"
                 size="icon-sm"
                 className="size-auto gap-1"
-                onClick={() => {
+                onClick={e => {
                   if (state === PreflightWorkerState.running) {
                     abortExecution();
                     return;
                   }
 
                   execute(scriptEditorRef.current?.getValue() ?? '');
+                  e.stopPropagation();
                 }}
                 data-cy="run-preflight"
               >


### PR DESCRIPTION
### Background

Flaky e2e tests

### Description

In our playwright tests, sometimes the test checking the log output fails. I checked out the screenshots and the whole modal had closed. This leads me to believe the click is being propagated up and closing the modal.