### PR TITLE
Laboratory preflight clickable log links

### DIFF
--- a/packages/libraries/laboratory/src/components/laboratory/preflight.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/preflight.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { HistoryIcon, PlayIcon } from 'lucide-react';
 import { runIsolatedLabScript } from '../../lib/preflight';
-import { cn } from '../../lib/utils';
+import { cn, tokenizeUrls } from '../../lib/utils';
 import { Button } from '../ui/button';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../ui/empty';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '../ui/resizable';
@@ -264,7 +264,23 @@ export const Preflight = () => {
                     >
                       {log.level.toUpperCase()}
                     </span>{' '}
-                    <span className="text-xs">{log.message.join(' ')}</span>
+                    <span className="text-xs">
+                      {tokenizeUrls(log.message.join(' ')).map((tok, i) =>
+                        tok.type === 'url' ? (
+                          <a
+                            key={i}
+                            href={tok.value}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-400 underline underline-offset-2 break-all hover:opacity-80"
+                          >
+                            {tok.value}
+                          </a>
+                        ) : (
+                          tok.value
+                        ),
+                      )}
+                    </span>
                   </div>
                 ))}
               </div>

--- a/packages/libraries/laboratory/src/components/laboratory/preflight.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/preflight.tsx
@@ -272,7 +272,7 @@ export const Preflight = () => {
                             href={tok.value}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-blue-400 underline underline-offset-2 break-all hover:opacity-80"
+                            className="break-all text-blue-400 underline underline-offset-2 hover:opacity-80"
                           >
                             {tok.value}
                           </a>

--- a/packages/libraries/laboratory/src/lib/utils.spec.ts
+++ b/packages/libraries/laboratory/src/lib/utils.spec.ts
@@ -1,0 +1,99 @@
+import { tokenizeUrls } from './utils';
+
+describe('tokenizeUrls', () => {
+  it('returns nothing for an empty string', () => {
+    expect(tokenizeUrls('')).toEqual([]);
+  });
+
+  it('keeps plain text with no URL as a single text token', () => {
+    expect(tokenizeUrls('no links here')).toEqual([{ type: 'text', value: 'no links here' }]);
+  });
+
+  it('does not linkify bare domains or non-http(s) schemes', () => {
+    const input = 'go to example.com or javascript:alert(1) or data:text/html,x or ftp://h/f';
+    expect(tokenizeUrls(input)).toEqual([{ type: 'text', value: input }]);
+  });
+
+  it('linkifies an http URL surrounded by text', () => {
+    expect(tokenizeUrls('visit http://example.com now')).toEqual([
+      { type: 'text', value: 'visit ' },
+      { type: 'url', value: 'http://example.com' },
+      { type: 'text', value: ' now' },
+    ]);
+  });
+
+  it('linkifies a URL at the start and at the end without empty text tokens', () => {
+    expect(tokenizeUrls('https://a.com')).toEqual([{ type: 'url', value: 'https://a.com' }]);
+    expect(tokenizeUrls('see https://a.com')).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'url', value: 'https://a.com' },
+    ]);
+  });
+
+  it('linkifies multiple URLs in one string', () => {
+    expect(tokenizeUrls('a https://one.com b https://two.com')).toEqual([
+      { type: 'text', value: 'a ' },
+      { type: 'url', value: 'https://one.com' },
+      { type: 'text', value: ' b ' },
+      { type: 'url', value: 'https://two.com' },
+    ]);
+  });
+
+  it('preserves query strings and fragments inside the URL', () => {
+    expect(tokenizeUrls('open https://example.com/device?code=ABCD-1234#frag')).toEqual([
+      { type: 'text', value: 'open ' },
+      { type: 'url', value: 'https://example.com/device?code=ABCD-1234#frag' },
+    ]);
+  });
+
+  it('strips trailing sentence punctuation from the URL', () => {
+    expect(tokenizeUrls('go https://example.com.')).toEqual([
+      { type: 'text', value: 'go ' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: '.' },
+    ]);
+    expect(tokenizeUrls('really https://example.com?!')).toEqual([
+      { type: 'text', value: 'really ' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: '?!' },
+    ]);
+  });
+
+  it('drops an unbalanced closing paren that wraps the URL', () => {
+    expect(tokenizeUrls('(see https://x.com/a)')).toEqual([
+      { type: 'text', value: '(see ' },
+      { type: 'url', value: 'https://x.com/a' },
+      { type: 'text', value: ')' },
+    ]);
+  });
+
+  it('keeps balanced parens that are part of the URL', () => {
+    expect(tokenizeUrls('https://en.wikipedia.org/wiki/Foo_(bar)')).toEqual([
+      { type: 'url', value: 'https://en.wikipedia.org/wiki/Foo_(bar)' },
+    ]);
+    expect(tokenizeUrls('https://en.wikipedia.org/wiki/Foo_(bar).')).toEqual([
+      { type: 'url', value: 'https://en.wikipedia.org/wiki/Foo_(bar)' },
+      { type: 'text', value: '.' },
+    ]);
+  });
+
+  it('preserves newlines and surrounding whitespace', () => {
+    expect(tokenizeUrls('line1\nhttps://x.com\nline2')).toEqual([
+      { type: 'text', value: 'line1\n' },
+      { type: 'url', value: 'https://x.com' },
+      { type: 'text', value: '\nline2' },
+    ]);
+  });
+
+  it('handles a wrapping paren and a trailing period together', () => {
+    const input = 'Wrapped: (see https://example.com/a). Trailing: https://example.com/b.';
+    expect(tokenizeUrls(input)).toEqual([
+      { type: 'text', value: 'Wrapped: (see ' },
+      { type: 'url', value: 'https://example.com/a' },
+      { type: 'text', value: ').' },
+      { type: 'text', value: ' Trailing: ' },
+      { type: 'url', value: 'https://example.com/b' },
+      { type: 'text', value: '.' },
+    ]);
+  });
+});

--- a/packages/libraries/laboratory/src/lib/utils.ts
+++ b/packages/libraries/laboratory/src/lib/utils.ts
@@ -44,3 +44,44 @@ export async function asyncInterval(
 export function isAsyncIterable<T>(val: unknown): val is AsyncIterable<T> {
   return typeof Object(val)[Symbol.asyncIterator] === 'function';
 }
+
+// Exclude whitespace and characters that are never part of a bare URL in log text.
+const URL_PATTERN = /https?:\/\/[^\s<>"'`]+/g;
+
+export type TextToken = { type: 'text'; value: string } | { type: 'url'; value: string };
+
+/**
+ * Split text into plain-text and http(s) URL tokens, preserving all original characters
+ * (incl. newlines/whitespace). Only https?:// is matched, so javascript:/data: can't be linked.
+ */
+export function tokenizeUrls(text: string): TextToken[] {
+  const tokens: TextToken[] = [];
+  let lastIndex = 0;
+  for (const match of text.matchAll(URL_PATTERN)) {
+    const start = match.index ?? 0;
+    let url = match[0];
+    // Trailing punctuation is usually sentence punctuation, not part of the URL.
+    let trailer = url.match(/[.,;:!?]+$/)?.[0] ?? '';
+    if (trailer) {
+      url = url.slice(0, -trailer.length);
+    }
+    // Drop an unbalanced closing paren, e.g. "(see https://x.com/a)".
+    if (url.endsWith(')') && !url.includes('(')) {
+      url = url.slice(0, -1);
+      trailer = ')' + trailer;
+    }
+
+    if (start > lastIndex) {
+      tokens.push({ type: 'text', value: text.slice(lastIndex, start) });
+    }
+    tokens.push({ type: 'url', value: url });
+    if (trailer) {
+      tokens.push({ type: 'text', value: trailer });
+    }
+    lastIndex = start + match[0].length;
+  }
+  if (lastIndex < text.length) {
+    tokens.push({ type: 'text', value: text.slice(lastIndex) });
+  }
+  return tokens;
+}


### PR DESCRIPTION
This PR makes `http(s)://` URLs in the Laboratory preflight Logs pane clickable (open in a new tab), so device-code OAuth scripts can log a sign-in link instead of making users copy a URL out of a log line.

Adds a pure `tokenizeUrls` helper in `lib/utils.ts` and renders URL tokens as anchors in `preflight.tsx`. Render-only: no worker, protocol, or `lab` API changes. Only `https?://` is linkified, links use `rel="noopener noreferrer"`, and non-URL logs render as before.
