### PR TITLE
reduce parallelism in e2e tests for ci runs

### DIFF
--- a/.github/workflows/tests-e2e.yaml
+++ b/.github/workflows/tests-e2e.yaml
@@ -48,7 +48,7 @@ jobs:
             up -d --wait
 
       - name: playwright
-        timeout-minutes: 12
+        timeout-minutes: 15
         run: pnpm test:e2e
         env:
           CI: true

--- a/.github/workflows/tests-e2e.yaml
+++ b/.github/workflows/tests-e2e.yaml
@@ -48,7 +48,7 @@ jobs:
             up -d --wait
 
       - name: playwright
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: pnpm test:e2e
         env:
           CI: true

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,10 +19,10 @@ export default defineConfig({
   expect: {
     timeout: 15_000,
   },
-  fullyParallel: !isCI,
+  fullyParallel: true,
   forbidOnly: isCI,
   retries: 0,
-  workers: isCI ? 2 : undefined,
+  workers: isCI ? 1 : undefined,
   reporter: isCI
     ? [['list'], ['github'], ['html', { open: 'never' }]]
     : [['list'], ['html', { open: 'never' }]],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,10 +19,10 @@ export default defineConfig({
   expect: {
     timeout: 15_000,
   },
-  fullyParallel: true,
+  fullyParallel: !isCI,
   forbidOnly: isCI,
   retries: 0,
-  workers: isCI ? 4 : undefined,
+  workers: isCI ? 2 : undefined,
   reporter: isCI
     ? [['list'], ['github'], ['html', { open: 'never' }]]
     : [['list'], ['html', { open: 'never' }]],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,8 +21,8 @@ export default defineConfig({
   },
   fullyParallel: true,
   forbidOnly: isCI,
-  retries: 0,
-  workers: isCI ? 1 : undefined,
+  retries: 1,
+  workers: isCI ? 2 : undefined,
   reporter: isCI
     ? [['list'], ['github'], ['html', { open: 'never' }]]
     : [['list'], ['html', { open: 'never' }]],


### PR DESCRIPTION
### Background

e2e tests can timeout randomly, causing failures. Locally, I don't experience this. I suspect the GH runner is being overwhelmed.

### Description

This change limits execution to one worker to prevent hardware overloading (and therefore test stalling), and slightly increases job timeout duration to account for the reduced parallelism.

Standard GitHub runner has 2 vCPUs.