### PR TITLE
Additional improvements to Metric Alerts dashboard

### DIFF
--- a/deployment/grafana-dashboards/Metric-Alerts.json
+++ b/deployment/grafana-dashboards/Metric-Alerts.json
@@ -319,7 +319,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "PROM_DATASOURCE_UID" },
           "editorMode": "code",
-          "expr": "hive_metric_alert_rule_groups{filtered=\"true\"}",
+          "expr": "max(hive_metric_alert_rule_groups{filtered=\"true\"})",
           "legendFormat": "with filter",
           "range": true,
           "refId": "A"
@@ -327,7 +327,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "PROM_DATASOURCE_UID" },
           "editorMode": "code",
-          "expr": "hive_metric_alert_rule_groups{filtered=\"false\"}",
+          "expr": "max(hive_metric_alert_rule_groups{filtered=\"false\"})",
           "legendFormat": "no filter",
           "range": true,
           "refId": "B"
@@ -382,7 +382,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "PROM_DATASOURCE_UID" },
           "editorMode": "code",
-          "expr": "hive_metric_alert_enabled_rules{filtered=\"true\"}",
+          "expr": "max(hive_metric_alert_enabled_rules{filtered=\"true\"})",
           "legendFormat": "with filter",
           "range": true,
           "refId": "A"
@@ -390,7 +390,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "PROM_DATASOURCE_UID" },
           "editorMode": "code",
-          "expr": "hive_metric_alert_enabled_rules{filtered=\"false\"}",
+          "expr": "max(hive_metric_alert_enabled_rules{filtered=\"false\"})",
           "legendFormat": "no filter",
           "range": true,
           "refId": "B"

--- a/deployment/grafana-dashboards/Metric-Alerts.json
+++ b/deployment/grafana-dashboards/Metric-Alerts.json
@@ -14,6 +14,7 @@
     ]
   },
   "description": "Health of the metric-alert evaluation cron and its ClickHouse queries.",
+  "uid": "28f149e2-2033-4e29-a8f5-54d4afa8e579",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,

--- a/deployment/grafana-dashboards/Metric-Alerts.json
+++ b/deployment/grafana-dashboards/Metric-Alerts.json
@@ -14,7 +14,7 @@
     ]
   },
   "description": "Health of the metric-alert evaluation cron and its ClickHouse queries.",
-  "uid": "28f149e2-2033-4e29-a8f5-54d4afa8e579",
+  "uid": "metric-alerts",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,

--- a/deployment/services/grafana.ts
+++ b/deployment/services/grafana.ts
@@ -38,10 +38,16 @@ export function deployGrafana(envName: string, tableSuffix: string) {
 
     const configJson = JSON.parse(configString);
 
-    if ('uid' in configJson) {
+    // Preserve a pinned uid only for opted-in dashboards, so re-saves keep a stable
+    // URL. Grafana 13's app platform mints a fresh uid on every re-save when none is
+    // set. Don't un-strip globally: re-saving the other working dashboards on Grafana
+    // 13 via this old provider is what churned Metric-Alerts.
+    const preserveUid = new Set(['Metric-Alerts']); // matches `identifier` (filename)
+    if ('uid' in configJson && !preserveUid.has(identifier)) {
       delete configJson.uid;
     }
 
+    // Always strip version to avoid version-mismatch errors on update.
     if ('version' in configJson) {
       delete configJson.version;
     }

--- a/deployment/services/grafana.ts
+++ b/deployment/services/grafana.ts
@@ -10,10 +10,16 @@ const dashboardDirectory = join(__dirname, '../grafana-dashboards/');
  * @param tableSuffix suffix for the table names (production, staging, dev)
  */
 export function deployGrafana(envName: string, tableSuffix: string) {
-  const availableFiles = readdirSync(dashboardDirectory)
-    .filter(f => f.endsWith('.json'))
-    // Temp workaround
-    .filter(v => !v.includes('ClickHouse-Latency.json'));
+  // Dashboards excluded from provisioning:
+  const excludedDashboards = [
+    'ClickHouse-Latency.json', // temp workaround
+    // #8114: the outdated provider churns this dashboard's uid/folder on Grafana
+    // 13, so it's managed manually in the UI until the provider upgrade.
+    'Metric-Alerts.json',
+  ];
+  const availableFiles = readdirSync(dashboardDirectory).filter(
+    f => f.endsWith('.json') && !excludedDashboards.includes(f),
+  );
   const folder = new Folder('grafana-hive-folder', {
     title: `Hive Monitoring (${envName})`,
   });
@@ -38,16 +44,10 @@ export function deployGrafana(envName: string, tableSuffix: string) {
 
     const configJson = JSON.parse(configString);
 
-    // Preserve a pinned uid only for opted-in dashboards, so re-saves keep a stable
-    // URL. Grafana 13's app platform mints a fresh uid on every re-save when none is
-    // set. Don't un-strip globally: re-saving the other working dashboards on Grafana
-    // 13 via this old provider is what churned Metric-Alerts.
-    const preserveUid = new Set(['Metric-Alerts']); // matches `identifier` (filename)
-    if ('uid' in configJson && !preserveUid.has(identifier)) {
+    if ('uid' in configJson) {
       delete configJson.uid;
     }
 
-    // Always strip version to avoid version-mismatch errors on update.
     if ('version' in configJson) {
       delete configJson.version;
     }


### PR DESCRIPTION
This PR stops provisioning the Metric Alerts dashboard through Pulumi and manages it manually in the Grafana UI until #8114 (the provider upgrade) lands, because the outdated `@lbrlabs/pulumi-grafana` provider churns the dashboard's uid and drops it in the wrong folder on Grafana Cloud's v13 app platform (after the observability PR added it, it 403'd and fell out of the nav). It also cleans up the two new gauge panels.


- Exclude `Metric-Alerts.json` from provisioning (added to the existing exclusion list next to `ClickHouse-Latency.json`), so Pulumi no longer recreates or churns it on deploy.
- Keep a pinned `uid: "metric-alerts"` in the JSON so the manually imported dashboard has a stable `/d/metric-alerts` URL.
- Aggregate the filtered/unfiltered gauge panels with `max(...)`, collapsing the per-replica series (one per workflow pod) to a single clean line each.

