### PR TITLE
Enable usage field errors reporting for graphql api

### DIFF
--- a/deployment/services/graphql.ts
+++ b/deployment/services/graphql.ts
@@ -137,7 +137,7 @@ export function deployGraphQL({
           HIVE_USAGE: '1',
           HIVE_TARGET: hiveConfig.require('target'),
           HIVE_USAGE_ENDPOINT: serviceLocalEndpoint(usage.service),
-          HIVE_FIELD_USAGE_ENABLED: '0',
+          HIVE_FIELD_USAGE_ENABLED: '1',
           HIVE_TRACING: '1',
           HIVE_TRACING_ENDPOINT: environment.isProduction
             ? 'https://api.graphql-hive.com/otel/v1/traces'


### PR DESCRIPTION
### Background

Toggles on usage field errors. This should be merged and deployed after usage-field-errors.

### Description

This PR targets the usage-field-errors as a base branch to more clearly show the toggle