### PR TITLE
apply timeout-minutes: 5 to changeset-version workflow

### DIFF
--- a/.github/workflows/changeset-version.yaml
+++ b/.github/workflows/changeset-version.yaml
@@ -21,6 +21,10 @@ jobs:
           actor: changeset-version
 
       - name: Apply changeset version
+        # @changesets/changelog-github hits the GitHub API per changeset; a GitHub
+        # API incident makes this hang indefinitely (nominal run is ~1 min), so fail
+        # fast instead of holding the runner for the whole workflow timeout.
+        timeout-minutes: 5
         run: pnpm changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds `timeout-minutes: 5` to the `Apply changeset version` step so a GitHub API incident (which makes `@changesets/changelog-github` hang on its per-changeset API calls) fails fast instead of hanging the job indefinitely, as happened in run [29174666547](https://github.com/graphql-hive/console/actions/runs/29174666547/job/86835584236?pr=8207).