### PR TITLE
Evaluate metric-alert groups with a concurrency pool

### DIFF
--- a/.changeset/giant-cups-matter.md
+++ b/.changeset/giant-cups-matter.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Runs metric alerts cron with a concurrency pool

--- a/packages/services/workflows/package.json
+++ b/packages/services/workflows/package.json
@@ -31,6 +31,7 @@
     "graphql-yoga": "5.13.3",
     "mjml": "4.14.0",
     "nodemailer": "9.0.1",
+    "p-limit": "6.2.0",
     "sendmail": "1.6.1",
     "zod": "3.25.76"
   }

--- a/packages/services/workflows/src/tasks/evaluate-metric-alert-rules.ts
+++ b/packages/services/workflows/src/tasks/evaluate-metric-alert-rules.ts
@@ -1,3 +1,4 @@
+import pLimit from 'p-limit';
 import { z } from 'zod';
 import { psql } from '@hive/postgres';
 import { SpanKind, SpanStatusCode, trace } from '@hive/service-common';
@@ -175,28 +176,25 @@ export const task = implementTask(EvaluateMetricAlertRulesTask, async args => {
     },
     async span => {
       try {
-        // Bounded parallelism over groups: each group = 1 CH query + per-rule
-        // state writes. allSettled (not Promise.all) so that one unexpected
-        // throw inside evaluateRule doesn't strand the rest of the batch's
-        // successful work; the throwing group's rules get re-evaluated on the
-        // next cron tick (60s) rather than via graphile-worker retries, which
-        // would otherwise re-run work that's already idempotently committed.
-        // With GROUP_CONCURRENCY=5 we cut wall-clock per tick by up to 5x
-        // without exhausting the PG pool.
+        // Fixed-capacity pool: keep GROUP_CONCURRENCY groups in flight at once so
+        // a slow group can't idle the other slots (a batch barrier would wait for
+        // the whole batch before starting the next). allSettled so one thrown
+        // group doesn't strand the rest; it re-evaluates on the next 60s tick,
+        // not via graphile-worker retries that would re-run already-committed work.
+        const limit = pLimit(GROUP_CONCURRENCY);
         let groupsFailed = 0;
         const evaluatedRuleIds: string[] = [];
-        for (let i = 0; i < groupList.length; i += GROUP_CONCURRENCY) {
-          const batch = groupList.slice(i, i + GROUP_CONCURRENCY);
-          const results = await Promise.allSettled(batch.map(processGroup));
-          for (const r of results) {
-            if (r.status === 'rejected') {
-              groupsFailed++;
-              logger.error({ error: r.reason }, 'Group evaluation threw unexpectedly');
-            } else if (r.value.failed) {
-              groupsFailed++;
-            } else {
-              evaluatedRuleIds.push(...r.value.evaluatedIds);
-            }
+        const results = await Promise.allSettled(
+          groupList.map(group => limit(() => processGroup(group))),
+        );
+        for (const r of results) {
+          if (r.status === 'rejected') {
+            groupsFailed++;
+            logger.error({ error: r.reason }, 'Group evaluation threw unexpectedly');
+          } else if (r.value.failed) {
+            groupsFailed++;
+          } else {
+            evaluatedRuleIds.push(...r.value.evaluatedIds);
           }
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2071,6 +2071,9 @@ importers:
       nodemailer:
         specifier: 9.0.1
         version: 9.0.1
+      p-limit:
+        specifier: 6.2.0
+        version: 6.2.0
       sendmail:
         specifier: 1.6.1
         version: 1.6.1


### PR DESCRIPTION
This PR replaces the fixed-batch barrier in the `evaluateMetricAlertRules` cron with a `p-limit` concurrency pool, so metric-alert groups are evaluated with continuous bounded parallelism instead of synchronized batches of 5. 

Before, a batch couldn't start until the previous one fully drained, so one slow group (like a timed-out ClickHouse query) idled the other slots and delayed every later group, including cheap ones from other orgs; the pool keeps up to 5 groups in flight at all times, starting the next as soon as one finishes. 

Behavior is otherwise unchanged: same cap (still below the Postgres pool size), same `allSettled` failure isolation, and the same batched `last_evaluated_at` update once all groups drain. `p-limit` is the limiter already used by the usage and migrations packages.