### PR TITLE
deflake yoga batch test

### DIFF
--- a/packages/libraries/yoga/tests/yoga.spec.ts
+++ b/packages/libraries/yoga/tests/yoga.spec.ts
@@ -1554,7 +1554,7 @@ describe('request batching usage reporting', () => {
           },
           agent: {
             maxSize: 2,
-            sendInterval: 20,
+            sendInterval: 1000,
             logger: createLogger('silent'),
             async fetch(_req, init) {
               d.resolve(init!);

--- a/packages/libraries/yoga/tests/yoga.spec.ts
+++ b/packages/libraries/yoga/tests/yoga.spec.ts
@@ -1553,8 +1553,8 @@ describe('request batching usage reporting', () => {
             endpoint: 'http://localhost/usage',
           },
           agent: {
-            maxSize: 1,
-            sendInterval: 10,
+            maxSize: 2,
+            sendInterval: 20,
             logger: createLogger('silent'),
             async fetch(_req, init) {
               d.resolve(init!);


### PR DESCRIPTION
### Background

This test semi-regularly fails for me in CI. I suspect that the batch is getting sent prematurely due to the low batch time (10ms) and the batch size being 1.

### Description

Increases the batch size to avoid early send, and slightly increase the send interval in case this is triggering between the operations being pushed to the batch