### PR TITLE
fix(cli): print schema delete changes and errors. Do not require confirm on dry run

### DIFF
--- a/.changeset/crazy-rules-bake.md
+++ b/.changeset/crazy-rules-bake.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+Print schema delete changes and errors. Do not require confirm on dry run deletes.

--- a/integration-tests/tests/models/federation-delete.spec.ts
+++ b/integration-tests/tests/models/federation-delete.spec.ts
@@ -44,7 +44,7 @@ describe('delete', () => {
         expect: 'latest-composable',
       });
 
-      expect(message).toMatch('reviews deleted');
+      expect(message).toContain('Deleted "reviews" from target');
     });
 
     test.concurrent('rejected: unknown service', async () => {

--- a/integration-tests/tests/models/federation-native-forceLegacyCompositionInTargets.spec.ts
+++ b/integration-tests/tests/models/federation-native-forceLegacyCompositionInTargets.spec.ts
@@ -590,7 +590,7 @@ describe('delete', () => {
         expect: 'latest-composable',
       });
 
-      expect(message).toMatch('reviews deleted');
+      expect(message).toMatch('Deleted "reviews" from target');
     });
 
     test.concurrent('rejected: unknown service', async () => {

--- a/integration-tests/tests/models/stitching.spec.ts
+++ b/integration-tests/tests/models/stitching.spec.ts
@@ -582,7 +582,7 @@ describe('delete', () => {
       expect: 'latest-composable',
     });
 
-    expect(message).toMatch('reviews deleted');
+    expect(message).toMatch('Deleted "reviews" from target');
   });
 
   test.concurrent('rejected: unknown service', async () => {

--- a/packages/libraries/cli/src/commands/schema/delete.ts
+++ b/packages/libraries/cli/src/commands/schema/delete.ts
@@ -162,10 +162,16 @@ export default class SchemaDelete extends Command<typeof SchemaDelete> {
         this.log('');
 
         if (result.schemaDelete.valid) {
-          this.logSuccess(`${service} ${flags.dryRun ? 'can be' : ''}deleted`);
+          this.logSuccess(
+            flags.dryRun
+              ? `Deleting "${service}" will produce a composable graph. But be sure to review changes to ensure this is safe.`
+              : `Deleted "${service}" from target`,
+          );
         } else {
           this.logWarning(
-            `${service} deletion ${flags.dryRun ? 'will result in' : 'created'} an uncomposable graph.`,
+            flags.dryRun
+              ? `Your graph will NOT be composable if "${service}" is deleted.`
+              : `Deleting "${service}" produced an uncomposable graph.`,
           );
         }
 

--- a/packages/libraries/cli/src/commands/schema/delete.ts
+++ b/packages/libraries/cli/src/commands/schema/delete.ts
@@ -1,6 +1,6 @@
 import { Args, Errors, Flags, ux } from '@oclif/core';
 import Command from '../../base-command';
-import { graphql } from '../../gql';
+import { graphql, useFragment } from '../../gql';
 import * as GraphQLSchema from '../../gql/graphql';
 import { graphqlEndpoint } from '../../helpers/config';
 import {
@@ -10,7 +10,12 @@ import {
   MissingRegistryTokenError,
   UnexpectedError,
 } from '../../helpers/errors';
-import { renderChanges, renderErrors } from '../../helpers/schema';
+import {
+  renderChanges,
+  RenderChanges_SchemaChanges,
+  renderErrors,
+  RenderErrors_SchemaErrorConnectionFragment,
+} from '../../helpers/schema';
 import * as TargetInput from '../../helpers/target-input';
 
 const schemaDeleteMutation = graphql(/* GraphQL */ `
@@ -153,11 +158,20 @@ export default class SchemaDelete extends Command<typeof SchemaDelete> {
 
       if (result.schemaDelete.__typename === 'SchemaDeleteSuccess') {
         const { errors, changes } = result.schemaDelete;
-        this.log(renderErrors(errors));
+
+        if (errors) {
+          const unmaskedErrors = useFragment(RenderErrors_SchemaErrorConnectionFragment, errors);
+          if (unmaskedErrors.edges.length > 0) {
+            this.log(renderErrors(errors));
+          }
+        }
 
         if (changes) {
-          this.log('');
-          this.log(renderChanges(changes));
+          const unmaskedChanges = useFragment(RenderChanges_SchemaChanges, changes);
+          if (unmaskedChanges.edges.length > 0) {
+            this.log('');
+            this.log(renderChanges(changes));
+          }
         }
         this.log('');
 
@@ -179,7 +193,7 @@ export default class SchemaDelete extends Command<typeof SchemaDelete> {
         return;
       }
 
-      this.logFailure(`Failed to delete ${service}`);
+      this.logFailure(`Failed to delete "${service}"`);
       const errors = result.schemaDelete.errors;
 
       if (errors) {

--- a/packages/libraries/cli/src/commands/schema/delete.ts
+++ b/packages/libraries/cli/src/commands/schema/delete.ts
@@ -10,7 +10,7 @@ import {
   MissingRegistryTokenError,
   UnexpectedError,
 } from '../../helpers/errors';
-import { renderErrors } from '../../helpers/schema';
+import { renderChanges, renderErrors } from '../../helpers/schema';
 import * as TargetInput from '../../helpers/target-input';
 
 const schemaDeleteMutation = graphql(/* GraphQL */ `
@@ -19,6 +19,9 @@ const schemaDeleteMutation = graphql(/* GraphQL */ `
       __typename
       ... on SchemaDeleteSuccess {
         valid
+        changes {
+          ...RenderChanges_schemaChanges
+        }
         errors {
           ...RenderErrors_SchemaErrorConnectionFragment
         }
@@ -59,7 +62,8 @@ export default class SchemaDelete extends Command<typeof SchemaDelete> {
       },
     }),
     dryRun: Flags.boolean({
-      description: 'Does not delete the service, only reports what it would have done.',
+      description:
+        'Does not delete the service, only reports what it would have done. Skips confirmation prompt.',
       default: false,
     }),
     confirm: Flags.boolean({
@@ -89,7 +93,7 @@ export default class SchemaDelete extends Command<typeof SchemaDelete> {
 
       const service: string = args.service;
 
-      if (!flags.confirm) {
+      if (!flags.confirm && !flags.dryRun) {
         const confirmed = await ux.confirm(
           `Are you sure you want to delete "${service}" from the registry? (y/n)`,
         );
@@ -148,7 +152,23 @@ export default class SchemaDelete extends Command<typeof SchemaDelete> {
       });
 
       if (result.schemaDelete.__typename === 'SchemaDeleteSuccess') {
-        this.logSuccess(`${service} deleted`);
+        const { errors, changes } = result.schemaDelete;
+        this.log(renderErrors(errors));
+
+        if (changes) {
+          this.log('');
+          this.log(renderChanges(changes));
+        }
+        this.log('');
+
+        if (result.schemaDelete.valid) {
+          this.logSuccess(`${service} ${flags.dryRun ? 'can be' : ''}deleted`);
+        } else {
+          this.logWarning(
+            `${service} deletion ${flags.dryRun ? 'will result in' : 'created'} an uncomposable graph.`,
+          );
+        }
+
         this.exit(0);
         return;
       }

--- a/packages/libraries/cli/src/helpers/schema.ts
+++ b/packages/libraries/cli/src/helpers/schema.ts
@@ -42,7 +42,7 @@ export const renderErrors = (
   return t.state.value;
 };
 
-const RenderChanges_SchemaChanges = graphql(`
+export const RenderChanges_SchemaChanges = graphql(`
   fragment RenderChanges_schemaChanges on SchemaChangeConnection {
     edges {
       node {


### PR DESCRIPTION
### Background

Schema deletes using the CLI currently print a success if the schema is deleted, but do not inform the user about this change.

This behavior is the same for dry runs. The schema will appear safe to delete.

### Description

This change improves the schema:delete command by printing a report of the errors and changes that will result from this delete action.

By printing this even on dry runs, we give users all the information they need to determine if a schema delete is a safe action to take.

### Checklist

- [X] Error handling and logging