### PR TITLE
Reduce replica count for staging schema and graphqlApi services

### DIFF
--- a/.changeset/huge-emus-call.md
+++ b/.changeset/huge-emus-call.md
@@ -1,5 +1,0 @@
----
-'hive': patch
----
-
-Reduce replica count for staging schema and graphqlApi services

--- a/.changeset/huge-emus-call.md
+++ b/.changeset/huge-emus-call.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Reduce replica count for staging schema and graphqlApi services

--- a/deployment/services/environment.ts
+++ b/deployment/services/environment.ts
@@ -49,7 +49,7 @@ export function prepareEnvironment(input: {
         replicas: isProduction || isStaging ? 3 : 1,
       },
       graphqlApi: {
-        replicas: isProduction || isStaging ? 6 : 1,
+        replicas: isProduction ? 6 : isStaging ? 3 : 1,
       },
       envoy: {
         replicas: isProduction || isStaging ? 3 : 1,
@@ -61,7 +61,7 @@ export function prepareEnvironment(input: {
       },
       schemaService: {
         memoryLimit: isProduction || isStaging ? '3584Mi' : '1Gi',
-        replicas: isProduction || isStaging ? 6 : 1,
+        replicas: isProduction ? 6 : isStaging ? 3 : 1,
       },
       usageService: {
         replicas: isProduction || isStaging ? 6 : 1,


### PR DESCRIPTION
### Background

Staging deployed once with the increased replica count but is failing to allocate the necessary memory now. We could either scale our containers or reduce replica count on staging.

### Description

Reduces staging replicas that were previously increased in https://github.com/graphql-hive/console/pull/8185
Keeps production higher