### PR TITLE
fil: lab e2e preflight to poll results, and wait before preflight act…

### DIFF
--- a/e2e/specs/laboratory-preflight.spec.ts
+++ b/e2e/specs/laboratory-preflight.spec.ts
@@ -84,9 +84,9 @@ test.describe('Preflight Script Modal', () => {
   test('logs show console/error information', async ({ page, laboratory }) => {
     await laboratory.setMonacoEditorContents('preflight-editor', script);
     await page.locator('[data-cy="run-preflight"]').click();
-    await expect(page.locator('[data-cy="console-output"]')).toContainText(
-      'log: Hello_world (1:1)',
-    );
+    await expect
+      .poll(() => page.locator('[data-cy="console-output"]').textContent())
+      .toContain('log: Hello_world (1:1)');
 
     await laboratory.setMonacoEditorContents(
       'preflight-editor',
@@ -94,9 +94,9 @@ test.describe('Preflight Script Modal', () => {
     );
 
     await page.locator('[data-cy="run-preflight"]').click();
-    await expect(page.locator('[data-cy="console-output"]')).toContainText(
-      'log: Hello_world (1:1)',
-    );
+    await expect
+      .poll(() => page.locator('[data-cy="console-output"]').textContent())
+      .toContain('log: Hello_world (1:1)');
     await expect(page.locator('[data-cy="console-output"]')).toContainText('info: 1');
     await expect(page.locator('[data-cy="console-output"]')).toContainText('warn: true');
     await expect(page.locator('[data-cy="console-output"]')).toContainText('error: Fatal');
@@ -107,9 +107,9 @@ test.describe('Preflight Script Modal', () => {
     await laboratory.setMonacoEditorContents('preflight-editor', script);
 
     await page.locator('[data-cy="run-preflight"]').click();
-    await expect(page.locator('[data-cy="console-output"]')).toContainText(
-      'log: Hello_world (1:1)',
-    );
+    await expect
+      .poll(() => page.locator('[data-cy="console-output"]').textContent())
+      .toContain('log: Hello_world (1:1)');
 
     await laboratory.setMonacoEditorContents(
       'preflight-editor',
@@ -122,9 +122,9 @@ test.describe('Preflight Script Modal', () => {
       (form as HTMLFormElement).requestSubmit();
     });
 
-    await expect(page.locator('[data-cy="console-output"]')).toContainText(
-      'log: Hello_world (1:1)',
-    );
+    await expect
+      .poll(() => page.locator('[data-cy="console-output"]').textContent())
+      .toContain('log: Hello_world (1:1)');
     await expect(page.locator('[data-cy="console-output"]')).toContainText('info: test-username');
   });
 
@@ -132,9 +132,9 @@ test.describe('Preflight Script Modal', () => {
     await laboratory.setMonacoEditorContents('preflight-editor', script);
 
     await page.locator('[data-cy="run-preflight"]').click();
-    await expect(page.locator('[data-cy="console-output"]')).toContainText(
-      'log: Hello_world (1:1)',
-    );
+    await expect
+      .poll(() => page.locator('[data-cy="console-output"]').textContent())
+      .toContain('log: Hello_world (1:1)');
 
     await laboratory.setMonacoEditorContents(
       'preflight-editor',
@@ -145,9 +145,9 @@ test.describe('Preflight Script Modal', () => {
     await page.locator('[data-cy="prompt"] input').fill('test-username');
     await page.locator('[data-cy="prompt-cancel"]').click();
 
-    await expect(page.locator('[data-cy="console-output"]')).toContainText(
-      'log: Hello_world (1:1)',
-    );
+    await expect
+      .poll(() => page.locator('[data-cy="console-output"]').textContent())
+      .toContain('log: Hello_world (1:1)');
     await expect(page.locator('[data-cy="console-output"]')).toContainText('info: null');
   });
 
@@ -167,9 +167,9 @@ test.describe('Preflight Script Modal', () => {
       'console.log(lab.CryptoJS.SHA256("test"))',
     );
     await page.locator('[data-cy="run-preflight"]').click();
-    await expect(page.locator('[data-cy="console-output"]')).toContainText(
-      'info: Using crypto-js version:',
-    );
+    await expect
+      .poll(() => page.locator('[data-cy="console-output"]').textContent())
+      .toContain('info: Using crypto-js version:');
     await expect(page.locator('[data-cy="console-output"]')).toContainText(
       'log: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
     );


### PR DESCRIPTION
Fix flacky Lab e2e preflight spec, to poll for results instead regular expect in order to await actual results of preflight script.

<!--
Before Contributing, please review the contribution guide:
https://the-guild.dev/graphql/hive/docs/schema-registry/contributing
--->

### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for developing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
