### PR TITLE
Remove retry behavior from laboratory

### DIFF
--- a/.changeset/lab-remove-retry.md
+++ b/.changeset/lab-remove-retry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/laboratory': minor
+---
+
+Remove the request `retry` setting from the laboratory. Retries are the wrong primitive for an interactive GraphQL IDE (the user re-runs operations, and schema introspection already polls), and the underlying HTTP executor retried on any GraphQL `errors` response while dropping request headers on the retry, so retries went out unauthenticated. Existing persisted `retry` values are ignored automatically.

--- a/packages/libraries/laboratory/src/components/laboratory/settings.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/settings.tsx
@@ -13,7 +13,6 @@ const settingsFormSchema = z.object({
   fetch: z.object({
     credentials: z.enum(['include', 'omit', 'same-origin']),
     timeout: z.number().optional(),
-    retry: z.number().optional(),
     useGETForQueries: z.boolean().optional(),
   }),
   subscriptions: z.object({
@@ -85,25 +84,6 @@ export const Settings = () => {
                   return (
                     <Field>
                       <FieldLabel htmlFor={field.name}>Timeout</FieldLabel>
-                      <Input
-                        type="number"
-                        name={field.name}
-                        value={field.state.value ?? ''}
-                        onChange={e =>
-                          field.handleChange(
-                            e.target.value === '' ? undefined : Number(e.target.value),
-                          )
-                        }
-                      />
-                    </Field>
-                  );
-                }}
-              </form.Field>
-              <form.Field name="fetch.retry">
-                {field => {
-                  return (
-                    <Field>
-                      <FieldLabel htmlFor={field.name}>Retry</FieldLabel>
                       <Input
                         type="number"
                         name={field.name}

--- a/packages/libraries/laboratory/src/lib/endpoint.ts
+++ b/packages/libraries/laboratory/src/lib/endpoint.ts
@@ -165,7 +165,6 @@ export const useEndpoint = (props: {
               specifiedByUrl: true,
               directiveIsRepeatable: true,
               inputValueDeprecation: true,
-              retry: props.settingsApi?.settings.fetch.retry,
               timeout: props.settingsApi?.settings.fetch.timeout,
               useGETForQueries: props.settingsApi?.settings.fetch.useGETForQueries,
               exposeHTTPDetailsInExtensions: true,

--- a/packages/libraries/laboratory/src/lib/operations.ts
+++ b/packages/libraries/laboratory/src/lib/operations.ts
@@ -442,7 +442,6 @@ export const useOperations = (
         specifiedByUrl: true,
         directiveIsRepeatable: true,
         inputValueDeprecation: true,
-        retry: props.settingsApi?.settings.fetch.retry,
         timeout: props.settingsApi?.settings.fetch.timeout,
         useGETForQueries: props.settingsApi?.settings.fetch.useGETForQueries,
         exposeHTTPDetailsInExtensions: true,

--- a/packages/libraries/laboratory/src/lib/settings.ts
+++ b/packages/libraries/laboratory/src/lib/settings.ts
@@ -4,7 +4,6 @@ export type LaboratorySettings = {
   fetch: {
     credentials: 'include' | 'omit' | 'same-origin';
     timeout?: number;
-    retry?: number;
     useGETForQueries?: boolean;
   };
   subscriptions: {
@@ -22,7 +21,6 @@ export const defaultLaboratorySettings: LaboratorySettings = {
   fetch: {
     credentials: 'same-origin',
     timeout: 10000,
-    retry: 3,
     useGETForQueries: false,
   },
   subscriptions: {
@@ -42,7 +40,6 @@ export const normalizeLaboratorySettings = (
   fetch: {
     credentials: settings?.fetch?.credentials ?? defaultLaboratorySettings.fetch.credentials,
     timeout: settings?.fetch?.timeout ?? defaultLaboratorySettings.fetch.timeout,
-    retry: settings?.fetch?.retry ?? defaultLaboratorySettings.fetch.retry,
     useGETForQueries:
       settings?.fetch?.useGETForQueries ?? defaultLaboratorySettings.fetch.useGETForQueries,
   },

--- a/packages/libraries/render-laboratory/src/index.ts
+++ b/packages/libraries/render-laboratory/src/index.ts
@@ -20,7 +20,6 @@ const mapGraphiQLOptionsToLaboratoryProps = (opts?: GraphiQLOptions): Laboratory
       fetch: {
         credentials: opts.credentials ?? 'same-origin',
         timeout: opts.timeout,
-        retry: opts.retry,
         useGETForQueries: opts.useGETForQueries,
       },
       subscriptions: {


### PR DESCRIPTION
This PR removes the request retry mechanism from the GraphQL laboratory: the `fetch.retry` setting, its Settings control, and the `retry` option passed to the executor for operations and introspection.

Retries are wrong for an interactive IDE (the user re-runs; introspection already polls), and the underlying executor retried on any GraphQL `errors` response while dropping headers on the retry, so retries went out unauthenticated. Users with a saved `retry` value need no migration: on load the lab normalizes settings against a fixed field list, so a stored `retry` is dropped before it ever reaches the executor, and the stale key gets rewritten out of local storage the next time settings are saved.