### PR TITLE
fix: improve filter dropdown list height

### DIFF
--- a/CONTRIBUTION_README.md
+++ b/CONTRIBUTION_README.md
@@ -3,7 +3,7 @@
 **Contribution Number:** 1
 **Student:** Qimin Wu
 **Issue:** https://github.com/graphql-hive/console/issues/3816
-**Status:** Phase I Complete
+**Status:** Phase IV Complete (Pull Request Submitted)
 
 ---
 
@@ -210,7 +210,7 @@ The build completed successfully. All packages built successfully and no build f
 
 ## Implementation Notes
 
-### Week 3 Progress (Phase III)
+### Phase III Implementation
 
 #### What I Built
 
@@ -255,7 +255,7 @@ maxHeight: 'min(384px, calc(100vh - 220px))'
 3. Updated scrolling behavior to use vertical scrolling:
 
 ```ts
-overflowY: 'auto'
+overflow: 'auto'
 ```
 
 These changes are intended to allow longer operation lists to remain visible while preventing the dropdown from extending beyond the browser viewport.
@@ -292,6 +292,21 @@ Another challenge was setting up the local development environment because this 
 packages/web/app/src/components/base/floating/filter-dropdown/filter-content.tsx
 ```
 
+### Changes Made
+
+* Increased the maximum dropdown list height from **256px** to **384px**.
+* Added a responsive maximum height:
+
+```ts
+maxHeight: 'min(384px, calc(100vh - 220px))'
+```
+
+* Kept the existing scrolling behavior using:
+
+```ts
+overflow: 'auto'
+```
+
 ### Key Commit
 
 ```text
@@ -306,9 +321,52 @@ fix: improve filter dropdown list height
 
 ### Working Branch
 
-```text
 https://github.com/Qimin5/console/tree/fix-issue-3816
+
+---
+
+## Pull Request
+
+### PR Link
+
+https://github.com/graphql-hive/console/pull/8176
+
+### PR Title
+
+fix: improve filter dropdown list height
+
+### PR Summary
+
+This pull request addresses Issue #3816 by improving the operation filter dropdown height and scrolling behavior.
+
+The implementation:
+
+* Increased the maximum dropdown height.
+* Added a viewport-aware maximum height.
+* Preserved the existing scrolling behavior.
+
+The goal is to prevent long operation lists from being cut off while keeping the dropdown usable on different screen sizes.
+
+### Testing Performed
+
+* Successfully ran:
+
+```bash
+pnpm build
 ```
+
+* Started Hive locally.
+* Logged into the application.
+* Verified the application loaded correctly.
+* Confirmed the project builds successfully after my code changes.
+
+### Status
+
+Awaiting maintainer review.
+
+### Maintainer Feedback
+
+No maintainer feedback received yet.
 
 ---
 
@@ -317,10 +375,11 @@ https://github.com/Qimin5/console/tree/fix-issue-3816
 ### Technical Skills Gained
 
 * Learned how to clone and set up a large open-source project locally.
-* Learned how to use Git branches, commits, and pushes.
+* Learned how to use Git branches, commits, pushes, and pull requests.
 * Learned how to navigate a React and TypeScript codebase.
 * Learned how shared UI components are structured in a large application.
 * Learned how to investigate frontend layout and overflow issues.
+* Learned how to submit my first open-source pull request on GitHub.
 
 ### Challenges Overcome
 
@@ -328,7 +387,14 @@ https://github.com/Qimin5/console/tree/fix-issue-3816
 * Understanding the project structure.
 * Tracing the operation filter through multiple component layers.
 * Successfully building the project and pushing code changes to GitHub.
+* Learning how the GitHub pull request workflow works for an open-source project.
 
-### Current Status
+## Current Status
 
-Phase III implementation completed. Code changes have been committed, pushed to the feature branch, and successfully built locally.
+Phase IV completed.
+
+The code changes were committed, pushed to my feature branch, and submitted as Pull Request #8176 for review by the Hive maintainers.
+
+**Pull Request:** https://github.com/graphql-hive/console/pull/8176
+
+I am currently waiting for feedback from the project maintainers and will update the pull request if changes are requested.

--- a/CONTRIBUTION_README.md
+++ b/CONTRIBUTION_README.md
@@ -181,3 +181,154 @@ Review similar dropdowns, dialogs, and filter components in the Hive application
 5. Verify that all operation entries remain accessible.
 6. Test the fix on different screen sizes and browser window heights.
 7. Run any relevant tests before creating a pull request.
+## Testing Strategy
+
+### Build Verification
+
+After making the code changes, I ran:
+
+```bash
+pnpm build
+```
+
+The build completed successfully. All packages built successfully and no build failures were reported.
+
+### Manual Testing
+
+* Started Hive locally using the development environment.
+* Logged into the local Hive application.
+* Navigated to the Insights page.
+* Investigated the operation filter dropdown implementation.
+* Verified that the modified component builds successfully and renders without errors.
+
+### Regression Checks
+
+* Confirmed that the project still compiles successfully after the change.
+* Verified that no new TypeScript or build errors were introduced.
+
+---
+
+## Implementation Notes
+
+### Week 3 Progress (Phase III)
+
+#### What I Built
+
+I investigated Issue #3816, "Operation Filter List on Insights Page Is Cut Off at the Bottom."
+
+Using the codebase search tools and project structure, I traced the operation filter implementation through the following components:
+
+* `use-insights-filter-dimensions.ts`
+* `filter-menu.tsx`
+* `filter-content.tsx`
+
+After reviewing the filter rendering logic, I identified a height restriction that may contribute to the dropdown list being cut off when many operation items are displayed.
+
+#### Code Changes
+
+Modified:
+
+```text
+packages/web/app/src/components/base/floating/filter-dropdown/filter-content.tsx
+```
+
+Changes made:
+
+1. Increased the maximum dropdown list height:
+
+```ts
+const MAX_LIST_HEIGHT = 256;
+```
+
+to:
+
+```ts
+const MAX_LIST_HEIGHT = 384;
+```
+
+2. Added viewport-aware maximum height handling:
+
+```ts
+maxHeight: 'min(384px, calc(100vh - 220px))'
+```
+
+3. Updated scrolling behavior to use vertical scrolling:
+
+```ts
+overflowY: 'auto'
+```
+
+These changes are intended to allow longer operation lists to remain visible while preventing the dropdown from extending beyond the browser viewport.
+
+#### Challenges Faced
+
+The biggest challenge was understanding the Hive codebase structure and locating the component responsible for rendering the operation filter.
+
+Initially, I examined the Insights page filter configuration files and discovered they only defined filter metadata rather than the actual dropdown UI. I then traced the component hierarchy through several shared UI components until locating the dropdown implementation in:
+
+```text
+packages/web/app/src/components/base/floating/filter-dropdown/filter-content.tsx
+```
+
+Another challenge was setting up the local development environment because this was my first time working with a large open-source project using Node.js, pnpm, Docker, and Turborepo.
+
+#### Tools Used
+
+* GitHub Issues
+* VS Code
+* Git
+* Node.js
+* pnpm
+* Docker Desktop
+* Hive local development environment
+
+---
+
+## Code Changes
+
+### Files Modified
+
+```text
+packages/web/app/src/components/base/floating/filter-dropdown/filter-content.tsx
+```
+
+### Key Commit
+
+```text
+da22dc656
+```
+
+Commit message:
+
+```text
+fix: improve filter dropdown list height
+```
+
+### Working Branch
+
+```text
+https://github.com/Qimin5/console/tree/fix-issue-3816
+```
+
+---
+
+## Learnings & Reflections
+
+### Technical Skills Gained
+
+* Learned how to clone and set up a large open-source project locally.
+* Learned how to use Git branches, commits, and pushes.
+* Learned how to navigate a React and TypeScript codebase.
+* Learned how shared UI components are structured in a large application.
+* Learned how to investigate frontend layout and overflow issues.
+
+### Challenges Overcome
+
+* Setting up Node.js, pnpm, and Docker correctly.
+* Understanding the project structure.
+* Tracing the operation filter through multiple component layers.
+* Successfully building the project and pushing code changes to GitHub.
+
+### Current Status
+
+Phase III implementation completed. Code changes have been committed, pushed to the feature branch, and successfully built locally.

--- a/CONTRIBUTION_README.md
+++ b/CONTRIBUTION_README.md
@@ -1,0 +1,224 @@
+## Reproduction Process
+
+### Environment Setup
+
+I cloned the GraphQL Hive repository locally and set up the development environment on macOS.
+
+Commands and setup steps completed:
+
+```bash
+git clone https://github.com/Qimin5/console.git
+cd console
+```
+
+Installed Node.js using nvm:
+
+```bash
+nvm install 24
+nvm use 24
+node -v
+```
+
+Node version used:
+
+```bash
+v24.16.0
+```
+
+Installed pnpm using Corepack:
+
+```bash
+corepack enable
+corepack prepare pnpm@latest --activate
+pnpm -v
+```
+
+pnpm version used:
+
+```bash
+10.33.2
+```
+
+Installed Docker Desktop and verified Docker:
+
+```bash
+docker --version
+```
+
+Docker version used:
+
+```bash
+Docker version 29.5.3
+```
+
+Created the required local `.env` file:
+
+```bash
+echo "ENVIRONMENT=local" > .env
+```
+
+Installed dependencies:
+
+```bash
+pnpm i
+```
+
+Started local Docker dependencies and ran database migrations:
+
+```bash
+pnpm local:setup
+```
+
+Generated required GraphQL and database types:
+
+```bash
+pnpm generate
+```
+
+Built the project:
+
+```bash
+pnpm build
+```
+
+Started the local Hive development environment:
+
+```bash
+pnpm dev:hive
+```
+
+Opened the local app at:
+
+```text
+http://localhost:3000
+```
+
+I created a local user account, organization, project, and target. I was able to reach the target
+Insights page locally.
+
+### Branch Link
+
+```text
+https://github.com/Qimin5/console/tree/fix-issue-3816
+```
+
+### Issue
+
+GitHub issue:
+
+```text
+#3816 - operation filter list on insights page is cut off at the bottom
+```
+
+### Steps to Reproduce
+
+1. Start the local Hive development environment:
+
+```bash
+pnpm dev:hive
+```
+
+2. Open the local Hive app:
+
+```text
+http://localhost:3000
+```
+
+3. Sign in or create a local account.
+
+4. Create or open an organization.
+
+5. Create or open a project.
+
+6. Select a target, such as:
+
+```text
+production
+```
+
+7. Open the **Insights** page.
+
+8. Ensure the target has many operations available. The issue screenshot shows the operation filter
+   modal with many operation names.
+
+9. Click the **Operations** filter.
+
+10. Open the **Filter by operation** list/modal.
+
+11. Observe the operation list.
+
+### Expected Behavior
+
+The operation list should be fully scrollable. A user should be able to access all operation items,
+including the items at the bottom of the list.
+
+### Actual Behavior
+
+When many operations are shown, the operation filter list overflows and gets cut off at the bottom.
+Some operations are not visible or accessible.
+
+---
+
+## Solution Approach
+
+### Understand
+
+The bug is a UI overflow issue on the Insights page. The **Filter by operation** modal/list can
+contain many operations. When the list is long, the modal does not constrain the list height
+correctly, so the bottom of the list is cut off.
+
+### Match
+
+I will compare this modal with other Hive UI components that display scrollable lists, filters,
+dialogs, or modals. I will look for existing patterns using fixed height, max height, overflow
+behavior, or scrollable containers.
+
+### Plan
+
+1. Locate the frontend component responsible for the Insights operation filter.
+2. Inspect the modal/list layout.
+3. Check whether the operation list container has correct height or max-height styling.
+4. Check whether the scroll behavior is applied to the correct container.
+5. Add or adjust styling so the operation list is constrained and vertically scrollable.
+6. Verify that all operation items can be reached when many operations are present.
+7. Test the modal on different browser/window heights.
+
+### Files to Investigate
+
+Initial files found during investigation:
+
+```text
+packages/web/app/src/pages/target-insights.tsx
+packages/web/app/src/components/target/insights/use-insights-filter-dimensions.ts
+packages/web/app/src/components/target/insights/search-params.ts
+packages/web/app/src/components/target/insights/list.tsx
+packages/web/app/src/pages/target-insights-manage-filters.tsx
+```
+
+The likely fix is in the frontend Insights filter UI, not in the backend resolver or GraphQL tests.
+
+### Implement
+
+Implementation will happen in Phase III on my working branch:
+
+```text
+fix-issue-3816
+```
+
+### Review
+
+I will review the project’s contributing and development documentation before opening a pull
+request. I will make sure the fix follows the existing React, TypeScript, and styling patterns used
+in the Hive dashboard.
+
+### Evaluate
+
+To verify the fix:
+
+1. Start Hive locally.
+2. Open a target with many operations.
+3. Go to the Insights page.
+4. Open the operation filter modal.
+5. Confirm the operation list scrolls correctly.
+6. Confirm no items are cut off at the bottom.
+7. Run relevant checks or tests if available.

--- a/CONTRIBUTION_README.md
+++ b/CONTRIBUTION_README.md
@@ -1,191 +1,154 @@
+# Contribution 1: Operation Filter List on Insights Page Is Cut Off at the Bottom
+
+**Contribution Number:** 1
+**Student:** Qimin Wu
+**Issue:** https://github.com/graphql-hive/console/issues/3816
+**Status:** Phase I Complete
+
+---
+
+## Why I Chose This Issue
+
+I chose this issue because it is a beginner-friendly bug with a clear problem and expected result. The issue affects the user interface, which matches my interest in JavaScript, HTML, and CSS. I also wanted to gain experience contributing to an open-source project and learn how to investigate and fix a real bug in a production application.
+
+Another reason I chose this issue is that the scope appears manageable for a first contribution. The issue description clearly explains the problem, and the project maintainers labeled it as a good first issue. I hope to learn more about debugging frontend issues, understanding a larger codebase, and working through the open-source contribution process.
+
+---
+
+## Understanding the Issue
+
+### Problem Description
+
+On the Insights page, the operation filter dropdown list is cut off at the bottom. Because of this, users cannot see all available items in the filter list.
+
+### Expected Behavior
+
+The operation filter dropdown should display all available items. If the list is longer than the available space, users should be able to scroll and access every option.
+
+### Current Behavior
+
+Part of the dropdown list is hidden because of an overflow or layout issue. Some items cannot be seen or selected.
+
+### Affected Components
+
+Based on the issue description, the affected components are likely the Insights page UI, the operation filter dropdown component, and the related CSS styling that controls layout, height, and overflow behavior.
+
+---
+
 ## Reproduction Process
 
 ### Environment Setup
 
-I cloned the GraphQL Hive repository locally and set up the development environment on macOS.
+I cloned the GraphQL Hive repository and set up the development environment on my MacBook.
 
-Commands and setup steps completed:
+Steps completed:
 
-```bash
-git clone https://github.com/Qimin5/console.git
-cd console
-```
+1. Cloned the repository:
 
-Installed Node.js using nvm:
+   ```bash
+   git clone https://github.com/Qimin5/console.git
+   cd console
+   ```
 
-```bash
-nvm install 24
-nvm use 24
-node -v
-```
+2. Installed Node.js v24.16.0 using nvm.
 
-Node version used:
+3. Installed pnpm v10.33.2 using Corepack.
 
-```bash
-v24.16.0
-```
+4. Installed Docker Desktop and verified Docker was running.
 
-Installed pnpm using Corepack:
+5. Created a local environment file:
 
-```bash
-corepack enable
-corepack prepare pnpm@latest --activate
-pnpm -v
-```
+   ```bash
+   echo "ENVIRONMENT=local" > .env
+   ```
 
-pnpm version used:
+6. Installed project dependencies:
 
-```bash
-10.33.2
-```
+   ```bash
+   pnpm i
+   ```
 
-Installed Docker Desktop and verified Docker:
+7. Started local services and databases:
 
-```bash
-docker --version
-```
+   ```bash
+   pnpm local:setup
+   ```
 
-Docker version used:
+8. Generated required files:
 
-```bash
-Docker version 29.5.3
-```
+   ```bash
+   pnpm generate
+   ```
 
-Created the required local `.env` file:
+9. Built the project:
 
-```bash
-echo "ENVIRONMENT=local" > .env
-```
+   ```bash
+   pnpm build
+   ```
 
-Installed dependencies:
+10. Started the application:
 
-```bash
-pnpm i
-```
+    ```bash
+    pnpm dev:hive
+    ```
 
-Started local Docker dependencies and ran database migrations:
+11. Opened the application at:
 
-```bash
-pnpm local:setup
-```
+    ```text
+    http://localhost:3000
+    ```
 
-Generated required GraphQL and database types:
-
-```bash
-pnpm generate
-```
-
-Built the project:
-
-```bash
-pnpm build
-```
-
-Started the local Hive development environment:
-
-```bash
-pnpm dev:hive
-```
-
-Opened the local app at:
-
-```text
-http://localhost:3000
-```
-
-I created a local user account, organization, project, and target. I was able to reach the target
-Insights page locally.
-
-### Branch Link
-
-```text
-https://github.com/Qimin5/console/tree/fix-issue-3816
-```
-
-### Issue
-
-GitHub issue:
-
-```text
-#3816 - operation filter list on insights page is cut off at the bottom
-```
+12. Created a local account, organization, project, and target to access the Insights page.
 
 ### Steps to Reproduce
 
-1. Start the local Hive development environment:
+1. Start the Hive application locally:
 
-```bash
-pnpm dev:hive
-```
+   ```bash
+   pnpm dev:hive
+   ```
 
-2. Open the local Hive app:
+2. Open the application in a browser:
 
-```text
-http://localhost:3000
-```
+   ```text
+   http://localhost:3000
+   ```
 
-3. Sign in or create a local account.
+3. Sign in and open a project target.
 
-4. Create or open an organization.
+4. Navigate to the **Insights** page.
 
-5. Create or open a project.
+5. Open the **Operation Filter** dropdown.
 
-6. Select a target, such as:
+6. When many operations are available, observe the operation list.
 
-```text
-production
-```
+### Reproduction Evidence
 
-7. Open the **Insights** page.
+**Working Branch:**
+https://github.com/Qimin5/console/tree/fix-issue-3816
 
-8. Ensure the target has many operations available. The issue screenshot shows the operation filter
-   modal with many operation names.
+**Screenshots:**
 
-9. Click the **Operations** filter.
+1. Local Hive application successfully running on localhost and displaying the Insights page.
 
-10. Open the **Filter by operation** list/modal.
+    <img width="1379" height="832" alt="Screenshot 2026-06-11 at 2 21 54 PM" src="https://github.com/user-attachments/assets/ecde9905-8c06-477d-b593-88b0a2bed9d2" />
 
-11. Observe the operation list.
+2. Screenshot from GitHub issue #3816 demonstrating the operation filter overflow problem.
 
-### Expected Behavior
+ <img width="845" height="1332" alt="297354689-1b7188a6-72b7-45dc-8b85-adb7e9c36f3e" src="https://github.com/user-attachments/assets/b642a55b-59aa-4545-9f65-cc172f91e24e" />
 
-The operation list should be fully scrollable. A user should be able to access all operation items,
-including the items at the bottom of the list.
 
-### Actual Behavior
+**My Findings:**
 
-When many operations are shown, the operation filter list overflows and gets cut off at the bottom.
-Some operations are not visible or accessible.
-
----
+The operation filter dropdown appears to overflow its container when a large number of operations are present. As a result, some items near the bottom of the list become hidden and inaccessible. The issue appears to be related to the frontend layout, height constraints, or scrolling behavior of the filter component.
 
 ## Solution Approach
 
-### Understand
+### Analysis
 
-The bug is a UI overflow issue on the Insights page. The **Filter by operation** modal/list can
-contain many operations. When the list is long, the modal does not constrain the list height
-correctly, so the bottom of the list is cut off.
+Based on the issue description and investigation of the codebase, this appears to be a frontend layout and overflow issue. The operation filter list is likely missing proper height constraints or scroll behavior. The issue is probably located in the Insights page filter UI rather than the backend API.
 
-### Match
-
-I will compare this modal with other Hive UI components that display scrollable lists, filters,
-dialogs, or modals. I will look for existing patterns using fixed height, max height, overflow
-behavior, or scrollable containers.
-
-### Plan
-
-1. Locate the frontend component responsible for the Insights operation filter.
-2. Inspect the modal/list layout.
-3. Check whether the operation list container has correct height or max-height styling.
-4. Check whether the scroll behavior is applied to the correct container.
-5. Add or adjust styling so the operation list is constrained and vertically scrollable.
-6. Verify that all operation items can be reached when many operations are present.
-7. Test the modal on different browser/window heights.
-
-### Files to Investigate
-
-Initial files found during investigation:
+During investigation, I identified several files related to the Insights filtering system:
 
 ```text
 packages/web/app/src/pages/target-insights.tsx
@@ -195,30 +158,26 @@ packages/web/app/src/components/target/insights/list.tsx
 packages/web/app/src/pages/target-insights-manage-filters.tsx
 ```
 
-The likely fix is in the frontend Insights filter UI, not in the backend resolver or GraphQL tests.
+### Proposed Solution
 
-### Implement
+Update the operation filter dropdown so that it properly handles large lists. The dropdown should have a constrained height and allow vertical scrolling when the number of operations exceeds the available space.
 
-Implementation will happen in Phase III on my working branch:
+### Implementation Plan
 
-```text
-fix-issue-3816
-```
+Using UMPIRE framework (adapted):
 
-### Review
+**Understand:**
+The operation filter dropdown does not properly display long lists of operations. Users cannot access items near the bottom of the list.
 
-I will review the project’s contributing and development documentation before opening a pull
-request. I will make sure the fix follows the existing React, TypeScript, and styling patterns used
-in the Hive dashboard.
+**Match:**
+Review similar dropdowns, dialogs, and filter components in the Hive application to identify existing scrolling and overflow patterns.
 
-### Evaluate
+**Plan:**
 
-To verify the fix:
-
-1. Start Hive locally.
-2. Open a target with many operations.
-3. Go to the Insights page.
-4. Open the operation filter modal.
-5. Confirm the operation list scrolls correctly.
-6. Confirm no items are cut off at the bottom.
-7. Run relevant checks or tests if available.
+1. Locate the component responsible for rendering the operation filter.
+2. Inspect the layout and styling for height and overflow behavior.
+3. Identify the container causing the content to be clipped.
+4. Add or adjust scrolling behavior and maximum height constraints.
+5. Verify that all operation entries remain accessible.
+6. Test the fix on different screen sizes and browser window heights.
+7. Run any relevant tests before creating a pull request.

--- a/packages/web/app/src/components/base/floating/filter-dropdown/filter-content.tsx
+++ b/packages/web/app/src/components/base/floating/filter-dropdown/filter-content.tsx
@@ -6,7 +6,7 @@ import { ItemRow } from './item-row';
 import type { FilterItem, FilterSelection } from './types';
 
 const ITEM_HEIGHT = 28; // h-7
-const MAX_LIST_HEIGHT = 256; // max-h-64
+const MAX_LIST_HEIGHT = 384; // max-h-96
 /** Hide the search input when the list is short enough to scan at a glance. */
 const SEARCH_VISIBILITY_THRESHOLD = 15;
 
@@ -136,7 +136,8 @@ export function FilterContent({
           className="[&>div>div>div>*]:mt-0!"
           style={{
             height: listHeight,
-            overflow: 'auto',
+            maxHeight: 'min(384px, calc(100vh - 220px))',
+            overflowY: 'auto',
             scrollbarColor: 'var(--color-neutral-7) transparent',
             scrollbarWidth: 'thin',
           }}


### PR DESCRIPTION
### Background

This PR attempts to address issue #3816, where the operation filter dropdown on the Insights page is cut off when many operations are displayed.

### Description

I investigated the Insights filter components and traced the operation filter to the shared `FilterContent` component.

Changes made:

- Increased the maximum dropdown list height from 256px to 384px.
- Added a responsive `maxHeight` based on the viewport so larger operation lists have more available space.
- Kept the existing scrolling behavior.

Modified file:

- `packages/web/app/src/components/base/floating/filter-dropdown/filter-content.tsx`

### Testing

- Built the project successfully using `pnpm build`.
- Started Hive locally.
- Verified the application still loads correctly.
- Reviewed the dropdown behavior locally.

### Related Issue

Fixes #3816

### Notes

My local environment did not contain enough operation data to reproduce the exact long dropdown shown in the GitHub issue, so this fix is based on the reported behavior and code investigation.