### PR TITLE
Update e2e tests and right size prev fix attempts

### DIFF
--- a/e2e/helpers/usage.ts
+++ b/e2e/helpers/usage.ts
@@ -83,28 +83,20 @@ export function createUsageHelper(
       expect(responseStatus).toBe(200);
     },
     async expectInsightOperation(operationName) {
-      await expect
-        .poll(
-          async () => {
-            await reloadInsightsPage();
-
-            return page.getByRole('link').filter({ hasText: operationName }).count();
-          },
-          { timeout: 60_000, intervals: [2_000] },
-        )
-        .toBeGreaterThan(0);
+      const link = page.getByRole('link').filter({ hasText: operationName });
+      await expect(async () => {
+        await reloadInsightsPage();
+        // Reload re-fetches; wait for the row to render before retrying so a slow load
+        // isn't reloaded away mid-flight.
+        await expect(link.first()).toBeVisible({ timeout: 15_000 });
+      }).toPass({ timeout: 90_000, intervals: [1_000] });
     },
     async expectInsightVersion(version) {
-      await expect
-        .poll(
-          async () => {
-            await reloadInsightsPage();
-
-            return page.getByText(version, { exact: true }).count();
-          },
-          { timeout: 60_000, intervals: [2_000] },
-        )
-        .toBeGreaterThan(0);
+      const versionText = page.getByText(version, { exact: true });
+      await expect(async () => {
+        await reloadInsightsPage();
+        await expect(versionText.first()).toBeVisible({ timeout: 15_000 });
+      }).toPass({ timeout: 90_000, intervals: [1_000] });
     },
   };
 }

--- a/e2e/specs/usage.spec.ts
+++ b/e2e/specs/usage.spec.ts
@@ -4,10 +4,9 @@ import type { AppHelper } from '../helpers/app';
 import { generateRandomSlug, getUserData } from '../helpers/data';
 import type { UsageHelper } from '../helpers/usage';
 
-// Each test waits on ClickHouse ingestion through several stacked polls (see helpers/usage.ts).
-// Keep the timeout above the sum of those poll budgets so a slow-but-succeeding poll isn't cut
-// off mid-wait by the per-test deadline.
-test.describe.configure({ mode: 'serial', timeout: 180_000 });
+// Generous per-test budget: each test drives the full org/project/target/token setup through
+// the UI before polling Insights.
+test.describe.configure({ mode: 'serial', timeout: 120_000 });
 
 type UsageReport = {
   size: number;

--- a/packages/services/usage-ingestor/src/writer.ts
+++ b/packages/services/usage-ingestor/src/writer.ts
@@ -57,13 +57,6 @@ export function createWriter({
     https: httpsAgent,
   };
 
-  logger.debug(
-    'ClickHouse writer initialized (async_insert=1, wait_for_async_insert=%s, async_insert_busy_timeout_ms=%s, async_insert_max_data_size=%s)',
-    clickhouse.wait_for_async_insert,
-    clickhouse.async_insert_busy_timeout_ms,
-    clickhouse.async_insert_max_data_size,
-  );
-
   return {
     async writeOperations(operations: string[]) {
       if (operations.length === 0) {
@@ -73,7 +66,6 @@ export function createWriter({
       const csv = joinIntoSingleMessage(operations);
       const compressed = await compress(csv);
 
-      const startedAt = performance.now();
       await writeCsv(
         clickhouse,
         agents,
@@ -81,13 +73,6 @@ export function createWriter({
         compressed,
         logger,
         3,
-      );
-      // With wait_for_async_insert=1 this blocks until the row is flushed (queryable);
-      // fire-and-forget returns in a few ms. Logged at debug so it stays out of prod (info).
-      logger.debug(
-        'operations INSERT completed in %sms (operations=%s)',
-        performance.now() - startedAt,
-        operations.length,
       );
     },
     async writeSubscriptionOperations(operations: string[]) {


### PR DESCRIPTION
This PR fixes the intermittent flakiness in the usage e2e tests (`usage.spec.ts`). The failures were a test-side race, not an ingestion problem: the Insights poll reloaded the page every ~2s and counted matching rows immediately after the app shell mounted, so under CI load it kept snapshotting the still-loading (skeleton) state and reloading the page away before its data rendered. The heavier per-client Insights page was the one that lost the race, which is why the failures were always on `/insights/client/...`.

Changes:
- Wait for the Insights row to actually render (`toBeVisible`) before retrying, instead of snapshotting mid-load with `.count()`.
- Right-size the per-test timeout from 180s back to 120s (the bump was a band-aid for the race, now fixed at the root).
- Remove the diagnostic CH writer logging added while investigating.

The `wait_for_async_insert=1` e2e ingestor setting is intentionally kept: it makes reported operations queryable quickly and removes ingestion timing as a variable.
