### PR TITLE
Write schema publish artifacts in parallel

### DIFF
--- a/.changeset/stale-pens-sleep.md
+++ b/.changeset/stale-pens-sleep.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Write s3 schema artifacts in parallel on schema publish. Previously, the subgraph SDL would be written first and then the supergraph would be written.

--- a/.changeset/stale-pens-sleep.md
+++ b/.changeset/stale-pens-sleep.md
@@ -2,4 +2,4 @@
 'hive': patch
 ---
 
-Write s3 schema artifacts in parallel on schema publish. Previously, the subgraph SDL would be written first and then the supergraph would be written.
+Write s3 schema artifacts in parallel on schema publish. Previously, the subgraph SDLs would be written first and then the composite schema SDL would be written.

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -3254,7 +3254,7 @@ export class SchemaPublisher {
 
     const publishCompositeSchema = async () => {
       await Promise.all([
-        await this.artifactStorageWriter.writeArtifact({
+        this.artifactStorageWriter.writeArtifact({
           targetId: target.id,
           artifactType: 'services',
           artifact: schemas.map(s => ({


### PR DESCRIPTION
### Background

In our effort to improve schema check and schema publish performance, I discovered we were awaiting a promise that we intended to be ran in parallel.

### Description

Removes the incorrect await statement.

