### PR TITLE
fix: bump laboratory bundled graphql to ^16.14.0

### DIFF
--- a/.changeset/tall-vans-battle.md
+++ b/.changeset/tall-vans-battle.md
@@ -1,0 +1,9 @@
+---
+'@graphql-hive/render-laboratory': patch
+---
+
+Bump bundled `graphql` from `^16.12.0` to `^16.14.0` to fix "Unexpected invariant triggered" error
+in the schema explorer when introspecting servers running graphql-js 16.14+. graphql-js 16.14.0
+added `DIRECTIVE_DEFINITION` to the `@deprecated` directive's introspection locations; the
+previously bundled 16.12.0 did not recognise this enum value, making the Laboratory unusable against
+any such server.


### PR DESCRIPTION
Bump bundled `graphql` from `^16.12.0` to `^16.14.0` to fix "Unexpected invariant triggered" error in the schema explorer when introspecting servers running graphql-js 16.14+. graphql-js 16.14.0 added `DIRECTIVE_DEFINITION` to the `@deprecated` directive's introspection locations; the previously bundled 16.12.0 did not recognise this enum value, making the Laboratory unusable against any such server.

<!--
Before Contributing, please review the contribution guide:
https://the-guild.dev/graphql/hive/docs/schema-registry/contributing
--->

### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for developing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
