### PR TITLE
Role create and edit trigger validation on submit instead of disablin…

### DIFF
--- a/.changeset/floppy-houses-play.md
+++ b/.changeset/floppy-houses-play.md
@@ -1,0 +1,5 @@
+---
+'hive': minor
+---
+
+Role create and edit trigger validation on submit instead of disabling the submit button

--- a/packages/web/app/src/components/organization/members/roles.tsx
+++ b/packages/web/app/src/components/organization/members/roles.tsx
@@ -141,8 +141,8 @@ function OrganizationMemberRoleEditor(props: {
   }, []);
 
   async function onSubmit(data: RoleFormValues) {
-    if (!form.formState.isValid) {
-      await form.trigger();
+    const isValid = await form.trigger();
+    if (!isValid) {
       return;
     }
     try {
@@ -213,12 +213,7 @@ function OrganizationMemberRoleEditor(props: {
                   <FormItem>
                     <FormLabel>Name</FormLabel>
                     <FormControl>
-                      <Input
-                        placeholder="Enter a name"
-                        type="text"
-                        autoComplete="off"
-                        {...field}
-                      />
+                      <Input placeholder="Enter a name" type="text" autoComplete="off" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -231,11 +226,7 @@ function OrganizationMemberRoleEditor(props: {
                   <FormItem>
                     <FormLabel>Description</FormLabel>
                     <FormControl>
-                      <Textarea
-                        placeholder="Enter a description"
-                        autoComplete="off"
-                        {...field}
-                      />
+                      <Textarea placeholder="Enter a description" autoComplete="off" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/packages/web/app/src/components/organization/members/roles.tsx
+++ b/packages/web/app/src/components/organization/members/roles.tsx
@@ -538,8 +538,8 @@ function OrganizationMemberRoleCreator(props: {
                 <Button
                   type="submit"
                   onClick={async () => {
-                    if (!form.formState.isValid) {
-                      await form.trigger();
+                    const isValid = await form.trigger();
+                    if (!isValid) {
                       return;
                     }
                     setState('confirm');

--- a/packages/web/app/src/components/organization/members/roles.tsx
+++ b/packages/web/app/src/components/organization/members/roles.tsx
@@ -141,6 +141,10 @@ function OrganizationMemberRoleEditor(props: {
   }, []);
 
   async function onSubmit(data: RoleFormValues) {
+    if (!form.formState.isValid) {
+      await form.trigger();
+      return;
+    }
     try {
       const result = await updateMemberRole({
         input: {
@@ -209,7 +213,13 @@ function OrganizationMemberRoleEditor(props: {
                   <FormItem>
                     <FormLabel>Name</FormLabel>
                     <FormControl>
-                      <Input placeholder="Enter a name" type="text" autoComplete="off" {...field} />
+                      <Input
+                        placeholder="Enter a name"
+                        type="text"
+                        autoComplete="off"
+                        {...field}
+                        required
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -222,7 +232,12 @@ function OrganizationMemberRoleEditor(props: {
                   <FormItem>
                     <FormLabel>Description</FormLabel>
                     <FormControl>
-                      <Textarea placeholder="Enter a description" autoComplete="off" {...field} />
+                      <Textarea
+                        placeholder="Enter a description"
+                        autoComplete="off"
+                        {...field}
+                        required
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -249,9 +264,7 @@ function OrganizationMemberRoleEditor(props: {
             <Button
               type="submit"
               onClick={form.handleSubmit(onSubmit)}
-              disabled={
-                !form.formState.isValid || form.formState.isSubmitting || form.formState.disabled
-              }
+              disabled={form.formState.isSubmitting || form.formState.disabled}
             >
               {form.formState.isSubmitting ? 'Creating...' : 'Confirm selection'}
             </Button>
@@ -525,12 +538,14 @@ function OrganizationMemberRoleCreator(props: {
                 </Button>
                 <Button
                   type="submit"
-                  onClick={() => setState('confirm')}
-                  disabled={
-                    !form.formState.isValid ||
-                    form.formState.isSubmitting ||
-                    form.formState.disabled
-                  }
+                  onClick={async () => {
+                    if (!form.formState.isValid) {
+                      await form.trigger();
+                      return;
+                    }
+                    setState('confirm');
+                  }}
+                  disabled={form.formState.isSubmitting || form.formState.disabled}
                 >
                   Confirm selection
                 </Button>

--- a/packages/web/app/src/components/organization/members/roles.tsx
+++ b/packages/web/app/src/components/organization/members/roles.tsx
@@ -218,7 +218,6 @@ function OrganizationMemberRoleEditor(props: {
                         type="text"
                         autoComplete="off"
                         {...field}
-                        required
                       />
                     </FormControl>
                     <FormMessage />

--- a/packages/web/app/src/components/organization/members/roles.tsx
+++ b/packages/web/app/src/components/organization/members/roles.tsx
@@ -235,7 +235,6 @@ function OrganizationMemberRoleEditor(props: {
                         placeholder="Enter a description"
                         autoComplete="off"
                         {...field}
-                        required
                       />
                     </FormControl>
                     <FormMessage />

--- a/packages/web/app/src/components/organization/members/roles.tsx
+++ b/packages/web/app/src/components/organization/members/roles.tsx
@@ -560,11 +560,7 @@ function OrganizationMemberRoleCreator(props: {
                 <Button
                   type="submit"
                   onClick={form.handleSubmit(onSubmit)}
-                  disabled={
-                    !form.formState.isValid ||
-                    form.formState.isSubmitting ||
-                    form.formState.disabled
-                  }
+                  disabled={form.formState.isSubmitting || form.formState.disabled}
                 >
                   {form.formState.isSubmitting
                     ? 'Creating...'


### PR DESCRIPTION
…g the submit button

### Background

Current implementation disables the create/submit button if the form is invalid. This can be confusing since the description doesnt show an error message.

### Description

This adjusts the form to allow clicking submit even if the form isnt valid, and if it's invalid, then the errors will be shown and inputs highlighted.

This way, it's much more clear to a user what they have to fill out.


https://github.com/user-attachments/assets/f7054d49-ded3-4fa6-b4f0-c4b87bfccff6

