### PR TITLE
Add configuration for selecting specific dangerous change types to fail on

### DIFF
--- a/.changeset/ninety-apes-sneeze.md
+++ b/.changeset/ninety-apes-sneeze.md
@@ -1,0 +1,6 @@
+---
+'hive': minor
+---
+
+Introduce a new configuration option for selecting individual dangerous change types to consider breaking.
+This is useful because dangerous changes can be situational based on a team's accepted risk and deployment process.

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -1323,6 +1323,76 @@ export function updateTargetValidationSettings(
   });
 }
 
+export function updateTargetDangerousChangeClassification(
+  input: GraphQLSchema.UpdateTargetDangerousChangeClassificationInput,
+  access:
+    | {
+        token: string;
+      }
+    | {
+        authToken: string;
+      },
+) {
+  return execute({
+    document: graphql(`
+      mutation UpdateTargetDangerousChangeClassification(
+        $input: UpdateTargetDangerousChangeClassificationInput!
+      ) {
+        updateTargetDangerousChangeClassification(input: $input) {
+          ok {
+            target {
+              id
+            }
+          }
+          error {
+            message
+          }
+        }
+      }
+    `),
+    ...access,
+    variables: {
+      input,
+    },
+  });
+}
+
+export function updateTargetFailingDangerousChanges(
+  input: GraphQLSchema.UpdateTargetFailingDangerousChangesInput,
+  access:
+    | {
+        token: string;
+      }
+    | {
+        authToken: string;
+      },
+) {
+  return execute({
+    document: graphql(`
+      mutation UpdateTargetFailingDangerousChanges(
+        $input: UpdateTargetFailingDangerousChangesInput!
+      ) {
+        updateTargetFailingDangerousChanges(input: $input) {
+          ok {
+            target {
+              id
+              failAllDangerousChanges
+              failDangerousChangeTypes
+            }
+          }
+          error {
+            message
+          }
+        }
+      }
+    `),
+    ...access,
+    variables: {
+      input,
+    },
+  });
+}
+
 export function updateBaseSchema(input: UpdateBaseSchemaInput, token: string) {
   return execute({
     document: graphql(`

--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -54,6 +54,8 @@ import {
   updateBaseSchema,
   updateMemberRole,
   updateMetricAlertRule,
+  updateTargetDangerousChangeClassification,
+  updateTargetFailingDangerousChanges,
   updateTargetValidationSettings,
 } from './flow';
 import * as GraphQLSchema from './gql/graphql';
@@ -1128,6 +1130,54 @@ export function initSeed() {
                   ).then(r => r.expectNoGraphQLErrors());
 
                   return result.updateTargetConditionalBreakingChangeConfiguration;
+                },
+                async updateTargetDangerousChangeClassification({
+                  failDiffOnDangerousChange,
+                  target: ttarget = target,
+                }: Omit<GraphQLSchema.UpdateTargetDangerousChangeClassificationInput, 'target'> & {
+                  target?: TargetOverwrite;
+                }) {
+                  const result = await updateTargetDangerousChangeClassification(
+                    {
+                      failDiffOnDangerousChange: failDiffOnDangerousChange,
+                      target: {
+                        bySelector: {
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: ttarget.slug,
+                        },
+                      },
+                    },
+                    {
+                      token: ownerToken,
+                    },
+                  ).then(r => r.expectNoGraphQLErrors());
+                  return result.updateTargetDangerousChangeClassification;
+                },
+                async updateTargetFailingDangerousChanges({
+                  target: ttarget = target,
+                  all,
+                  failingTypes,
+                }: Omit<GraphQLSchema.UpdateTargetFailingDangerousChangesInput, 'target'> & {
+                  target?: TargetOverwrite;
+                }) {
+                  const result = await updateTargetFailingDangerousChanges(
+                    {
+                      all,
+                      failingTypes,
+                      target: {
+                        bySelector: {
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: ttarget.slug,
+                        },
+                      },
+                    },
+                    {
+                      token: ownerToken,
+                    },
+                  ).then(r => r.expectNoGraphQLErrors());
+                  return result.updateTargetFailingDangerousChanges;
                 },
                 async compareToPreviousVersion(version: string, ttarget: TargetOverwrite = target) {
                   return (

--- a/integration-tests/tests/cli/__snapshots__/schema.spec.ts.snap
+++ b/integration-tests/tests/cli/__snapshots__/schema.spec.ts.snap
@@ -713,3 +713,43 @@ stderr--------------------------------------------:
 stdout--------------------------------------------:
 __NONE__
 `;
+
+exports[`breaking changes can be upgraded to breaking changes > schemaPublish (initial) 1`] = `
+:::::::::::::::: CLI SUCCESS OUTPUT :::::::::::::::::
+
+stdout--------------------------------------------:
+✔ Published initial schema.
+ℹ Available at http://__URL__
+`;
+
+exports[`can update the service url and show it in comparison query > schemaPublish (initial) 1`] = `
+:::::::::::::::: CLI SUCCESS OUTPUT :::::::::::::::::
+
+stdout--------------------------------------------:
+✔ Published initial schema.
+ℹ Available at http://__URL__
+`;
+
+exports[`schema:check errors for dangerous changes when upgraded to breaking changes (fail all) > schemaPublish (initial) 1`] = `
+:::::::::::::::: CLI SUCCESS OUTPUT :::::::::::::::::
+
+stdout--------------------------------------------:
+✔ Published initial schema.
+ℹ Available at http://__URL__
+`;
+
+exports[`schema:check errors for dangerous changes when upgraded to breaking changes (fail specific change type) > schemaPublish (initial) 1`] = `
+:::::::::::::::: CLI SUCCESS OUTPUT :::::::::::::::::
+
+stdout--------------------------------------------:
+✔ Published initial schema.
+ℹ Available at http://__URL__
+`;
+
+exports[`schema:check passes for dangerous changes when upgraded to breaking changes, if type is not in the failing list > schemaPublish (initial) 1`] = `
+:::::::::::::::: CLI SUCCESS OUTPUT :::::::::::::::::
+
+stdout--------------------------------------------:
+✔ Published initial schema.
+ℹ Available at http://__URL__
+`;

--- a/integration-tests/tests/cli/schema.spec.ts
+++ b/integration-tests/tests/cli/schema.spec.ts
@@ -1348,3 +1348,249 @@ test.concurrent('schema:check works with federated subgraphs', async () => {
 
   await server.close();
 });
+
+test.concurrent(
+  'schema:check errors for dangerous changes when upgraded to breaking changes (fail all)',
+  async ({ expect }) => {
+    const { createOrg } = await initSeed().createOwner();
+    const { inviteAndJoinMember, createProject } = await createOrg();
+    await inviteAndJoinMember();
+    const {
+      createTargetAccessToken,
+      updateTargetFailingDangerousChanges,
+      updateTargetDangerousChangeClassification,
+      target,
+    } = await createProject(ProjectType.Single);
+    const { secret } = await createTargetAccessToken({});
+    const cli = createCLI({
+      readonly: secret,
+      readwrite: secret,
+    });
+
+    // enable: dangerous change -> breaking
+    await updateTargetDangerousChangeClassification({
+      failDiffOnDangerousChange: true,
+      target,
+    });
+    /** Explicitly specify failing dangerous type condition */
+    await updateTargetFailingDangerousChanges({
+      all: true,
+      failingTypes: [],
+      target,
+    });
+
+    const sdl = /* GraphQL */ `
+      type Query {
+        users: [User!]
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        email: String!
+      }
+
+      enum UserType {
+        CUSTOMER
+      }
+    `;
+
+    await expect(
+      cli.publish({
+        sdl,
+        commit: 'push1',
+        expect: 'latest-composable',
+      }),
+    ).resolves.toMatchSnapshot('schemaPublish (initial)');
+
+    // add an enum value
+    const sdl2 = /* GraphQL */ `
+      type Query {
+        users: [User!]
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        email: String!
+      }
+
+      enum UserType {
+        CUSTOMER
+        ADMIN
+      }
+    `;
+
+    const output = await cli.check({
+      sdl: sdl2,
+      expect: 'rejected',
+    });
+    /** remove colors */
+    const cleanOutput = output.replace(/\x1b\[[0-9;]*m/g, '');
+    expect(cleanOutput).toMatch(/Enum value ADMIN was added to enum UserType/);
+  },
+);
+
+test.concurrent(
+  'schema:check errors for dangerous changes when upgraded to breaking changes (fail specific change type)',
+  async ({ expect }) => {
+    const { createOrg } = await initSeed().createOwner();
+    const { inviteAndJoinMember, createProject } = await createOrg();
+    await inviteAndJoinMember();
+    const {
+      createTargetAccessToken,
+      updateTargetFailingDangerousChanges,
+      updateTargetDangerousChangeClassification,
+      target,
+    } = await createProject(ProjectType.Single);
+    const { secret } = await createTargetAccessToken({});
+    const cli = createCLI({
+      readonly: secret,
+      readwrite: secret,
+    });
+
+    // enable: dangerous change -> breaking
+    await updateTargetDangerousChangeClassification({
+      failDiffOnDangerousChange: true,
+      target,
+    });
+    /** Explicitly specify failing dangerous type condition */
+    await updateTargetFailingDangerousChanges({
+      all: false,
+      failingTypes: [GraphQLSchema.DangerousChangeType.EnumValueAdded],
+      target,
+    });
+
+    const sdl = /* GraphQL */ `
+      type Query {
+        users: [User!]
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        email: String!
+      }
+
+      enum UserType {
+        CUSTOMER
+      }
+    `;
+
+    await expect(
+      cli.publish({
+        sdl,
+        commit: 'push1',
+        expect: 'latest-composable',
+      }),
+    ).resolves.toMatchSnapshot('schemaPublish (initial)');
+
+    // add an enum value
+    const sdl2 = /* GraphQL */ `
+      type Query {
+        users: [User!]
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        email: String!
+      }
+
+      enum UserType {
+        CUSTOMER
+        ADMIN
+      }
+    `;
+
+    const output = await cli.check({
+      sdl: sdl2,
+      expect: 'rejected',
+    });
+    /** remove colors */
+    const cleanOutput = output.replace(/\x1b\[[0-9;]*m/g, '');
+    expect(cleanOutput).toMatch(/Enum value ADMIN was added to enum UserType/);
+  },
+);
+
+test.concurrent(
+  'schema:check passes for dangerous changes when upgraded to breaking changes, if type is not in the failing list',
+  async ({ expect }) => {
+    const { createOrg } = await initSeed().createOwner();
+    const { inviteAndJoinMember, createProject } = await createOrg();
+    await inviteAndJoinMember();
+    const {
+      createTargetAccessToken,
+      updateTargetFailingDangerousChanges,
+      updateTargetDangerousChangeClassification,
+      target,
+    } = await createProject(ProjectType.Single);
+    const { secret } = await createTargetAccessToken({});
+    const cli = createCLI({
+      readonly: secret,
+      readwrite: secret,
+    });
+
+    // enable: dangerous change -> breaking
+    await updateTargetDangerousChangeClassification({
+      failDiffOnDangerousChange: true,
+      target,
+    });
+    /** Explicitly specify failing dangerous type condition */
+    await updateTargetFailingDangerousChanges({
+      all: false,
+      failingTypes: [GraphQLSchema.DangerousChangeType.DirectiveArgumentDefaultValueChanged],
+      target,
+    });
+
+    const sdl = /* GraphQL */ `
+      type Query {
+        users: [User!]
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        email: String!
+      }
+
+      enum UserType {
+        CUSTOMER
+      }
+    `;
+
+    await expect(
+      cli.publish({
+        sdl,
+        commit: 'push1',
+        expect: 'latest-composable',
+      }),
+    ).resolves.toMatchSnapshot('schemaPublish (initial)');
+
+    // add an enum value
+    const sdl2 = /* GraphQL */ `
+      type Query {
+        users: [User!]
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        email: String!
+      }
+
+      enum UserType {
+        CUSTOMER
+        ADMIN
+      }
+    `;
+
+    const output = await cli.check({
+      sdl: sdl2,
+      expect: 'approved',
+    });
+    /** remove colors */
+    const cleanOutput = output.replace(/\x1b\[[0-9;]*m/g, '');
+    expect(cleanOutput).toMatch(/Enum value ADMIN was added to enum UserType/);
+  },
+);

--- a/packages/migrations/src/actions/2026.06.25T00-00-00.failing-dangerous-change-types.ts
+++ b/packages/migrations/src/actions/2026.06.25T00-00-00.failing-dangerous-change-types.ts
@@ -1,0 +1,15 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+export default {
+  name: '2026.06.25T00-00-00.failing-dangerous-change-types.ts',
+  run: ({ psql }) => [
+    {
+      name: 'add failing dangerous change columns',
+      query: psql`
+        ALTER TABLE IF EXISTS "targets"
+          ADD COLUMN IF NOT EXISTS fail_all_dangerous_changes BOOLEAN NOT NULL DEFAULT TRUE
+          , ADD COLUMN IF NOT EXISTS fail_dangerous_change_types TEXT[] NOT NULL DEFAULT '{}'
+      `,
+    },
+  ],
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -190,5 +190,6 @@ export const runPGMigrations = async (args: { slonik: PostgresDatabasePool; runT
       await import('./actions/2026.05.29T00-00-00.schema-log-target-id-nullability'),
       await import('./actions/2026.05.07T00-00-00.schema-version-promotion'),
       await import('./actions/2026.06.05T00-00-00.metric-alert-filter-shared-only'),
+      await import('./actions/2026.06.25T00-00-00.failing-dangerous-change-types'),
     ],
   });

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -1,4 +1,5 @@
 import { Injectable, Scope } from 'graphql-modules';
+import type { DangerousChangeType } from '@hive/api/__generated__/types';
 import { traceFn } from '@hive/service-common';
 import { SchemaChangeType } from '@hive/storage';
 import { AppDeployments } from '../../../app-deployments/providers/app-deployments';
@@ -46,6 +47,8 @@ export class CompositeModel {
     compositionCheck: Awaited<ReturnType<RegistryChecks['composition']>>;
     conditionalBreakingChangeDiffConfig: null | ConditionalBreakingChangeDiffConfig;
     failDiffOnDangerousChange: null | boolean;
+    failAllDangerousChanges: null | boolean;
+    failDangerousChangeTypes: null | DangerousChangeType[];
     getAffectedAppDeployments: GetAffectedAppDeployments | null;
   }): Promise<Array<ContractCheckInput> | null> {
     const contractResults = (args.compositionCheck.result ?? args.compositionCheck.reason)
@@ -74,7 +77,9 @@ export class CompositeModel {
             approvedChanges: contract.approvedChanges ?? null,
             existingSdl: contract.latestValidVersion?.compositeSchemaSdl ?? null,
             incomingSdl: contractCompositionResult?.result?.fullSchemaSdl ?? null,
-            failDiffOnDangerousChange: args.failDiffOnDangerousChange,
+            failDiffOnDangerousChange: args.failDiffOnDangerousChange ?? false,
+            failAllDangerousChanges: args.failAllDangerousChanges ?? true,
+            failDangerousChangeTypes: args.failDangerousChangeTypes ?? [],
             filterNestedChanges: true,
             getAffectedAppDeployments: args.getAffectedAppDeployments,
           }),
@@ -114,6 +119,8 @@ export class CompositeModel {
     conditionalBreakingChangeDiffConfig,
     contracts,
     failDiffOnDangerousChange,
+    failAllDangerousChanges,
+    failDangerousChangeTypes,
     filterNestedChanges,
   }: {
     input: Pick<CompositeSchemaInput, 'sdl' | 'serviceName'> & {
@@ -142,6 +149,8 @@ export class CompositeModel {
     approvedChanges: Map<string, SchemaChangeType>;
     conditionalBreakingChangeDiffConfig: null | ConditionalBreakingChangeDiffConfig;
     failDiffOnDangerousChange: null | boolean;
+    failAllDangerousChanges: null | boolean;
+    failDangerousChangeTypes: null | DangerousChangeType[];
     contracts: Array<
       ContractInput & {
         approvedChanges: Map<string, SchemaChangeType> | null;
@@ -222,6 +231,8 @@ export class CompositeModel {
       compositionCheck,
       conditionalBreakingChangeDiffConfig,
       failDiffOnDangerousChange,
+      failAllDangerousChanges,
+      failDangerousChangeTypes,
       getAffectedAppDeployments,
     });
     this.logger.debug('Contract checks: %o', contractChecks);
@@ -235,7 +246,9 @@ export class CompositeModel {
         incomingSdl:
           compositionCheck.result?.fullSchemaSdl ?? compositionCheck.reason?.fullSchemaSdl ?? null,
         conditionalBreakingChangeConfig: conditionalBreakingChangeDiffConfig,
-        failDiffOnDangerousChange,
+        failDiffOnDangerousChange: failDiffOnDangerousChange ?? false,
+        failAllDangerousChanges: failAllDangerousChanges ?? true,
+        failDangerousChangeTypes: failDangerousChangeTypes ?? [],
         filterNestedChanges,
         getAffectedAppDeployments,
       }),
@@ -310,6 +323,8 @@ export class CompositeModel {
     contracts,
     conditionalBreakingChangeDiffConfig,
     failDiffOnDangerousChange,
+    failAllDangerousChanges,
+    failDangerousChangeTypes,
   }: {
     input: {
       sdl: string;
@@ -336,6 +351,8 @@ export class CompositeModel {
     contracts: Array<ContractInput> | null;
     conditionalBreakingChangeDiffConfig: null | ConditionalBreakingChangeDiffConfig;
     failDiffOnDangerousChange: null | boolean;
+    failAllDangerousChanges: null | boolean;
+    failDangerousChangeTypes: null | DangerousChangeType[];
   }): Promise<SchemaPublishResult> {
     const latestSchemaVersion = latest;
     const latestServiceVersion = latest?.schemas?.find(
@@ -466,7 +483,9 @@ export class CompositeModel {
         approvedChanges: null,
         existingSdl: previousVersionSdl,
         incomingSdl: compositionCheck.result?.fullSchemaSdl ?? null,
-        failDiffOnDangerousChange,
+        failDiffOnDangerousChange: failDiffOnDangerousChange ?? false,
+        failAllDangerousChanges: failAllDangerousChanges ?? true,
+        failDangerousChangeTypes: failDangerousChangeTypes ?? [],
         filterNestedChanges: true, // filter because publish is never associated to schema proposals in this way.
         getAffectedAppDeployments: getAffectedAppDeploymentsForPublish,
       }),
@@ -480,6 +499,8 @@ export class CompositeModel {
         failDiffOnDangerousChange: false,
         filterNestedChanges: true,
         getAffectedAppDeployments: null,
+        failAllDangerousChanges: false,
+        failDangerousChangeTypes: [],
       }),
       this.checks.diff({
         existingSdl: latestComposable?.supergraphSdl ?? null,
@@ -491,12 +512,16 @@ export class CompositeModel {
         failDiffOnDangerousChange: false,
         filterNestedChanges: true,
         getAffectedAppDeployments: null,
+        failAllDangerousChanges: false,
+        failDangerousChangeTypes: [],
       }),
       this.getContractChecks({
         contracts,
         compositionCheck,
         conditionalBreakingChangeDiffConfig,
         failDiffOnDangerousChange,
+        failAllDangerousChanges: false,
+        failDangerousChangeTypes: [],
         getAffectedAppDeployments: getAffectedAppDeploymentsForPublish,
       }),
     ]);
@@ -565,6 +590,8 @@ export class CompositeModel {
     conditionalBreakingChangeDiffConfig,
     contracts,
     failDiffOnDangerousChange,
+    failAllDangerousChanges,
+    failDangerousChangeTypes,
   }: {
     input: {
       serviceName: string;
@@ -591,6 +618,8 @@ export class CompositeModel {
     contracts: Array<ContractInput> | null;
     conditionalBreakingChangeDiffConfig: null | ConditionalBreakingChangeDiffConfig;
     failDiffOnDangerousChange: null | boolean;
+    failAllDangerousChanges: null | boolean;
+    failDangerousChangeTypes: null | DangerousChangeType[];
   }): Promise<SchemaDeleteResult> {
     const latestVersion = latest;
 
@@ -641,7 +670,9 @@ export class CompositeModel {
         approvedChanges: null,
         existingSdl: previousVersionSdl,
         incomingSdl: compositionCheck.result?.fullSchemaSdl ?? null,
-        failDiffOnDangerousChange,
+        failDiffOnDangerousChange: failDiffOnDangerousChange ?? false,
+        failAllDangerousChanges: failAllDangerousChanges ?? true,
+        failDangerousChangeTypes: failDangerousChangeTypes ?? [],
         filterNestedChanges: true, // filter because deletes are never associated with schema proposals in this way.
         getAffectedAppDeployments: getAffectedAppDeploymentsForDelete,
       }),
@@ -650,6 +681,8 @@ export class CompositeModel {
         compositionCheck,
         conditionalBreakingChangeDiffConfig,
         failDiffOnDangerousChange,
+        failAllDangerousChanges: failAllDangerousChanges ?? true,
+        failDangerousChangeTypes: failDangerousChangeTypes ?? [],
         getAffectedAppDeployments: getAffectedAppDeploymentsForDelete,
       }),
       this.checks.diff({
@@ -662,6 +695,8 @@ export class CompositeModel {
         failDiffOnDangerousChange: false,
         filterNestedChanges: true,
         getAffectedAppDeployments: null,
+        failAllDangerousChanges: failAllDangerousChanges ?? true,
+        failDangerousChangeTypes: failDangerousChangeTypes ?? [],
       }),
     ]);
 

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -1,4 +1,5 @@
 import { Injectable, Scope } from 'graphql-modules';
+import type { DangerousChangeType } from '@hive/api/__generated__/types';
 import { traceFn } from '@hive/service-common';
 import { SchemaChangeType } from '@hive/storage';
 import { AppDeployments } from '../../../app-deployments/providers/app-deployments';
@@ -57,6 +58,8 @@ export class SingleModel {
     approvedChanges,
     conditionalBreakingChangeDiffConfig,
     failDiffOnDangerousChange,
+    failAllDangerousChanges,
+    failDangerousChangeTypes,
     filterNestedChanges,
   }: {
     input: Pick<SingleSchemaInput, 'sdl'>;
@@ -81,6 +84,8 @@ export class SingleModel {
     approvedChanges: Map<string, SchemaChangeType>;
     conditionalBreakingChangeDiffConfig: null | ConditionalBreakingChangeDiffConfig;
     failDiffOnDangerousChange: boolean;
+    failAllDangerousChanges: boolean;
+    failDangerousChangeTypes: DangerousChangeType[];
     filterNestedChanges: boolean;
   }): Promise<SchemaCheckResult> {
     const incoming: SingleSchemaInput = {
@@ -146,6 +151,8 @@ export class SingleModel {
         existingSdl: previousVersionSdl,
         incomingSdl: compositionCheck.result?.fullSchemaSdl ?? null,
         failDiffOnDangerousChange,
+        failAllDangerousChanges,
+        failDangerousChangeTypes,
         filterNestedChanges,
         getAffectedAppDeployments,
       }),
@@ -203,6 +210,8 @@ export class SingleModel {
     baseSchema,
     conditionalBreakingChangeDiffConfig,
     failDiffOnDangerousChange,
+    failAllDangerousChanges,
+    failDangerousChangeTypes,
   }: {
     input: {
       sdl: string;
@@ -224,6 +233,8 @@ export class SingleModel {
     baseSchema: string | null;
     conditionalBreakingChangeDiffConfig: null | ConditionalBreakingChangeDiffConfig;
     failDiffOnDangerousChange: boolean;
+    failAllDangerousChanges: boolean;
+    failDangerousChangeTypes: DangerousChangeType[];
   }): Promise<SchemaPublishResult> {
     const incoming: SingleSchemaInput = {
       id: temp,
@@ -312,6 +323,8 @@ export class SingleModel {
         existingSdl: previousVersionSdl,
         incomingSdl: compositionCheck.result?.fullSchemaSdl ?? null,
         failDiffOnDangerousChange,
+        failAllDangerousChanges,
+        failDangerousChangeTypes,
         filterNestedChanges: true, // publish is never associated with schema proposals in this way. So always show the minimal changeset.
         getAffectedAppDeployments: getAffectedAppDeploymentsForPublish,
       }),

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -3,6 +3,7 @@ import { type GraphQLSchema } from 'graphql';
 import { Injectable, Scope } from 'graphql-modules';
 import hashObject from 'object-hash';
 import { ChangeType, CriticalityLevel, DiffRule, TypeOfChangeType } from '@graphql-inspector/core';
+import type { DangerousChangeType } from '@hive/api/__generated__/types';
 import type { CheckPolicyResponse } from '@hive/policy';
 import type { CompositionFailureError, ContractsInputType } from '@hive/schema';
 import { traceFn } from '@hive/service-common';
@@ -506,7 +507,9 @@ export class RegistryChecks {
     approvedChanges: null | Map<string, SchemaChangeType>;
     /** Settings for fetching conditional breaking changes. */
     conditionalBreakingChangeConfig: null | ConditionalBreakingChangeDiffConfig;
-    failDiffOnDangerousChange: null | boolean;
+    failDiffOnDangerousChange: boolean;
+    failAllDangerousChanges: boolean;
+    failDangerousChangeTypes: DangerousChangeType[];
     /**
      * Set to true to reduce the number of changes to only what's relevant to the user.
      * Use false for schema proposals in order to capture every single change record for the patch function.
@@ -742,11 +745,18 @@ export class RegistryChecks {
 
     const coordinatesDiff = diffSchemaCoordinates(existingSchema, incomingSchema);
 
+    const isFailingDangerousChange = (change: { criticality: CriticalityLevel; type: string }) => {
+      return (
+        args.failDiffOnDangerousChange &&
+        change.criticality === CriticalityLevel.Dangerous &&
+        // if failAll is null or true, or if the list of failing change types includes this type...
+        (args.failAllDangerousChanges === true ||
+          (args.failDangerousChangeTypes as string[])?.includes(change.type))
+      );
+    };
+
     for (const change of inspectorChanges) {
-      if (
-        change.criticality === CriticalityLevel.Breaking ||
-        (args.failDiffOnDangerousChange && change.criticality === CriticalityLevel.Dangerous)
-      ) {
+      if (change.criticality === CriticalityLevel.Breaking || isFailingDangerousChange(change)) {
         if (change.isSafeBasedOnUsage === true) {
           breakingChanges.push(change);
           continue;

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -205,6 +205,8 @@ export class SchemaPublisher {
   }): Promise<{
     conditionalBreakingChangeConfiguration: ConditionalBreakingChangeConfiguration | null;
     failDiffOnDangerousChange: boolean;
+    failAllDangerousChanges: boolean;
+    failDangerousChangeTypes: Types.DangerousChangeType[];
   }> {
     try {
       const settings = await this.storage.getTargetSettings(selector);
@@ -215,6 +217,8 @@ export class SchemaPublisher {
         return {
           failDiffOnDangerousChange: settings.failDiffOnDangerousChange,
           conditionalBreakingChangeConfiguration: null,
+          failAllDangerousChanges: settings.failAllDangerousChanges,
+          failDangerousChangeTypes: settings.failDangerousChangeTypes,
         };
       }
 
@@ -224,6 +228,8 @@ export class SchemaPublisher {
         return {
           failDiffOnDangerousChange: settings.failDiffOnDangerousChange,
           conditionalBreakingChangeConfiguration: null,
+          failAllDangerousChanges: settings.failAllDangerousChanges,
+          failDangerousChangeTypes: settings.failDangerousChangeTypes,
         };
       }
 
@@ -262,6 +268,8 @@ export class SchemaPublisher {
           totalRequestCount,
         },
         failDiffOnDangerousChange: settings.failDiffOnDangerousChange,
+        failAllDangerousChanges: settings.failAllDangerousChanges,
+        failDangerousChangeTypes: settings.failDangerousChangeTypes,
       };
     } catch (error: unknown) {
       const errorText =
@@ -609,10 +617,14 @@ export class SchemaPublisher {
       );
     });
 
-    const { conditionalBreakingChangeConfiguration, failDiffOnDangerousChange } =
-      await this.getBreakingChangeConfiguration({
-        selector,
-      });
+    const {
+      conditionalBreakingChangeConfiguration,
+      failDiffOnDangerousChange,
+      failAllDangerousChanges,
+      failDangerousChangeTypes,
+    } = await this.getBreakingChangeConfiguration({
+      selector,
+    });
 
     const latestSchemaVersionContracts = latestVersion
       ? await this.contracts.getContractVersionsForSchemaVersion({
@@ -665,6 +677,8 @@ export class SchemaPublisher {
           conditionalBreakingChangeDiffConfig:
             conditionalBreakingChangeConfiguration?.conditionalBreakingChangeDiffConfig ?? null,
           failDiffOnDangerousChange,
+          failAllDangerousChanges,
+          failDangerousChangeTypes,
           filterNestedChanges: true,
         });
         break;
@@ -732,6 +746,8 @@ export class SchemaPublisher {
           conditionalBreakingChangeDiffConfig:
             conditionalBreakingChangeConfiguration?.conditionalBreakingChangeDiffConfig ?? null,
           failDiffOnDangerousChange,
+          failAllDangerousChanges,
+          failDangerousChangeTypes,
           filterNestedChanges: !input.schemaProposalId,
         });
         break;
@@ -1459,14 +1475,18 @@ export class SchemaPublisher {
           } as const;
         }
 
-        const { conditionalBreakingChangeConfiguration, failDiffOnDangerousChange } =
-          await this.getBreakingChangeConfiguration({
-            selector: {
-              targetId: selector.targetId,
-              projectId: selector.projectId,
-              organizationId: selector.organizationId,
-            },
-          });
+        const {
+          conditionalBreakingChangeConfiguration,
+          failDiffOnDangerousChange,
+          failAllDangerousChanges,
+          failDangerousChangeTypes,
+        } = await this.getBreakingChangeConfiguration({
+          selector: {
+            targetId: selector.targetId,
+            projectId: selector.projectId,
+            organizationId: selector.organizationId,
+          },
+        });
 
         const contracts =
           project.type === ProjectType.FEDERATION
@@ -1506,6 +1526,8 @@ export class SchemaPublisher {
             conditionalBreakingChangeConfiguration?.conditionalBreakingChangeDiffConfig ?? null,
           contracts,
           failDiffOnDangerousChange,
+          failAllDangerousChanges,
+          failDangerousChangeTypes,
         });
 
         if (deleteResult.conclusion === SchemaDeleteConclusion.Accept) {
@@ -1776,14 +1798,18 @@ export class SchemaPublisher {
 
     this.logger.debug(`Found ${latestVersion?.schemas.length ?? 0} most recent schemas`);
 
-    const { conditionalBreakingChangeConfiguration, failDiffOnDangerousChange } =
-      await this.getBreakingChangeConfiguration({
-        selector: {
-          organizationId: organization.id,
-          projectId: project.id,
-          targetId: target.id,
-        },
-      });
+    const {
+      conditionalBreakingChangeConfiguration,
+      failDiffOnDangerousChange,
+      failAllDangerousChanges,
+      failDangerousChangeTypes,
+    } = await this.getBreakingChangeConfiguration({
+      selector: {
+        organizationId: organization.id,
+        projectId: project.id,
+        targetId: target.id,
+      },
+    });
 
     const contracts =
       project.type === ProjectType.FEDERATION
@@ -1832,6 +1858,8 @@ export class SchemaPublisher {
           conditionalBreakingChangeDiffConfig:
             conditionalBreakingChangeConfiguration?.conditionalBreakingChangeDiffConfig ?? null,
           failDiffOnDangerousChange,
+          failAllDangerousChanges,
+          failDangerousChangeTypes,
         });
         break;
       case ProjectType.FEDERATION:
@@ -1880,6 +1908,8 @@ export class SchemaPublisher {
           conditionalBreakingChangeDiffConfig:
             conditionalBreakingChangeConfiguration?.conditionalBreakingChangeDiffConfig ?? null,
           failDiffOnDangerousChange,
+          failAllDangerousChanges,
+          failDangerousChangeTypes,
         });
         break;
       default: {
@@ -2477,6 +2507,8 @@ export class SchemaPublisher {
               includeUrlChanges: false,
               filterOutFederationChanges: false,
               failDiffOnDangerousChange: false,
+              failAllDangerousChanges: false,
+              failDangerousChangeTypes: [],
               filterNestedChanges: true,
               getAffectedAppDeployments: null,
             })
@@ -2565,6 +2597,8 @@ export class SchemaPublisher {
           filterOutFederationChanges: false,
           approvedChanges: null,
           failDiffOnDangerousChange: false,
+          failAllDangerousChanges: false,
+          failDangerousChangeTypes: [],
           getAffectedAppDeployments: null,
           filterNestedChanges: true,
         })
@@ -2657,6 +2691,8 @@ export class SchemaPublisher {
             filterOutFederationChanges: false,
             approvedChanges: null,
             failDiffOnDangerousChange: false,
+            failAllDangerousChanges: false,
+            failDangerousChangeTypes: [],
             getAffectedAppDeployments: null,
             filterNestedChanges: true,
           })
@@ -2880,6 +2916,8 @@ export class SchemaPublisher {
           filterOutFederationChanges: true,
           approvedChanges: null,
           failDiffOnDangerousChange: false,
+          failAllDangerousChanges: false,
+          failDangerousChangeTypes: [],
           getAffectedAppDeployments: schemaCoordinates =>
             this.appDeployments.getAffectedAppDeploymentsBySchemaCoordinates({
               targetId: target.id,
@@ -2900,6 +2938,8 @@ export class SchemaPublisher {
           filterOutFederationChanges: false,
           approvedChanges: null,
           failDiffOnDangerousChange: false,
+          failAllDangerousChanges: false,
+          failDangerousChangeTypes: [],
           getAffectedAppDeployments: null,
           filterNestedChanges: true,
         })

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -231,7 +231,10 @@ export class SchemaVersionHelper {
       return null;
     }
 
-    const [project, { failDiffOnDangerousChange }] = await Promise.all([
+    const [
+      project,
+      { failDiffOnDangerousChange, failAllDangerousChanges, failDangerousChangeTypes },
+    ] = await Promise.all([
       this.projectManager.getProjectById(schemaVersion.projectId),
       this.storage.getTargetSettings({
         targetId: schemaVersion.targetId,
@@ -251,6 +254,8 @@ export class SchemaVersionHelper {
       filterOutFederationChanges: project.type === ProjectType.FEDERATION,
       conditionalBreakingChangeConfig: null,
       failDiffOnDangerousChange,
+      failAllDangerousChanges,
+      failDangerousChangeTypes: failDangerousChangeTypes ?? [],
       filterNestedChanges: true,
       getAffectedAppDeployments: null,
     });

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -8,7 +8,7 @@ import type {
   SchemaCheckInput,
   TargetBreadcrumb,
 } from '@hive/storage';
-import type { SchemaChecksFilter } from '../../../__generated__/types';
+import type { DangerousChangeType, SchemaChecksFilter } from '../../../__generated__/types';
 import type {
   Alert,
   AlertChannel,
@@ -329,6 +329,13 @@ export interface Storage {
   updateTargetDangerousChangeClassification(
     _: TargetSelector & Pick<TargetSettings, 'failDiffOnDangerousChange'>,
   ): Promise<TargetSettings | never>; // @todo decide if something should be returned.
+
+  updateTargetFailingDangerousChanges(
+    _: TargetSelector & {
+      all: boolean;
+      failingTypes: readonly DangerousChangeType[];
+    },
+  ): Promise<void>;
 
   updateTargetAppDeploymentProtectionSettings(
     _: Pick<TargetSelector, 'targetId' | 'projectId'> &

--- a/packages/services/api/src/modules/target/module.graphql.ts
+++ b/packages/services/api/src/modules/target/module.graphql.ts
@@ -55,6 +55,68 @@ export default gql`
     experimental__updateTargetSchemaComposition(
       input: Experimental__UpdateTargetSchemaCompositionInput!
     ): Target!
+
+    updateTargetFailingDangerousChanges(
+      input: UpdateTargetFailingDangerousChangesInput!
+    ): UpdateTargetFailingDangerousChangesResult!
+  }
+
+  type UpdateTargetFailingDangerousChangesResult {
+    ok: UpdateTargetFailingDangerousChangesOk
+    error: UpdateTargetFailingDangerousChangesError
+  }
+
+  type UpdateTargetFailingDangerousChangesError {
+    message: String!
+  }
+
+  """
+  If the option to consider dangerous changes failing is enabled, then
+  this contains granular configuration for which specific changes are
+  flagged as failing. The option to consider all types as failing is a
+  separate boolean because it allows saving the state of the granular
+  selection.
+  """
+  type UpdateTargetFailingDangerousChangesOk {
+    target: Target!
+  }
+
+  enum DangerousChangeType {
+    INPUT_FIELD_DEFAULT_VALUE_CHANGED
+    INPUT_FIELD_ADDED
+    OBJECT_TYPE_INTERFACE_ADDED
+    UNION_MEMBER_ADDED
+    FIELD_ARGUMENT_ADDED
+    FIELD_ARGUMENT_DEFAULT_CHANGED
+    ENUM_VALUE_ADDED
+    DIRECTIVE_USAGE_ARGUMENT_ADDED
+    DIRECTIVE_USAGE_ARGUMENT_DEFINITION_ADDED
+    DIRECTIVE_USAGE_ENUM_ADDED
+    DIRECTIVE_USAGE_FIELD_ADDED
+    DIRECTIVE_USAGE_FIELD_DEFINITION_ADDED
+    DIRECTIVE_USAGE_INPUT_FIELD_DEFINITION_ADDED
+    DIRECTIVE_USAGE_OBJECT_ADDED
+    DIRECTIVE_USAGE_SCALAR_ADDED
+    DIRECTIVE_USAGE_SCHEMA_ADDED
+    DIRECTIVE_USAGE_UNION_MEMBER_ADDED
+    DIRECTIVE_USAGE_ARGUMENT_REMOVED
+    DIRECTIVE_USAGE_ARGUMENT_DEFINITION_REMOVED
+    DIRECTIVE_USAGE_ENUM_REMOVED
+    DIRECTIVE_USAGE_FIELD_REMOVED
+    DIRECTIVE_USAGE_FIELD_DEFINITION_REMOVED
+    DIRECTIVE_USAGE_INPUT_FIELD_DEFINITION_REMOVED
+    DIRECTIVE_USAGE_OBJECT_REMOVED
+    DIRECTIVE_USAGE_SCALAR_REMOVED
+    DIRECTIVE_USAGE_SCHEMA_REMOVED
+    DIRECTIVE_USAGE_UNION_MEMBER_REMOVED
+    DIRECTIVE_ARGUMENT_DEFAULT_VALUE_CHANGED
+    DIRECTIVE_REPEATABLE_REMOVED
+  }
+
+  input UpdateTargetFailingDangerousChangesInput {
+    target: TargetReferenceInput!
+    all: Boolean!
+    failingTypes: [DangerousChangeType!]!
   }
 
   input Experimental__UpdateTargetSchemaCompositionInput {
@@ -286,6 +348,17 @@ export default gql`
     Whether a dangerous change fails a schema check and requires a manual approval.
     """
     failDiffOnDangerousChange: Boolean! @tag(name: "public")
+    """
+    If failDiffOnDangerousChange is enabled, then this determines if all dangerous changes are
+    considered failures, or if only the list provided by failDangerousChangeTypes will fail.
+    By default, this is true.
+    """
+    failAllDangerousChanges: Boolean!
+    """
+    IF failDiffOnDangerousChange is true and failAllDangerousChanges is false, then
+    this list determines which dangerous changes are considered failures.
+    """
+    failDangerousChangeTypes: [DangerousChangeType!]!
     """
     Configuration for conditional breaking change detection.
     """

--- a/packages/services/api/src/modules/target/providers/target-manager.ts
+++ b/packages/services/api/src/modules/target/providers/target-manager.ts
@@ -300,6 +300,37 @@ export class TargetManager {
     return this.getTarget(selector);
   }
 
+  async updateTargetFailingDangerousChanges(args: {
+    target: GraphQLSchema.TargetReferenceInput;
+    all: boolean;
+    failingTypes: readonly GraphQLSchema.DangerousChangeType[];
+  }) {
+    this.logger.debug('Updating target dangerous change classification (target=%o)', args.target);
+    const selector = await this.idTranslator.resolveTargetReference({ reference: args.target });
+
+    if (!selector) {
+      this.session.raise('target:modifySettings');
+    }
+
+    await this.session.assertPerformAction({
+      action: 'target:modifySettings',
+      organizationId: selector.organizationId,
+      params: {
+        organizationId: selector.organizationId,
+        projectId: selector.projectId,
+        targetId: selector.targetId,
+      },
+    });
+
+    await this.storage.updateTargetFailingDangerousChanges({
+      ...selector,
+      all: args.all,
+      failingTypes: args.failingTypes,
+    });
+
+    return this.getTarget(selector);
+  }
+
   async updateTargetConditionalBreakingChangeConfiguration(args: {
     target: GraphQLSchema.TargetReferenceInput;
     configuration: GraphQLSchema.ConditionalBreakingChangeConfigurationInput;

--- a/packages/services/api/src/modules/target/resolvers/Mutation/updateTargetFailingDangerousChanges.ts
+++ b/packages/services/api/src/modules/target/resolvers/Mutation/updateTargetFailingDangerousChanges.ts
@@ -1,0 +1,18 @@
+import { TargetManager } from '../../providers/target-manager';
+import type { MutationResolvers } from './../../../../__generated__/types';
+
+export const updateTargetFailingDangerousChanges: NonNullable<
+  MutationResolvers['updateTargetFailingDangerousChanges']
+> = async (_, { input }, { injector }) => {
+  const target = await injector.get(TargetManager).updateTargetFailingDangerousChanges({
+    target: input.target,
+    all: input.all,
+    failingTypes: input.failingTypes,
+  });
+
+  return {
+    ok: {
+      target,
+    },
+  };
+};

--- a/packages/services/api/src/modules/target/resolvers/Target.ts
+++ b/packages/services/api/src/modules/target/resolvers/Target.ts
@@ -143,4 +143,7 @@ export const Target: Pick<
 
     return targetSettings.appDeploymentProtection;
   },
+  failDangerousChangeTypes: ({ failDangerousChangeTypes }, _arg, _ctx) => {
+    return failDangerousChangeTypes as any; // let gql validate the enum
+  },
 };

--- a/packages/services/api/src/modules/target/resolvers/Target.ts
+++ b/packages/services/api/src/modules/target/resolvers/Target.ts
@@ -9,6 +9,8 @@ export const Target: Pick<
   | 'cleanId'
   | 'conditionalBreakingChangeConfiguration'
   | 'experimental_forcedLegacySchemaComposition'
+  | 'failAllDangerousChanges'
+  | 'failDangerousChangeTypes'
   | 'failDiffOnDangerousChange'
   | 'graphqlEndpointUrl'
   | 'id'

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -390,6 +390,8 @@ export interface TargetSettings {
     excludedAppDeployments: string[];
   };
   failDiffOnDangerousChange: boolean;
+  failAllDangerousChanges: boolean;
+  failDangerousChangeTypes: DangerousChangeType[];
   appDeploymentProtection: {
     isEnabled: boolean;
     minDaysInactive: number;

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -333,7 +333,7 @@ export interface Target {
   graphqlEndpointUrl: string | null;
   failDiffOnDangerousChange: boolean;
   failAllDangerousChanges: boolean;
-  failDangerousChangeTypes: DangerousChangeType[];
+  failDangerousChangeTypes: string[];
 }
 
 export interface Token {

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -8,6 +8,7 @@ import type {
   AlertChannelType,
   AlertType,
   AuthProviderType,
+  DangerousChangeType,
   OrganizationAccessScope,
   ProjectAccessScope,
   TargetAccessScope,
@@ -331,6 +332,8 @@ export interface Target {
   name: string;
   graphqlEndpointUrl: string | null;
   failDiffOnDangerousChange: boolean;
+  failAllDangerousChanges: boolean;
+  failDangerousChangeTypes: DangerousChangeType[];
 }
 
 export interface Token {

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -537,6 +537,8 @@ export interface targets {
   base_schema: string | null;
   clean_id: string;
   created_at: Date;
+  fail_all_dangerous_changes: boolean;
+  fail_dangerous_change_types: Array<string>;
   fail_diff_on_dangerous_change: boolean;
   graphql_endpoint_url: string | null;
   id: string;

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -4316,7 +4316,7 @@ const TargetModel = z.object({
   graphqlEndpointUrl: z.string().nullable(),
   failDiffOnDangerousChange: z.boolean(),
   failAllDangerousChanges: z.boolean(),
-  failDangerousChangeTypes: z.array(z.any()), // DangerousChangeType
+  failDangerousChangeTypes: z.array(z.string()), // DangerousChangeType
 });
 
 const TargetWithOrgIdModel = TargetModel.extend({

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -1733,23 +1733,11 @@ export async function createStorage(
     }) {
       await pool.transaction('updateTargetDangerousChangeClassification', async trx => {
         return trx.maybeOne(psql`/* updateTargetValidationSettings */
-            UPDATE targets as t
+            UPDATE targets
             SET
               fail_all_dangerous_changes = ${all},
               fail_dangerous_change_types = ${psql.array(failingTypes, 'text')}
-            FROM (
-              SELECT
-                it.id,
-                array_agg(DISTINCT tv.destination_target_id)
-                FILTER (WHERE tv.destination_target_id IS NOT NULL)
-                  AS "targets"
-              FROM targets AS it
-              LEFT JOIN target_validation AS tv ON (tv.target_id = it.id)
-              WHERE it.id = ${target} AND it.project_id = ${project}
-              GROUP BY it.id
-              LIMIT 1
-            ) ret
-            WHERE t.id = ret.id
+            WHERE id = ${target} AND project_id = ${project}
           `);
       });
     },

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -4464,6 +4464,8 @@ const targetSettingsFields = (prefix: TaggedTemplateLiteralInvocation) => psql`
   , ${prefix}"validation_request_count" AS "validationRequestCount"
   , ${prefix}"validation_breaking_change_formula" AS "validationBreakingChangeFormula"
   , ${prefix}"fail_diff_on_dangerous_change" AS "failDiffOnDangerousChange"
+  , ${prefix}"fail_all_dangerous_changes" as "failAllDangerousChanges"
+  , ${prefix}"fail_dangerous_change_types" as "failDangerousChangeTypes"
   , ${prefix}"app_deployment_protection_enabled" AS "appDeploymentProtectionEnabled"
   , ${prefix}"app_deployment_protection_min_days_inactive" AS "appDeploymentProtectionMinDaysInactive"
   , ${prefix}"app_deployment_protection_min_days_since_creation" AS "appDeploymentProtectionMinDaysSinceCreation"
@@ -4711,6 +4713,8 @@ const TargetSettingsModel = z
     validationRequestCount: z.number().nullable(),
     validationBreakingChangeFormula: z.string().nullable(),
     failDiffOnDangerousChange: z.boolean(),
+    failAllDangerousChanges: z.boolean(),
+    failDangerousChangeTypes: z.array(z.any()),
     targets: z.array(z.string()).nullable(),
     appDeploymentProtectionEnabled: z.boolean(),
     appDeploymentProtectionMinDaysInactive: z.number(),
@@ -4721,6 +4725,8 @@ const TargetSettingsModel = z
   })
   .transform(row => ({
     failDiffOnDangerousChange: row.failDiffOnDangerousChange,
+    failAllDangerousChanges: row.failAllDangerousChanges,
+    failDangerousChangeTypes: row.failDangerousChangeTypes,
     validation: {
       isEnabled: row.validationEnabled,
       percentage: row.validationPercentage,

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -1725,6 +1725,34 @@ export async function createStorage(
         })
         .then(TargetSettingsModel.parse);
     },
+    async updateTargetFailingDangerousChanges({
+      targetId: target,
+      projectId: project,
+      all,
+      failingTypes,
+    }) {
+      await pool.transaction('updateTargetDangerousChangeClassification', async trx => {
+        return trx.maybeOne(psql`/* updateTargetValidationSettings */
+            UPDATE targets as t
+            SET
+              fail_all_dangerous_changes = ${all},
+              fail_dangerous_change_types = ${psql.array(failingTypes, 'text')}
+            FROM (
+              SELECT
+                it.id,
+                array_agg(DISTINCT tv.destination_target_id)
+                FILTER (WHERE tv.destination_target_id IS NOT NULL)
+                  AS "targets"
+              FROM targets AS it
+              LEFT JOIN target_validation AS tv ON (tv.target_id = it.id)
+              WHERE it.id = ${target} AND it.project_id = ${project}
+              GROUP BY it.id
+              LIMIT 1
+            ) ret
+            WHERE t.id = ret.id
+          `);
+      });
+    },
     async updateTargetValidationSettings({
       targetId: target,
       projectId: project,
@@ -4214,7 +4242,9 @@ const targetSQLFields = psql`
   "name",
   "project_id" as "projectId",
   "graphql_endpoint_url" as "graphqlEndpointUrl",
-  "fail_diff_on_dangerous_change" as "failDiffOnDangerousChange"
+  "fail_diff_on_dangerous_change" as "failDiffOnDangerousChange",
+  "fail_all_dangerous_changes" as "failAllDangerousChanges",
+  "fail_dangerous_change_types" as "failDangerousChangeTypes"
 `;
 
 export function findTargetById(deps: { pool: PostgresDatabasePool }) {
@@ -4285,6 +4315,8 @@ const TargetModel = z.object({
   projectId: z.string(),
   graphqlEndpointUrl: z.string().nullable(),
   failDiffOnDangerousChange: z.boolean(),
+  failAllDangerousChanges: z.boolean(),
+  failDangerousChangeTypes: z.array(z.any()), // DangerousChangeType
 });
 
 const TargetWithOrgIdModel = TargetModel.extend({

--- a/packages/web/app/src/components/base/checkbox/checkbox.tsx
+++ b/packages/web/app/src/components/base/checkbox/checkbox.tsx
@@ -3,7 +3,7 @@ import { Check, Minus } from 'lucide-react';
 import { Checkbox as BaseCheckbox } from '@base-ui/react/checkbox';
 
 const checkboxVariants = cva(
-  'inline-flex shrink-0 items-center justify-center rounded-sm border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-50',
+  'inline-flex shrink-0 items-center justify-center rounded-sm border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
   {
     variants: {
       size: {
@@ -14,8 +14,8 @@ const checkboxVariants = cva(
         default: [
           'border-neutral-6',
           'data-[checked]:bg-accent_30 data-[checked]:border-accent_30 data-[checked]:text-accent',
-          'hover:bg-neutral-6 hover:border-accent_30',
-          'data-[checked]:hover:bg-accent_10',
+          'not-[[data-disabled]]:hover:bg-neutral-6 not-[[data-disabled]]:hover:border-accent_30',
+          'not-[[data-disabled]]:data-[checked]:hover:bg-accent_10',
           'data-[indeterminate]:bg-accent_30 data-[indeterminate]:border-accent_30 data-[indeterminate]:text-accent',
         ],
       },

--- a/packages/web/app/src/components/ui/button.tsx
+++ b/packages/web/app/src/components/ui/button.tsx
@@ -4,11 +4,12 @@ import { cn } from '@/lib/utils';
 import { Slot } from '@radix-ui/react-slot';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-neutral-2',
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none disabled:cursor-not-allowed ring-offset-neutral-2',
   {
     variants: {
       variant: {
-        default: 'bg-neutral-4 text-neutral-11 hover:text-neutral-12 hover:bg-neutral-5',
+        default:
+          'bg-neutral-4 text-neutral-11 hover:text-neutral-12 hover:bg-neutral-5 disabled:ring-1 disabled:ring-neutral-5 ring-inset disabled:!bg-neutral-4/0',
         primary: 'bg-accent text-neutral-2 hover:brightness-110 active:bg-accent',
         destructive: 'bg-red-500 text-neutral-1 dark:text-neutral-12 hover:bg-red-700',
         outline:

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -2225,7 +2225,8 @@ function DangerousChangeTypeForm({
     } as { failingChangeTypes: DangerousChangeType[]; failAllDangerousChanges: boolean },
     validationSchema: Yup.object().shape({
       failAllDangerousChanges: Yup.bool().label('Fail all'),
-      failingChangeTypes: Yup.array().of(Yup.string())
+      failingChangeTypes: Yup.array()
+        .of(Yup.string())
         .when('failAllDangerousChanges', {
           is: true,
           then: schema => schema.notRequired(),

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -2474,7 +2474,7 @@ enum SaveStatus {
 
 export const useSaveStatus = () => {
   const [saveStatus, setSaveStatus] = useState<SaveStatus | null>();
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const triggerSaveMessage = () => {
     if (timerRef.current) {

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -2225,7 +2225,7 @@ function DangerousChangeTypeForm({
     } as { failingChangeTypes: DangerousChangeType[]; failAllDangerousChanges: boolean },
     validationSchema: Yup.object().shape({
       failAllDangerousChanges: Yup.bool().label('Fail all'),
-      failingChangeTypes: Yup.array(Yup.string())
+      failingChangeTypes: Yup.array().of(Yup.string())
         .when('failAllDangerousChanges', {
           is: true,
           then: schema => schema.notRequired(),

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/components/ui/dialog';
 import { DocsLink } from '@/components/ui/docs-note';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
+import { XIcon } from '@/components/ui/icon';
 import { Input } from '@/components/ui/input';
 import { Meta } from '@/components/ui/meta';
 import {
@@ -63,9 +64,7 @@ import {
 import { useRedirect } from '@/lib/access/common';
 import { subDays } from '@/lib/date-time';
 import { useToggle } from '@/lib/hooks';
-import { useTimed } from '@/lib/hooks/use-timed';
 import { cn } from '@/lib/utils';
-import type { TypeOfChangeType } from '@graphql-inspector/core';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { CheckIcon } from '@radix-ui/react-icons';
 import { RadioGroupIndicator } from '@radix-ui/react-radio-group';
@@ -2205,11 +2204,21 @@ function DangerousChangeTypeForm({
   projectSlug: string;
   targetSlug: string;
 }) {
-  const [mutation, mutate] = useMutation(TargetSettingsPage_UpdateFailingDangerousChangeSettings);
+  const [_, mutate] = useMutation(TargetSettingsPage_UpdateFailingDangerousChangeSettings);
   const { saveStatus, triggerSaveMessage } = useSaveStatus();
 
   const formik = useFormik({
     enableReinitialize: true,
+    initialStatus: {
+      error: undefined,
+    } as {
+      error:
+        | undefined
+        | {
+            title: string;
+            description: string | undefined;
+          };
+    },
     initialValues: {
       failingChangeTypes: initialFailingChangeTypes,
       failAllDangerousChanges: initialFailAllDangerousChanges,
@@ -2224,7 +2233,7 @@ function DangerousChangeTypeForm({
         })
         .label('Failing types'),
     }),
-    onSubmit: ({ failingChangeTypes, failAllDangerousChanges }, { setSubmitting }) =>
+    onSubmit: ({ failingChangeTypes, failAllDangerousChanges }, { setSubmitting, setStatus }) =>
       mutate({
         selector: {
           organizationSlug,
@@ -2235,14 +2244,36 @@ function DangerousChangeTypeForm({
           ? failingChangeTypes
           : [failingChangeTypes],
         failAllDangerousChanges,
-      }).then(() => {
-        setSubmitting(false);
-        triggerSaveMessage();
-      }),
+      })
+        .then(result => {
+          setSubmitting(false);
+          if (result.data?.updateTargetFailingDangerousChanges.error?.message || result.error) {
+            setStatus({
+              error: {
+                title: 'Dangerous change types were not updated.',
+                description:
+                  result.data?.updateTargetFailingDangerousChanges.error?.message ||
+                  result.error?.message,
+              },
+            });
+          } else {
+            setStatus({ error: undefined });
+            triggerSaveMessage();
+          }
+        })
+        .catch(e => {
+          setSubmitting(false);
+          setStatus({
+            error: {
+              title: 'Dangerous change types were not updated.',
+              description: e instanceof Error ? e.message : String(e),
+            },
+          });
+        }),
   });
 
   const setFailAllDangerousChanges = (val: boolean) => {
-    formik.setFieldValue('failAllDangerousChanges', val);
+    return formik.setFieldValue('failAllDangerousChanges', val);
   };
 
   /** Allows adding or removing multiple change types from the list of failing change types */
@@ -2257,7 +2288,7 @@ function DangerousChangeTypeForm({
         set.delete(type);
       }
     }
-    formik.setFieldValue('failingChangeTypes', Array.from(set));
+    return formik.setFieldValue('failingChangeTypes', Array.from(set));
   };
 
   return (
@@ -2272,16 +2303,16 @@ function DangerousChangeTypeForm({
         <div className="text-neutral-12 mb-3 mt-1 font-semibold">
           Select Failing Dangerous Change Types
         </div>
-        <div className="align-center flex gap-1 whitespace-nowrap border-b">
+        <div className="flex gap-1 whitespace-nowrap border-b">
           <Checkbox
             disabled={!considerDangerousAsBreaking}
             checked={formik.values.failAllDangerousChanges}
             onCheckedChange={setFailAllDangerousChanges}
           />
           <span
-            onClick={() => {
+            onClick={async () => {
               if (considerDangerousAsBreaking) {
-                setFailAllDangerousChanges(!formik.values.failAllDangerousChanges);
+                await setFailAllDangerousChanges(!formik.values.failAllDangerousChanges);
               }
             }}
             className={cn(
@@ -2308,7 +2339,7 @@ function DangerousChangeTypeForm({
           <span className="text-red-400">{formik.errors.failAllDangerousChanges}</span>
         </div>
         <div className="my-3">or fail only:</div>
-        <div className="grid grid-cols-1 gap-1 gap-2 lg:grid-cols-2">
+        <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
           {dangerousChangeList.map(
             ({
               /**
@@ -2338,7 +2369,7 @@ function DangerousChangeTypeForm({
               const disabled =
                 !considerDangerousAsBreaking || formik.values.failAllDangerousChanges;
               return (
-                <div className="align-center flex gap-x-1" key={label}>
+                <div className="flex gap-x-1" key={label}>
                   <Checkbox
                     onCheckedChange={state => setFailingChangeTypes(types, state)}
                     checked={checked}
@@ -2366,7 +2397,10 @@ function DangerousChangeTypeForm({
         </div>
       </div>
       <div className="flex flex-row items-center gap-5">
-        <Button type="submit" disabled={formik.isSubmitting || !considerDangerousAsBreaking}>
+        <Button
+          type="submit"
+          disabled={formik.isSubmitting || !considerDangerousAsBreaking || !formik.dirty}
+        >
           Save selections
         </Button>
         {formik.dirty && <UnsavedChangesLabel />}
@@ -2383,6 +2417,13 @@ function DangerousChangeTypeForm({
             : formik.errors.failingChangeTypes}
         </span>
       </div>
+      {formik.status?.error ? (
+        <div className="flex flex-row items-center gap-1 p-2 text-red-600 dark:text-red-400">
+          <XIcon className="size-4" />
+          <span className="font-semibold">{formik.status.error.title}</span>
+          <span>{formik.status.error.description}</span>
+        </div>
+      ) : null}
     </form>
   );
 }

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -1,4 +1,12 @@
-import { ComponentProps, PropsWithoutRef, useCallback, useMemo, useState } from 'react';
+import {
+  ComponentProps,
+  PropsWithoutRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import clsx from 'clsx';
 import { formatISO } from 'date-fns';
 import { useFormik } from 'formik';
@@ -49,12 +57,17 @@ import { graphql, useFragment } from '@/gql';
 import {
   AppDeploymentProtectionRuleLogicType,
   BreakingChangeFormulaType,
+  DangerousChangeType,
   ProjectType,
 } from '@/gql/graphql';
 import { useRedirect } from '@/lib/access/common';
 import { subDays } from '@/lib/date-time';
 import { useToggle } from '@/lib/hooks';
+import { useTimed } from '@/lib/hooks/use-timed';
+import { cn } from '@/lib/utils';
+import type { TypeOfChangeType } from '@graphql-inspector/core';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { CheckIcon } from '@radix-ui/react-icons';
 import { RadioGroupIndicator } from '@radix-ui/react-radio-group';
 import { Link, useRouter } from '@tanstack/react-router';
 
@@ -494,6 +507,8 @@ const TargetSettingsPage_TargetSettingsQuery = graphql(`
     target(reference: { bySelector: $selector }) {
       id
       failDiffOnDangerousChange
+      failAllDangerousChanges
+      failDangerousChangeTypes
       conditionalBreakingChangeConfiguration {
         ...TargetSettings_ConditionalBreakingChangeConfigurationFragment
       }
@@ -755,7 +770,6 @@ const BreakingChanges = (props: {
                   Learn more
                 </DocsLink>
                 <br />
-                <br />
               </CardDescription>
             </>
           }
@@ -790,6 +804,16 @@ const BreakingChanges = (props: {
               dangerousAsBreaking.error.message}
           </span>
         )}
+        <DangerousChangeTypeForm
+          considerDangerousAsBreaking={considerDangerousAsBreaking}
+          initialFailAllDangerousChanges={
+            targetSettings.data?.target?.failAllDangerousChanges ?? true
+          }
+          initialFailingChangeTypes={targetSettings.data?.target?.failDangerousChangeTypes ?? []}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
+        />
       </SubPageLayout>
       <form onSubmit={handleSubmit}>
         <SubPageLayout>
@@ -1059,7 +1083,7 @@ const BreakingChanges = (props: {
             {touched.targetIds && errors.targetIds && (
               <div className="text-red-500">{errors.targetIds}</div>
             )}
-            <div className="border-l-neutral-5 bg-neutral-8/10 text-neutral-10 mb-3 mt-5 space-y-2 rounded-sm border-l-2 py-2 pl-5">
+            <div className="border-neutral-5 bg-neutral-8/10 text-neutral-10 mb-3 mt-5 space-y-2 rounded-sm border py-2 pl-5">
               <div>
                 <div className="font-semibold">Example settings</div>
                 <div className="text-sm">Removal of a field is considered breaking if</div>
@@ -2091,3 +2115,344 @@ export function DeleteTargetModalContent(props: {
     </Dialog>
   );
 }
+
+export const TargetSettingsPage_UpdateFailingDangerousChangeSettings = graphql(`
+  mutation TargetSettingsPage_UpdateFailingDangerousChangeSettings(
+    $selector: TargetSelectorInput!
+    $failAllDangerousChanges: Boolean!
+    $failingChangeTypes: [DangerousChangeType!]!
+  ) {
+    updateTargetFailingDangerousChanges(
+      input: {
+        target: { bySelector: $selector }
+        all: $failAllDangerousChanges
+        failingTypes: $failingChangeTypes
+      }
+    ) {
+      ok {
+        target {
+          id
+          failAllDangerousChanges
+          failDangerousChangeTypes
+        }
+      }
+      error {
+        message
+      }
+    }
+  }
+`);
+
+const dangerousChangeList = (
+  [
+    { label: 'INPUT_FIELD_DEFAULT_VALUE_CHANGED', types: ['INPUT_FIELD_DEFAULT_VALUE_CHANGED'] },
+    { label: 'INPUT_FIELD_ADDED', types: ['INPUT_FIELD_ADDED'] },
+    { label: 'OBJECT_TYPE_INTERFACE_ADDED', types: ['OBJECT_TYPE_INTERFACE_ADDED'] },
+    { label: 'UNION_MEMBER_ADDED', types: ['UNION_MEMBER_ADDED'] },
+    { label: 'FIELD_ARGUMENT_ADDED', types: ['FIELD_ARGUMENT_ADDED'] },
+    { label: 'FIELD_ARGUMENT_DEFAULT_CHANGED', types: ['FIELD_ARGUMENT_DEFAULT_CHANGED'] },
+    { label: 'ENUM_VALUE_ADDED', types: ['ENUM_VALUE_ADDED'] },
+    {
+      label: 'DIRECTIVE_USAGE_<KIND>_ADDED',
+      types: [
+        'DIRECTIVE_USAGE_ARGUMENT_ADDED',
+        'DIRECTIVE_USAGE_ARGUMENT_DEFINITION_ADDED',
+        'DIRECTIVE_USAGE_ENUM_ADDED',
+        'DIRECTIVE_USAGE_FIELD_ADDED',
+        'DIRECTIVE_USAGE_FIELD_DEFINITION_ADDED',
+        'DIRECTIVE_USAGE_INPUT_FIELD_DEFINITION_ADDED',
+        'DIRECTIVE_USAGE_OBJECT_ADDED',
+        'DIRECTIVE_USAGE_SCALAR_ADDED',
+        'DIRECTIVE_USAGE_SCHEMA_ADDED',
+        'DIRECTIVE_USAGE_UNION_MEMBER_ADDED',
+      ],
+    },
+    {
+      label: 'DIRECTIVE_USAGE_<KIND>_REMOVED',
+      types: [
+        'DIRECTIVE_USAGE_ARGUMENT_REMOVED',
+        'DIRECTIVE_USAGE_ARGUMENT_DEFINITION_REMOVED',
+        'DIRECTIVE_USAGE_ENUM_REMOVED',
+        'DIRECTIVE_USAGE_FIELD_REMOVED',
+        'DIRECTIVE_USAGE_FIELD_DEFINITION_REMOVED',
+        'DIRECTIVE_USAGE_INPUT_FIELD_DEFINITION_REMOVED',
+        'DIRECTIVE_USAGE_OBJECT_REMOVED',
+        'DIRECTIVE_USAGE_SCALAR_REMOVED',
+        'DIRECTIVE_USAGE_SCHEMA_REMOVED',
+        'DIRECTIVE_USAGE_UNION_MEMBER_REMOVED',
+      ],
+    },
+    {
+      label: 'DIRECTIVE_ARGUMENT_DEFAULT_VALUE_CHANGED',
+      types: ['DIRECTIVE_ARGUMENT_DEFAULT_VALUE_CHANGED'],
+    },
+    { label: 'DIRECTIVE_REPEATABLE_REMOVED', types: ['DIRECTIVE_REPEATABLE_REMOVED'] },
+  ] as { label: string; types: DangerousChangeType[] }[]
+).sort((a, b) => a.label.localeCompare(b.label));
+
+function DangerousChangeTypeForm({
+  considerDangerousAsBreaking,
+  initialFailingChangeTypes,
+  initialFailAllDangerousChanges,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
+}: {
+  considerDangerousAsBreaking: boolean;
+  initialFailingChangeTypes: DangerousChangeType[];
+  initialFailAllDangerousChanges: boolean;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
+}) {
+  const [mutation, mutate] = useMutation(TargetSettingsPage_UpdateFailingDangerousChangeSettings);
+  const { saveStatus, triggerSaveMessage } = useSaveStatus();
+
+  const formik = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      failingChangeTypes: initialFailingChangeTypes,
+      failAllDangerousChanges: initialFailAllDangerousChanges,
+    } as { failingChangeTypes: DangerousChangeType[]; failAllDangerousChanges: boolean },
+    validationSchema: Yup.object().shape({
+      failAllDangerousChanges: Yup.bool().label('Fail all'),
+      failingChangeTypes: Yup.array(Yup.string())
+        .when('failAllDangerousChanges', {
+          is: true,
+          then: schema => schema.notRequired(),
+          otherwise: schema => schema.min(1),
+        })
+        .label('Failing types'),
+    }),
+    onSubmit: ({ failingChangeTypes, failAllDangerousChanges }, { setSubmitting }) =>
+      mutate({
+        selector: {
+          organizationSlug,
+          projectSlug,
+          targetSlug,
+        },
+        failingChangeTypes: Array.isArray(failingChangeTypes)
+          ? failingChangeTypes
+          : [failingChangeTypes],
+        failAllDangerousChanges,
+      }).then(() => {
+        setSubmitting(false);
+        triggerSaveMessage();
+      }),
+  });
+
+  const setFailAllDangerousChanges = (val: boolean) => {
+    formik.setFieldValue('failAllDangerousChanges', val);
+  };
+
+  /** Allows adding or removing multiple change types from the list of failing change types */
+  const setFailingChangeTypes = (types: DangerousChangeType[], checked: boolean) => {
+    const set = new Set(formik.values.failingChangeTypes);
+    if (checked) {
+      for (const type of types) {
+        set.add(type);
+      }
+    } else {
+      for (const type of types) {
+        set.delete(type);
+      }
+    }
+    formik.setFieldValue('failingChangeTypes', Array.from(set));
+  };
+
+  return (
+    <form
+      onSubmit={formik.handleSubmit}
+      className={cn(
+        'opacity-100 transition-opacity duration-150',
+        !considerDangerousAsBreaking && 'opacity-50',
+      )}
+    >
+      <div className="border-neutral-5 bg-neutral-8/10 text-neutral-10 mb-3 block w-auto max-w-4xl rounded-sm border px-5 py-3">
+        <div className="text-neutral-12 mb-3 mt-1 font-semibold">
+          Select Failing Dangerous Change Types
+        </div>
+        <div className="align-center flex gap-1 whitespace-nowrap border-b">
+          <Checkbox
+            disabled={!considerDangerousAsBreaking}
+            checked={formik.values.failAllDangerousChanges}
+            onCheckedChange={setFailAllDangerousChanges}
+          />
+          <span
+            onClick={() => {
+              if (considerDangerousAsBreaking) {
+                setFailAllDangerousChanges(!formik.values.failAllDangerousChanges);
+              }
+            }}
+            className={cn(
+              'mb-3',
+              formik.values.failAllDangerousChanges && considerDangerousAsBreaking
+                ? 'text-neutral-12'
+                : 'text-neutral-10',
+              !considerDangerousAsBreaking
+                ? 'pointer-events-none cursor-not-allowed'
+                : 'hover:text-neutral-12 cursor-default',
+            )}
+          >
+            Fail All Dangerous Changes
+          </span>
+          <span
+            className={cn(
+              'grow pl-4',
+              formik.values.failAllDangerousChanges ===
+                formik.initialValues.failAllDangerousChanges && 'hidden',
+            )}
+          >
+            <PendingIndicator />
+          </span>
+          <span className="text-red-400">{formik.errors.failAllDangerousChanges}</span>
+        </div>
+        <div className="my-3">or fail only:</div>
+        <div className="grid grid-cols-1 gap-1 gap-2 lg:grid-cols-2">
+          {dangerousChangeList.map(
+            ({
+              /**
+               * Text label representing one or many dangerous change types that can be added or removed from
+               * the selection.
+               */
+              label,
+              /**
+               * One or many dangerous change types that can be toggled to be included or excluded from the check.
+               */
+              types,
+            }) => {
+              function isTypesIncluded(failingChangeTypes: DangerousChangeType[]) {
+                return types.every(type => failingChangeTypes.includes(type));
+              }
+
+              // @NOTE only check isTypesIncluded and not whether or not this is checked to avoid showing a changed indicator on individual types
+              // when toggling the select all.
+              const isFieldChanged =
+                formik.values.failAllDangerousChanges === false &&
+                isTypesIncluded(formik.values.failingChangeTypes) !==
+                  isTypesIncluded(formik.initialValues.failingChangeTypes);
+
+              const checked =
+                formik.values.failAllDangerousChanges ||
+                isTypesIncluded(formik.values.failingChangeTypes);
+              const disabled =
+                !considerDangerousAsBreaking || formik.values.failAllDangerousChanges;
+              return (
+                <div className="align-center flex gap-x-1" key={label}>
+                  <Checkbox
+                    onCheckedChange={state => setFailingChangeTypes(types, state)}
+                    checked={checked}
+                    disabled={disabled}
+                  />
+                  <span
+                    onClick={() => setFailingChangeTypes(types, !checked)}
+                    className={cn(
+                      'truncate',
+                      checked && !disabled ? 'text-neutral-12' : 'text-neutral-10',
+                      disabled
+                        ? 'pointer-events-none cursor-not-allowed'
+                        : 'hover:text-neutral-12 cursor-default',
+                    )}
+                  >
+                    {label}
+                  </span>
+                  <span className={cn('grow pr-4 text-right', !isFieldChanged && 'hidden')}>
+                    <PendingIndicator />
+                  </span>
+                </div>
+              );
+            },
+          )}
+        </div>
+      </div>
+      <div className="flex flex-row items-center gap-5">
+        <Button type="submit" disabled={formik.isSubmitting || !considerDangerousAsBreaking}>
+          Save selections
+        </Button>
+        {formik.dirty && <UnsavedChangesLabel />}
+        {!formik.dirty && saveStatus === SaveStatus.SAVED && <SavedLabel />}
+        {!formik.dirty && saveStatus === SaveStatus.JUST_SAVED && <JustSavedLabel />}
+        <span
+          className={cn(
+            'text-red-600 dark:text-red-400',
+            !formik.errors.failingChangeTypes && 'hidden',
+          )}
+        >
+          {Array.isArray(formik.errors.failingChangeTypes)
+            ? formik.errors.failingChangeTypes.join(', ')
+            : formik.errors.failingChangeTypes}
+        </span>
+      </div>
+    </form>
+  );
+}
+
+function JustSavedLabel() {
+  return (
+    <div className="inline-flex flex-row items-center gap-1 italic text-green-700 subpixel-antialiased dark:text-green-500">
+      <JustSavedIndicator />
+      <span>Saved just now</span>
+    </div>
+  );
+}
+
+function JustSavedIndicator() {
+  return <CheckIcon className="size-5 text-green-700 dark:text-green-500" />;
+}
+
+function SavedLabel() {
+  return (
+    <div className="text-neutral-10 inline-flex flex-row items-center gap-1 italic subpixel-antialiased">
+      <SavedIndicator />
+      <span>All changes saved</span>
+    </div>
+  );
+}
+
+function SavedIndicator() {
+  return <CheckIcon className="text-neutral-10 size-5" />;
+}
+
+function UnsavedChangesLabel() {
+  return (
+    <div className="inline-flex flex-row items-center gap-2 italic text-yellow-600 subpixel-antialiased dark:text-yellow-400">
+      <PendingIndicator />
+      <span>Unsaved changes</span>
+    </div>
+  );
+}
+
+function PendingIndicator() {
+  return <span className="inline-block size-2 rounded-full bg-yellow-600 dark:bg-yellow-400" />;
+}
+
+enum SaveStatus {
+  JUST_SAVED = 'JUST_SAVED',
+  SAVED = 'SAVED',
+}
+
+export const useSaveStatus = () => {
+  const [saveStatus, setSaveStatus] = useState<SaveStatus | null>();
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const triggerSaveMessage = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    setSaveStatus(SaveStatus.JUST_SAVED);
+
+    timerRef.current = setTimeout(() => {
+      setSaveStatus(SaveStatus.SAVED);
+    }, 5000);
+  };
+
+  // Cleanup timer if the component unmounts
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return { saveStatus, triggerSaveMessage };
+};


### PR DESCRIPTION
### Background

Dangerous changes can be situational based on a team's accepted risk and deployment process.

### Description

This introduces a new configuration option which allows selecting individual change types.

https://github.com/user-attachments/assets/e89e5ac1-5bbc-426c-b9cc-d85f9f06f2b4
