### PR TITLE
Improve UI per metric type on alert create form

### DIFF
--- a/packages/web/app/src/components/base/form/form.stories.tsx
+++ b/packages/web/app/src/components/base/form/form.stories.tsx
@@ -40,7 +40,7 @@ export const Default: Story = () => {
               <FormItem>
                 <FormLabel label="Alert name" />
                 <FormControl>
-                  <Input placeholder="Some cool alert name" {...field} />
+                  <Input placeholder="Enter alert name" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -84,7 +84,7 @@ export const WithErrors: Story = () => {
               <FormItem>
                 <FormLabel label="Alert name" />
                 <FormControl>
-                  <Input placeholder="Some cool alert name" {...field} />
+                  <Input placeholder="Enter alert name" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/packages/web/app/src/components/base/input/input.stories.tsx
+++ b/packages/web/app/src/components/base/input/input.stories.tsx
@@ -7,7 +7,7 @@ export default {
 
 export const Default: Story = () => (
   <div className="max-w-sm p-8">
-    <Input placeholder="Some cool alert name" />
+    <Input placeholder="Enter alert name" />
   </div>
 );
 

--- a/packages/web/app/src/components/target/alerts/alert-conditions-panel.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-conditions-panel.tsx
@@ -170,17 +170,21 @@ export function AlertConditionsPanel({
       ? `${rule.metric.toLowerCase()} latency`
       : METRIC_LABEL_BY_TYPE[rule.type];
 
-  // A PERCENTAGE_CHANGE threshold is always a percent. A fixed value carries the
-  // metric's own unit: ms for latency (rendered via formatDuration, e.g.
-  // "4.00s"), percent for error rate, and a bare count for traffic.
   const thresholdDisplay =
     rule.thresholdType === MetricAlertRuleThresholdType.PercentageChange
-      ? `${rule.thresholdValue}%`
+      ? `${Math.abs(rule.thresholdValue)}%`
       : rule.type === MetricAlertRuleType.Latency
         ? formatDuration(rule.thresholdValue, true)
         : rule.type === MetricAlertRuleType.ErrorRate
           ? `${rule.thresholdValue}%`
           : String(rule.thresholdValue);
+
+  const conditionLabel =
+    rule.thresholdType === MetricAlertRuleThresholdType.PercentageChange
+      ? rule.direction.toUpperCase() === 'BELOW'
+        ? 'decrease'
+        : 'increase'
+      : rule.direction.toLowerCase();
 
   const destination = destinationLabel(rule.channels);
 
@@ -239,7 +243,7 @@ export function AlertConditionsPanel({
             items: [
               {
                 term: 'Condition',
-                description: <span className="capitalize">{rule.direction.toLowerCase()}</span>,
+                description: <span className="capitalize">{conditionLabel}</span>,
               },
               {
                 term: 'Threshold type',

--- a/packages/web/app/src/components/target/alerts/alert-form.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-form.tsx
@@ -829,6 +829,7 @@ export function AlertForm(props: AlertFormProps) {
                               min={0}
                               max={valueMax}
                               placeholder={valuePlaceholder}
+                              style={{ minWidth: '7rem' }}
                               {...field}
                             />
                           </FormControl>
@@ -861,6 +862,7 @@ export function AlertForm(props: AlertFormProps) {
                   }
                   direction={watchedValues.direction}
                   thresholdType={watchedValues.thresholdType}
+                  timeWindowMinutes={parseInt(watchedValues.timeWindowMinutes, 10) || 0}
                 />
 
                 <Accordion defaultValue={expandAdvanced ? [0] : undefined}>

--- a/packages/web/app/src/components/target/alerts/alert-form.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-form.tsx
@@ -44,6 +44,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Link } from '@tanstack/react-router';
 import { AlertMetricChart } from './alert-metric-chart';
 import { AlertPreview } from './alert-notification-preview';
+import { applyThresholdSign, thresholdUnit } from './alert-threshold';
 
 const AlertForm_ChannelsQuery = graphql(`
   query AlertForm_ChannelsQuery($organizationSlug: String!, $projectSlug: String!) {
@@ -227,9 +228,19 @@ const RANGE_OPTIONS = [
   { value: '43200', label: '30d' },
 ] as const;
 
-const CONDITION_OPTIONS = [
+// Condition labels depend on threshold type. For a fixed value the metric is
+// compared against an absolute level ("Above"/"Below"). For a window-over-window
+// % change the rule fires on a rise or a fall, so "Increase"/"Decrease" reads
+// naturally and lets the user enter a positive magnitude (the sign is applied
+// for them in `applyThresholdSign`). The underlying values stay ABOVE/BELOW.
+const CONDITION_OPTIONS_FIXED = [
   { value: 'ABOVE', label: 'Above' },
   { value: 'BELOW', label: 'Below' },
+] as const;
+
+const CONDITION_OPTIONS_CHANGE = [
+  { value: 'ABOVE', label: 'Increase' },
+  { value: 'BELOW', label: 'Decrease' },
 ] as const;
 
 const THRESHOLD_TYPE_OPTIONS = [
@@ -247,26 +258,51 @@ const SEVERITIES = [
   { value: 'CRITICAL' as const, label: 'Critical', dotClass: 'bg-red-400' },
 ];
 
-export const AlertFormSchema = z.object({
-  metricSelection: z.string().min(1, 'Metric is required'),
-  timeWindowMinutes: z.string().min(1, 'Range is required'),
-  name: z.string().min(1, 'Name is required'),
-  severity: z.enum(['INFO', 'WARNING', 'CRITICAL']),
-  direction: z.string().min(1),
-  thresholdType: z.string().min(1),
-  thresholdValue: z.string().min(1, 'Value is required'),
-  savedFilterId: z.string().optional(),
-  confirmationMinutes: z.string().default('0'),
-  // Zero channels is intentionally allowed here so users can create a rule
-  // and observe its state transitions in the UI without firing notifications
-  // ("test mode"), then attach destinations once the rule's behavior is
-  // trusted.
-  channels: z.array(
-    z.object({
-      channelId: z.string().min(1, 'Select a channel'),
-    }),
-  ),
-});
+export const AlertFormSchema = z
+  .object({
+    metricSelection: z.string().min(1, 'Metric is required'),
+    timeWindowMinutes: z.string().min(1, 'Range is required'),
+    name: z.string().min(1, 'Name is required'),
+    severity: z.enum(['INFO', 'WARNING', 'CRITICAL']),
+    direction: z.string().min(1),
+    thresholdType: z.string().min(1),
+    thresholdValue: z.string().min(1, 'Value is required'),
+    savedFilterId: z.string().optional(),
+    confirmationMinutes: z.string().default('0'),
+    // Zero channels is intentionally allowed here so users can create a rule
+    // and observe its state transitions in the UI without firing notifications
+    // ("test mode"), then attach destinations once the rule's behavior is
+    // trusted.
+    channels: z.array(
+      z.object({
+        channelId: z.string().min(1, 'Select a channel'),
+      }),
+    ),
+  })
+  .superRefine((data, ctx) => {
+    const value = parseFloat(data.thresholdValue);
+    if (Number.isNaN(value)) {
+      return; // empty is already caught by `.min(1)`; non-numeric by the input
+    }
+    if (value < 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['thresholdValue'],
+        message: 'Value must be 0 or greater',
+      });
+    }
+    const { type } = parseMetricSelection(data.metricSelection);
+    const capAt100 =
+      (data.thresholdType === 'FIXED_VALUE' && type === MetricAlertRuleType.ErrorRate) ||
+      (data.thresholdType === 'PERCENTAGE_CHANGE' && data.direction === 'BELOW');
+    if (capAt100 && value > 100) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['thresholdValue'],
+        message: 'Value cannot exceed 100%',
+      });
+    }
+  });
 
 export type AlertFormValues = z.infer<typeof AlertFormSchema>;
 
@@ -359,7 +395,7 @@ export function ruleToFormDefaults(rule: AlertFormRuleSeed): AlertFormValues {
     severity: severityKey,
     direction: String(rule.direction).toUpperCase(),
     thresholdType: String(rule.thresholdType).toUpperCase(),
-    thresholdValue: String(rule.thresholdValue),
+    thresholdValue: String(Math.abs(rule.thresholdValue)),
     savedFilterId: rule.savedFilter?.id ?? '',
     confirmationMinutes: String(rule.confirmationMinutes),
     channels: rule.channels.map(c => ({ channelId: c.id })),
@@ -433,7 +469,11 @@ export function AlertForm(props: AlertFormProps) {
               metric: metric ?? null,
               timeWindowMinutes: parseInt(values.timeWindowMinutes, 10),
               thresholdType: THRESHOLD_TYPE_MAP[values.thresholdType],
-              thresholdValue: parseFloat(values.thresholdValue),
+              thresholdValue: applyThresholdSign(
+                parseFloat(values.thresholdValue),
+                values.thresholdType,
+                values.direction,
+              ),
               direction: DIRECTION_MAP[values.direction],
               severity: SEVERITY_MAP[values.severity],
               confirmationMinutes: parseInt(values.confirmationMinutes || '0', 10),
@@ -520,6 +560,22 @@ export function AlertForm(props: AlertFormProps) {
   const parsedMetric = watchedValues.metricSelection
     ? parseMetricSelection(watchedValues.metricSelection)
     : { type: MetricAlertRuleType.Traffic };
+
+  const isPercentageChange = watchedValues.thresholdType === 'PERCENTAGE_CHANGE';
+  const valueUnit = thresholdUnit(parsedMetric.type, watchedValues.thresholdType);
+  const conditionOptions = isPercentageChange ? CONDITION_OPTIONS_CHANGE : CONDITION_OPTIONS_FIXED;
+  const valueMax =
+    (!isPercentageChange && parsedMetric.type === MetricAlertRuleType.ErrorRate) ||
+    (isPercentageChange && watchedValues.direction === 'BELOW')
+      ? 100
+      : undefined;
+  const valuePlaceholder = isPercentageChange
+    ? 'e.g. 25'
+    : parsedMetric.type === MetricAlertRuleType.Latency
+      ? 'e.g. 500'
+      : parsedMetric.type === MetricAlertRuleType.ErrorRate
+        ? 'e.g. 5'
+        : 'e.g. 1000';
 
   const previewWindowMinutes = Math.min(
     (parseInt(watchedValues.timeWindowMinutes, 10) || 10_080) * 2,
@@ -735,7 +791,7 @@ export function AlertForm(props: AlertFormProps) {
                           <FormLabel label="Condition" />
                           <FormControl>
                             <Select
-                              options={CONDITION_OPTIONS}
+                              options={conditionOptions}
                               value={field.value}
                               onValueChange={field.onChange}
                             />
@@ -766,9 +822,15 @@ export function AlertForm(props: AlertFormProps) {
                       name="thresholdValue"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel label="Value" />
+                          <FormLabel label={`Value (${valueUnit})`} />
                           <FormControl>
-                            <Input type="number" placeholder="Enter a value" {...field} />
+                            <Input
+                              type="number"
+                              min={0}
+                              max={valueMax}
+                              placeholder={valuePlaceholder}
+                              {...field}
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -776,8 +838,14 @@ export function AlertForm(props: AlertFormProps) {
                     />
                   </div>
                   <p className="text-neutral-10 text-[13px]">
-                    {watchedValues.thresholdType === 'PERCENTAGE_CHANGE'
-                      ? `"% change vs. previous" compares this ${thresholdRangeLabel} window to the one before it. Your value is the percent change between them, e.g. 75 fires on a +75% change rather than an absolute level.`
+                    {isPercentageChange
+                      ? `"% change vs. previous" compares this ${thresholdRangeLabel} window to the one before it. With "${
+                          watchedValues.direction === 'BELOW' ? 'Decrease' : 'Increase'
+                        }" it fires when the metric ${
+                          watchedValues.direction === 'BELOW' ? 'drops' : 'rises'
+                        } by more than your value, e.g. 75 fires on a ${
+                          watchedValues.direction === 'BELOW' ? '−75%' : '+75%'
+                        } change rather than an absolute level.`
                       : `"Fixed value" compares the metric over the ${thresholdRangeLabel} window directly against your value, in the metric's own unit (% for error rate, ms for latency, requests for total requests).`}
                   </p>
                 </div>

--- a/packages/web/app/src/components/target/alerts/alert-form.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-form.tsx
@@ -505,7 +505,11 @@ export function AlertForm(props: AlertFormProps) {
             metric: metric ?? null,
             timeWindowMinutes: parseInt(values.timeWindowMinutes, 10),
             thresholdType: THRESHOLD_TYPE_MAP[values.thresholdType],
-            thresholdValue: parseFloat(values.thresholdValue),
+            thresholdValue: applyThresholdSign(
+              parseFloat(values.thresholdValue),
+              values.thresholdType,
+              values.direction,
+            ),
             direction: DIRECTION_MAP[values.direction],
             severity: SEVERITY_MAP[values.severity],
             confirmationMinutes: parseInt(values.confirmationMinutes || '0', 10),

--- a/packages/web/app/src/components/target/alerts/alert-form.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-form.tsx
@@ -745,7 +745,7 @@ export function AlertForm(props: AlertFormProps) {
                     <FormItem>
                       <FormLabel label="Alert name" />
                       <FormControl>
-                        <Input placeholder="Some cool alert name" {...field} />
+                        <Input placeholder="Enter alert name" {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/packages/web/app/src/components/target/alerts/alert-form.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-form.tsx
@@ -845,7 +845,7 @@ export function AlertForm(props: AlertFormProps) {
                   <p className="text-neutral-10 text-[13px]">
                     {isPercentageChange
                       ? `"% change vs. previous" compares this ${thresholdRangeLabel} window to the one before it. With "${
-                          watchedValues.direction === 'BELOW' ? 'Decrease' : 'Increase'
+                          watchedValues.direction === 'BELOW' ? 'a Decrease' : 'an Increase'
                         }" it fires when the metric ${
                           watchedValues.direction === 'BELOW' ? 'drops' : 'rises'
                         } by more than your value, e.g. 75 fires on a ${

--- a/packages/web/app/src/components/target/alerts/alert-metric-chart.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-metric-chart.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import * as echarts from 'echarts';
+import type { MarkAreaComponentOption, MarkLineComponentOption } from 'echarts';
 import ReactECharts from 'echarts-for-react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { FragmentType, graphql, useFragment } from '@/gql';
@@ -8,6 +9,7 @@ import { formatDuration } from '@/lib/hooks/use-formatted-duration';
 import { formatNumber } from '@/lib/hooks/use-formatted-number';
 import { useChartStyles } from '@/lib/utils';
 import { ALERT_CHART_INSET_LEFT, ALERT_CHART_INSET_RIGHT } from './alert-chart-layout';
+import { applyThresholdSign, windowAggregates } from './alert-threshold';
 
 export const AlertMetricChart_OperationsStatsFragment = graphql(`
   fragment AlertMetricChart_OperationsStatsFragment on OperationsStats {
@@ -42,12 +44,21 @@ type AlertMetricChartProps = {
   metric?: MetricAlertRuleMetric | null;
   /** Rule severity...tints the threshold marker line to match the severity badge. */
   severity?: string | null;
-  /** Threshold value to show as a horizontal marker line (only drawn for FIXED_VALUE rules) */
+  /**
+   * Threshold magnitude (always >= 0; the form edits a magnitude). For
+   * FIXED_VALUE it's the level drawn as a horizontal marker line; for
+   * PERCENTAGE_CHANGE it's the % the window-over-window delta is compared to.
+   */
   thresholdValue: number | null;
   /** 'ABOVE' or 'BELOW' */
   direction: string;
   /** 'FIXED_VALUE' or 'PERCENTAGE_CHANGE' */
   thresholdType: string;
+  /**
+   * The rule's evaluation window in minutes. Used to split the fetched span
+   * (~2 windows) into the previous | current windows the evaluator compares.
+   */
+  timeWindowMinutes: number;
 };
 
 // Maps the GraphQL enum to the lowercase field names on DurationValues
@@ -70,6 +81,13 @@ const SEVERITY_COLOR_KEY: Record<string, 'critical' | 'warning' | 'info'> = {
   INFO: 'info',
 };
 
+// The preview fetch span is capped at 30 days (see `previewWindowMinutes` in
+// alert-form.tsx), so for windows longer than 15 days the "previous" window
+// falls outside the fetched data and can't be drawn or compared.
+const PREVIEW_SPAN_CAP_MINUTES = 43_200;
+
+const MS_PER_MINUTE = 60_000;
+
 export function AlertMetricChart({
   stats,
   loading,
@@ -79,6 +97,7 @@ export function AlertMetricChart({
   thresholdValue,
   direction,
   thresholdType,
+  timeWindowMinutes,
 }: AlertMetricChartProps) {
   const { colors } = useChartStyles();
 
@@ -141,31 +160,139 @@ export function AlertMetricChart({
   const severityColorKey = severity ? SEVERITY_COLOR_KEY[severity] : undefined;
   const markColor = severityColorKey ? colors[severityColorKey] : colors.primary;
 
-  const markLine =
-    thresholdValue != null && thresholdType === 'FIXED_VALUE'
-      ? {
-          symbol: 'none',
-          silent: true,
-          data: [
-            {
-              yAxis: thresholdValue,
-              label: {
-                formatter: `${direction === 'ABOVE' ? '>' : '<'} ${yAxisFormatter(thresholdValue)}`,
-                position: 'insideEndTop' as const,
-                color: markColor,
-                fontSize: 11,
-              },
-            },
-          ],
-          lineStyle: {
-            color: markColor,
-            type: 'dashed' as const,
-            width: 1,
-          },
-        }
-      : undefined;
+  const isPercentageChange = thresholdType === 'PERCENTAGE_CHANGE';
+  // Callers pass the stored value, which is signed for a % decrease (e.g. -50).
+  // The chart only needs its magnitude — for the fixed-value level and to
+  // rebuild the signed comparison consistently — so normalize once here.
+  const thresholdMagnitude = thresholdValue != null ? Math.abs(thresholdValue) : null;
 
-  const range = new Date(data[data.length - 1][0]).getTime() - new Date(data[0][0]).getTime();
+  const firstMs = new Date(data[0][0]).getTime();
+  const lastMs = new Date(data[data.length - 1][0]).getTime();
+  // The current window is the most recent `timeWindowMinutes` of the fetched
+  // span; the previous window is the slice before it. Mirrors the evaluator's
+  // split (its 1-minute offset is immaterial for an illustrative preview).
+  const boundaryMs = lastMs - timeWindowMinutes * MS_PER_MINUTE;
+  // The previous window is only present when the fetched span covers two full
+  // windows (the form caps it at 30 days) and the boundary lands in the data.
+  const hasPreviousWindow =
+    timeWindowMinutes > 0 &&
+    timeWindowMinutes * 2 <= PREVIEW_SPAN_CAP_MINUTES &&
+    boundaryMs > firstMs;
+
+  const { current: currentAgg, previous: previousAgg } = windowAggregates(
+    type,
+    latencyPercentile,
+    requestsOverTime,
+    failuresOverTime,
+    durationOverTime,
+    boundaryMs,
+  );
+
+  // Aggregates come from averaging / ratio math, so they can be long floats
+  // (e.g. a 433.3333…ms mean). `formatDuration` only rounds values >= 1s, so
+  // round before formatting: whole ms for latency, one decimal for the
+  // error-rate %. Counts pass straight through `formatNumber`.
+  const formatAggregate = (value: number) =>
+    yAxisFormatter(
+      isLatency ? Math.round(value) : isErrorRate ? Math.round(value * 10) / 10 : value,
+    );
+
+  // The window-over-window % change the rule evaluates. Null when there's no
+  // previous baseline (a 0 -> n jump is an infinite change we don't plot).
+  const deltaPercent =
+    hasPreviousWindow && previousAgg !== 0
+      ? ((currentAgg - previousAgg) / previousAgg) * 100
+      : null;
+
+  const signedThreshold =
+    thresholdMagnitude != null
+      ? applyThresholdSign(thresholdMagnitude, thresholdType, direction)
+      : null;
+  const deltaBreaches =
+    isPercentageChange && deltaPercent != null && signedThreshold != null
+      ? direction === 'ABOVE'
+        ? deltaPercent > signedThreshold
+        : deltaPercent < signedThreshold
+      : false;
+
+  const showWindowSplit = isPercentageChange && hasPreviousWindow;
+  const displayData =
+    isPercentageChange || timeWindowMinutes <= 0 || boundaryMs <= firstMs
+      ? data
+      : data.filter(([date]) => new Date(date).getTime() >= boundaryMs);
+
+  const markLineData: NonNullable<MarkLineComponentOption['data']> = [];
+
+  // Dotted divider + faint shade on the previous window so the current window
+  // reads as the focus (% change only).
+  if (showWindowSplit) {
+    markLineData.push({
+      xAxis: boundaryMs,
+      lineStyle: { color: colors.gridSubtle, type: 'dotted', width: 1 },
+      label: { show: false },
+    });
+  }
+  const markArea: MarkAreaComponentOption | undefined = showWindowSplit
+    ? {
+        silent: true,
+        itemStyle: { color: colors.gridSubtle, opacity: 0.18 },
+        data: [[{ xAxis: firstMs }, { xAxis: boundaryMs }]],
+      }
+    : undefined;
+
+  if (!isPercentageChange && thresholdMagnitude != null) {
+    markLineData.push(
+      // Threshold level (dashed, severity-tinted)...
+      {
+        yAxis: thresholdMagnitude,
+        label: {
+          formatter: `${direction === 'ABOVE' ? '>' : '<'} ${yAxisFormatter(thresholdMagnitude)}`,
+          position: 'insideEndTop',
+          color: markColor,
+          fontSize: 11,
+        },
+        lineStyle: { color: markColor, type: 'dashed', width: 1 },
+      },
+      // ...and the current-window aggregate the rule actually compares to it, so
+      // the user sees the evaluated number rather than only the per-bucket line.
+      {
+        yAxis: currentAgg,
+        label: {
+          formatter: `current ${formatAggregate(currentAgg)}`,
+          position: 'insideEndBottom',
+          color: colors.primary,
+          fontSize: 11,
+        },
+        lineStyle: { color: colors.primary, type: 'solid', width: 1 },
+      },
+    );
+  }
+
+  if (isPercentageChange && hasPreviousWindow) {
+    // Each window's aggregate as a short horizontal segment, so the comparison
+    // the rule makes (previous level vs current level) is visible. Tinted by
+    // severity when the delta breaches the threshold.
+    const segColor = deltaBreaches ? markColor : colors.primary;
+    const segLine = { color: segColor, type: 'solid' as const, width: 2 };
+    markLineData.push(
+      [
+        { coord: [firstMs, previousAgg], symbol: 'none', lineStyle: segLine },
+        { coord: [boundaryMs, previousAgg], symbol: 'none' },
+      ],
+      [
+        { coord: [boundaryMs, currentAgg], symbol: 'none', lineStyle: segLine },
+        { coord: [lastMs, currentAgg], symbol: 'none' },
+      ],
+    );
+  }
+
+  const markLine: MarkLineComponentOption | undefined = markLineData.length
+    ? { symbol: 'none', silent: true, data: markLineData }
+    : undefined;
+
+  const range =
+    new Date(displayData[displayData.length - 1][0]).getTime() -
+    new Date(displayData[0][0]).getTime();
   const dayMs = 24 * 60 * 60 * 1000;
 
   const timeFormatter = new Intl.DateTimeFormat(
@@ -175,7 +302,7 @@ export function AlertMetricChart({
 
   const axisLabel = { fontSize: 11, color: colors.axisLabel };
 
-  return (
+  const chart = (
     <AutoSizer disableHeight>
       {size => (
         <ReactECharts
@@ -251,13 +378,43 @@ export function AlertMetricChart({
                 },
                 emphasis: { disabled: true },
                 large: true,
-                data,
+                data: displayData,
                 markLine,
+                markArea,
               },
             ],
           }}
         />
       )}
     </AutoSizer>
+  );
+
+  if (!isPercentageChange) {
+    return chart;
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="text-neutral-10 flex flex-wrap items-center gap-x-2 text-[13px]">
+        {hasPreviousWindow ? (
+          <>
+            <span>
+              Previous {seriesName.toLowerCase()}: {formatAggregate(previousAgg)}
+            </span>
+            <span>→ current: {formatAggregate(currentAgg)}</span>
+            <span className="font-medium" style={deltaBreaches ? { color: markColor } : undefined}>
+              Δ{' '}
+              {deltaPercent == null
+                ? '—'
+                : `${deltaPercent >= 0 ? '+' : ''}${deltaPercent.toFixed(1)}%`}
+            </span>
+            {isLatency ? <span className="italic">(latency Δ is approximate)</span> : null}
+          </>
+        ) : (
+          <span className="italic">No previous window in this range to compare.</span>
+        )}
+      </div>
+      {chart}
+    </div>
   );
 }

--- a/packages/web/app/src/components/target/alerts/alert-notification-preview.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-notification-preview.tsx
@@ -7,6 +7,7 @@
 import { Copy } from 'lucide-react';
 import { Button } from '@/components/base/button/button';
 import { useClipboard } from '@/lib/hooks/use-clipboard';
+import { applyThresholdSign, thresholdUnit } from './alert-threshold';
 
 const WEBHOOK_JSON_SCHEMA = {
   $schema: 'http://json-schema.org/draft-07/schema#',
@@ -91,16 +92,11 @@ function formatThreshold(
   const dir = direction === 'ABOVE' ? 'above' : 'below';
   // Mirror the unit logic in formatChangeText() in
   // packages/services/workflows/src/lib/metric-alert-notifier.ts so the preview
-  // matches the real notification. A PERCENTAGE_CHANGE threshold is always a
-  // percent, regardless of the underlying metric.
-  const unit =
-    thresholdType === 'PERCENTAGE_CHANGE'
-      ? '%'
-      : alertType === 'LATENCY'
-        ? 'ms'
-        : alertType === 'ERROR_RATE'
-          ? '%'
-          : ' requests';
+  // matches the real notification. The shared `thresholdUnit` keeps this in
+  // sync with the form's Value label; "requests" carries a leading space so it
+  // reads "150 requests" rather than "150requests".
+  const unitToken = thresholdUnit(alertType, thresholdType);
+  const unit = unitToken === 'requests' ? ' requests' : unitToken;
   return thresholdType === 'PERCENTAGE_CHANGE'
     ? `${direction === 'ABOVE' ? 'increased' : 'decreased'} by ${val}${unit}`
     : `${dir} ${val}${unit}`;
@@ -183,7 +179,11 @@ export function buildPreviewWebhookPayload(props: PreviewProps) {
     changePercent: null,
     threshold: {
       type: props.thresholdType || 'FIXED_VALUE',
-      value: props.thresholdValue ? parseFloat(props.thresholdValue) : 0,
+      // The form edits a non-negative magnitude; the stored/real payload value
+      // is signed (a % drop is negative), so sign it here to match the notifier.
+      value: props.thresholdValue
+        ? applyThresholdSign(parseFloat(props.thresholdValue), props.thresholdType, props.direction)
+        : 0,
       direction: props.direction || 'ABOVE',
     },
     target: { slug: props.targetSlug },

--- a/packages/web/app/src/components/target/alerts/alert-threshold.spec.ts
+++ b/packages/web/app/src/components/target/alerts/alert-threshold.spec.ts
@@ -1,4 +1,4 @@
-import { applyThresholdSign, thresholdUnit } from './alert-threshold';
+import { applyThresholdSign, thresholdUnit, windowAggregates } from './alert-threshold';
 
 describe('thresholdUnit', () => {
   it('is always % for a percentage change, regardless of metric', () => {
@@ -32,5 +32,65 @@ describe('applyThresholdSign', () => {
     const magnitude = 75;
     const signed = applyThresholdSign(magnitude, 'PERCENTAGE_CHANGE', 'BELOW');
     expect(Math.abs(signed)).toBe(magnitude);
+  });
+});
+
+describe('windowAggregates', () => {
+  // Boundary at t=100; buckets at 100+ are "current", before are "previous".
+  const boundaryMs = new Date('2026-06-15T01:00:00.000Z').getTime();
+  const prev = '2026-06-15T00:30:00.000Z'; // before boundary
+  const curr = '2026-06-15T01:30:00.000Z'; // at/after boundary
+
+  const requests = [
+    { date: prev, value: 100 },
+    { date: prev, value: 100 },
+    { date: curr, value: 200 },
+    { date: curr, value: 300 },
+  ];
+  const failures = [
+    { date: prev, value: 10 },
+    { date: prev, value: 30 },
+    { date: curr, value: 5 },
+    { date: curr, value: 15 },
+  ];
+  const noDuration: never[] = [];
+
+  it('sums requests per window for TRAFFIC', () => {
+    const { current, previous } = windowAggregates(
+      'TRAFFIC',
+      null,
+      requests,
+      failures,
+      noDuration,
+      boundaryMs,
+    );
+    expect(previous).toBe(200); // 100 + 100
+    expect(current).toBe(500); // 200 + 300
+  });
+
+  it('uses ratio-of-sums (not mean of per-bucket rates) for ERROR_RATE', () => {
+    const { current, previous } = windowAggregates(
+      'ERROR_RATE',
+      null,
+      requests,
+      failures,
+      noDuration,
+      boundaryMs,
+    );
+    // previous: (10 + 30) / (100 + 100) = 20%, NOT the mean of 10% and 30%.
+    expect(previous).toBe(20);
+    // current: (5 + 15) / (200 + 300) = 4%
+    expect(current).toBe(4);
+  });
+
+  it('averages bucket percentiles per window for LATENCY (approximation)', () => {
+    const durations = [
+      { date: prev, duration: { avg: 0, p75: 0, p90: 0, p95: 100, p99: 0 } },
+      { date: prev, duration: { avg: 0, p75: 0, p90: 0, p95: 300, p99: 0 } },
+      { date: curr, duration: { avg: 0, p75: 0, p90: 0, p95: 800, p99: 0 } },
+    ];
+    const { current, previous } = windowAggregates('LATENCY', 'p95', [], [], durations, boundaryMs);
+    expect(previous).toBe(200); // mean(100, 300)
+    expect(current).toBe(800); // mean(800)
   });
 });

--- a/packages/web/app/src/components/target/alerts/alert-threshold.spec.ts
+++ b/packages/web/app/src/components/target/alerts/alert-threshold.spec.ts
@@ -1,0 +1,36 @@
+import { applyThresholdSign, thresholdUnit } from './alert-threshold';
+
+describe('thresholdUnit', () => {
+  it('is always % for a percentage change, regardless of metric', () => {
+    expect(thresholdUnit('LATENCY', 'PERCENTAGE_CHANGE')).toBe('%');
+    expect(thresholdUnit('TRAFFIC', 'PERCENTAGE_CHANGE')).toBe('%');
+    expect(thresholdUnit('ERROR_RATE', 'PERCENTAGE_CHANGE')).toBe('%');
+  });
+
+  it('uses the metric unit for a fixed value', () => {
+    expect(thresholdUnit('LATENCY', 'FIXED_VALUE')).toBe('ms');
+    expect(thresholdUnit('ERROR_RATE', 'FIXED_VALUE')).toBe('%');
+    expect(thresholdUnit('TRAFFIC', 'FIXED_VALUE')).toBe('requests');
+  });
+});
+
+describe('applyThresholdSign', () => {
+  it('negates only a percentage-change decrease (Below)', () => {
+    expect(applyThresholdSign(50, 'PERCENTAGE_CHANGE', 'BELOW')).toBe(-50);
+  });
+
+  it('leaves a percentage-change increase (Above) positive', () => {
+    expect(applyThresholdSign(50, 'PERCENTAGE_CHANGE', 'ABOVE')).toBe(50);
+  });
+
+  it('never negates a fixed value, even Below', () => {
+    expect(applyThresholdSign(100, 'FIXED_VALUE', 'BELOW')).toBe(100);
+    expect(applyThresholdSign(100, 'FIXED_VALUE', 'ABOVE')).toBe(100);
+  });
+
+  it('round-trips magnitude -> signed -> magnitude via Math.abs', () => {
+    const magnitude = 75;
+    const signed = applyThresholdSign(magnitude, 'PERCENTAGE_CHANGE', 'BELOW');
+    expect(Math.abs(signed)).toBe(magnitude);
+  });
+});

--- a/packages/web/app/src/components/target/alerts/alert-threshold.ts
+++ b/packages/web/app/src/components/target/alerts/alert-threshold.ts
@@ -84,7 +84,7 @@ export function windowAggregates(
     let req = 0;
     let fail = 0;
     for (const [i, n] of requests.entries()) {
-      if ((new Date(n.date).getTime() >= boundaryMs) === isCurrent) {
+      if (new Date(n.date).getTime() >= boundaryMs === isCurrent) {
         req += n.value;
         fail += failures[i]?.value ?? 0;
       }

--- a/packages/web/app/src/components/target/alerts/alert-threshold.ts
+++ b/packages/web/app/src/components/target/alerts/alert-threshold.ts
@@ -44,3 +44,55 @@ export function applyThresholdSign(
 ): number {
   return thresholdType === 'PERCENTAGE_CHANGE' && direction === 'BELOW' ? -magnitude : magnitude;
 }
+
+function mean(values: number[]): number {
+  return values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+}
+
+type OverTime = ReadonlyArray<{ date: string; value: number }>;
+type DurationOverTime = ReadonlyArray<{
+  date: string;
+  duration: { avg: number; p75: number; p90: number; p95: number; p99: number };
+}>;
+
+/**
+ * Reduces each window to the single aggregate the evaluator compares...summed
+ * requests for TRAFFIC, ratio-of-sums for ERROR_RATE. LATENCY percentiles can't
+ * be re-merged from per-bucket percentiles without the t-digest states, so this
+ * approximates with the mean of the window's bucket percentiles (the chart
+ * flags it as approximate).
+ *
+ * A bucket belongs to the current window when its timestamp is at/after
+ * `boundaryMs`, mirroring the evaluator's window split.
+ */
+export function windowAggregates(
+  metricType: string,
+  latencyKey: 'avg' | 'p75' | 'p90' | 'p95' | 'p99' | null,
+  requests: OverTime,
+  failures: OverTime,
+  durations: DurationOverTime,
+  boundaryMs: number,
+): { current: number; previous: number } {
+  const reduce = (isCurrent: boolean): number => {
+    if (metricType === 'LATENCY' && latencyKey) {
+      return mean(
+        durations
+          .filter(n => new Date(n.date).getTime() >= boundaryMs === isCurrent)
+          .map(n => n.duration[latencyKey]),
+      );
+    }
+    let req = 0;
+    let fail = 0;
+    for (const [i, n] of requests.entries()) {
+      if ((new Date(n.date).getTime() >= boundaryMs) === isCurrent) {
+        req += n.value;
+        fail += failures[i]?.value ?? 0;
+      }
+    }
+    if (metricType === 'ERROR_RATE') {
+      return req > 0 ? (fail / req) * 100 : 0;
+    }
+    return req; // TRAFFIC
+  };
+  return { current: reduce(true), previous: reduce(false) };
+}

--- a/packages/web/app/src/components/target/alerts/alert-threshold.ts
+++ b/packages/web/app/src/components/target/alerts/alert-threshold.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared threshold helpers for metric-alert rules, used by the create/edit
+ * form, the notification preview, and the conditions panel so the unit and
+ * sign conventions can't drift between them.
+ */
+
+/**
+ * The display unit for a rule's threshold value. A PERCENTAGE_CHANGE threshold
+ * is always a percent regardless of the underlying metric; a FIXED_VALUE
+ * carries the metric's own unit (ms for latency, % for error rate, requests
+ * for traffic). Mirrors the per-type units in the evaluator / notifier.
+ *
+ * Accepts the raw enum string ('LATENCY' | 'ERROR_RATE' | 'TRAFFIC',
+ * 'FIXED_VALUE' | 'PERCENTAGE_CHANGE') so callers can pass either the GraphQL
+ * enum value or the form's Select value without converting.
+ */
+export function thresholdUnit(metricType: string, thresholdType: string): 'ms' | '%' | 'requests' {
+  if (thresholdType === 'PERCENTAGE_CHANGE') {
+    return '%';
+  }
+  switch (metricType) {
+    case 'LATENCY':
+      return 'ms';
+    case 'ERROR_RATE':
+      return '%';
+    default:
+      return 'requests'; // TRAFFIC
+  }
+}
+
+/**
+ * The form presents % change as a non-negative magnitude plus an
+ * Increase/Decrease direction. The evaluator, however, compares a *signed*
+ * percentage...a 50% drop is -50 (see `isThresholdBreached` in
+ * packages/services/workflows/src/lib/metric-alert-evaluator.ts). Convert a UI
+ * magnitude to the signed value the backend stores: only PERCENTAGE_CHANGE +
+ * BELOW (a "decrease") is negated. FIXED_VALUE values are always non-negative
+ * and pass through unchanged.
+ */
+export function applyThresholdSign(
+  magnitude: number,
+  thresholdType: string,
+  direction: string,
+): number {
+  return thresholdType === 'PERCENTAGE_CHANGE' && direction === 'BELOW' ? -magnitude : magnitude;
+}

--- a/packages/web/app/src/pages/target-alerts-detail.tsx
+++ b/packages/web/app/src/pages/target-alerts-detail.tsx
@@ -368,6 +368,7 @@ function RuleStateLogSection(props: {
           thresholdValue={rule.thresholdValue}
           direction={rule.direction}
           thresholdType={rule.thresholdType}
+          timeWindowMinutes={rule.timeWindowMinutes}
         />
       </section>
 


### PR DESCRIPTION
This PR improves the usability of the condition/threshold/value section of the create alert form by ensuring that the section displays appropriately for each metric type.

https://github.com/user-attachments/assets/b0f89956-fbf5-4298-bee8-50d6932520f9


