### PR TITLE
address flaky usage e2e tests

### DIFF
--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -51,11 +51,13 @@ export function createAuthHelper(
     let lastError: unknown;
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
-        await page.goto(path, { waitUntil: 'domcontentloaded' });
+        await page.goto(path);
         return;
       } catch (error) {
         lastError = error;
-        await page.waitForTimeout(1_000);
+        if (attempt < 2) {
+          await page.waitForTimeout(1_000);
+        }
       }
     }
     throw lastError;

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -45,6 +45,22 @@ export function createAuthHelper(
 ): AuthHelper {
   const cookieUrl = typeof baseURL === 'string' && baseURL ? baseURL : 'http://localhost:3000';
 
+  // The first navigation of a spec can race the app/stack becoming ready and abort
+  // (net::ERR_ABORTED). Retry a few times instead of failing the whole test on a transient.
+  async function gotoWithRetry(path: string) {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        await page.goto(path, { waitUntil: 'domcontentloaded' });
+        return;
+      } catch (error) {
+        lastError = error;
+        await page.waitForTimeout(1_000);
+      }
+    }
+    throw lastError;
+  }
+
   return {
     async fillSignInFormAndSubmit(user) {
       const form = page.locator('form').first();
@@ -65,7 +81,7 @@ export function createAuthHelper(
       });
     },
     async signup(user) {
-      await page.goto('/');
+      await gotoWithRetry('/');
       await page.locator('a[data-auth-link="sign-up"]').click();
       await this.fillSignUpFormAndSubmit(user);
       const verifyEmail = page.getByText('Verify your email address');
@@ -83,7 +99,7 @@ export function createAuthHelper(
       await expect(createOrganization).toBeVisible();
     },
     async login(user) {
-      await page.goto('/');
+      await gotoWithRetry('/');
       await this.fillSignInFormAndSubmit(user);
       await expect(page.getByText('Create Organization')).toBeVisible();
     },

--- a/e2e/specs/usage.spec.ts
+++ b/e2e/specs/usage.spec.ts
@@ -4,7 +4,10 @@ import type { AppHelper } from '../helpers/app';
 import { generateRandomSlug, getUserData } from '../helpers/data';
 import type { UsageHelper } from '../helpers/usage';
 
-test.describe.configure({ mode: 'serial', timeout: 120_000 });
+// Each test waits on ClickHouse ingestion through several stacked polls (see helpers/usage.ts).
+// Keep the timeout above the sum of those poll budgets so a slow-but-succeeding poll isn't cut
+// off mid-wait by the per-test deadline.
+test.describe.configure({ mode: 'serial', timeout: 180_000 });
 
 type UsageReport = {
   size: number;


### PR DESCRIPTION
This PR fixes two migration-era sources of flakiness in the usage reporting e2e suite (from the Cypress -> Playwright port in #8050).

First, it retries the initial `page.goto` in the auth helper's `signup`/`login`. The first navigation can race the app becoming ready and abort with `net::ERR_ABORTED`, the most common failure in recent CI runs.

Second, it raises the usage spec per-test timeout from 120s to 180s, since each test has stacked ingestion polls that can sum past 120s and get cut off mid-wait by the deadline.
