### PR TITLE
fix: monolithic schema version promotion

### DIFF
--- a/.changeset/nine-cows-create.md
+++ b/.changeset/nine-cows-create.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Fix unexpected exception that could be raised when promoting a schema version within a monolithic project.

--- a/integration-tests/tests/api/schema/promotion.spec.ts
+++ b/integration-tests/tests/api/schema/promotion.spec.ts
@@ -1022,7 +1022,7 @@ test.concurrent('promote delete schema version results in correct state', async 
   expect(promotedVersion.supergraph).toEqual(serviceDeletedVersion.supergraph);
 });
 
-test.concurrent('promote monolith schema version', async ({ expect }) => {
+test.concurrent('promote monolith schema version succeeds', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject, createOrganizationAccessToken } = await createOrg();
   const { target, fetchVersions } = await createProject(ProjectType.Single);

--- a/integration-tests/tests/api/schema/promotion.spec.ts
+++ b/integration-tests/tests/api/schema/promotion.spec.ts
@@ -1021,3 +1021,113 @@ test.concurrent('promote delete schema version results in correct state', async 
   expect(serviceDeletedVersion.valid).toEqual(true);
   expect(promotedVersion.supergraph).toEqual(serviceDeletedVersion.supergraph);
 });
+
+test.concurrent('promote monolith schema version', async ({ expect }) => {
+  const { createOrg } = await initSeed().createOwner();
+  const { createProject, createOrganizationAccessToken } = await createOrg();
+  const { target, fetchVersions } = await createProject(ProjectType.Single);
+  const { privateAccessKey } = await createOrganizationAccessToken({
+    resources: {
+      mode: ResourceAssignmentModeType.All,
+    },
+    permissions: [
+      'schemaVersion:publish',
+      'target:modifySettings',
+      'project:describe',
+      'schemaVersion:promote',
+    ],
+  });
+
+  await publishSchema(
+    {
+      author: 'a',
+      commit: 'a',
+      sdl: /* GraphQL */ `
+        type Query {
+          a: String!
+        }
+      `,
+      target: {
+        byId: target.id,
+      },
+    },
+    privateAccessKey,
+  ).then(r => r.expectNoGraphQLErrors());
+  await publishSchema(
+    {
+      author: 'b',
+      commit: 'b',
+      sdl: /* GraphQL */ `
+        type Query {
+          b: String!
+        }
+      `,
+      target: {
+        byId: target.id,
+      },
+    },
+    privateAccessKey,
+  ).then(r => r.expectNoGraphQLErrors());
+
+  const [publishedVersion, versionToPromote] = await fetchVersions(2);
+  assertNonNullish(versionToPromote);
+  assertNonNullish(publishedVersion);
+  expect(versionToPromote.sdl).toContain('a: String!');
+
+  let promoteResult = await schemaVersionPromote(
+    {
+      source: {
+        fromSchemaVersionById: versionToPromote.id,
+      },
+      target: {
+        toTarget: {
+          byId: target.id,
+        },
+      },
+    },
+    privateAccessKey,
+  ).then(r => r.expectNoGraphQLErrors());
+
+  expect(promoteResult.schemaVersionPromote.error).toEqual(null);
+  assertNonNullish(promoteResult.schemaVersionPromote.ok);
+  let promotedVersionDetails = await getSchemaVersionWithAllDetails(
+    target.id,
+    promoteResult.schemaVersionPromote.ok.newSchemaVersion.id,
+    privateAccessKey,
+  );
+  assertNonNull(promotedVersionDetails);
+  expect(promotedVersionDetails.origin).toEqual({
+    __typename: 'SchemaVersionPromoteOrigin',
+    schemaVersionId: versionToPromote.id,
+  });
+  expect(promotedVersionDetails.sdl).toContain('a: String!');
+
+  // why not also publish another version just to be sure
+  promoteResult = await schemaVersionPromote(
+    {
+      source: {
+        fromSchemaVersionById: publishedVersion.id,
+      },
+      target: {
+        toTarget: {
+          byId: target.id,
+        },
+      },
+    },
+    privateAccessKey,
+  ).then(r => r.expectNoGraphQLErrors());
+
+  expect(promoteResult.schemaVersionPromote.error).toEqual(null);
+  assertNonNullish(promoteResult.schemaVersionPromote.ok);
+  promotedVersionDetails = await getSchemaVersionWithAllDetails(
+    target.id,
+    promoteResult.schemaVersionPromote.ok.newSchemaVersion.id,
+    privateAccessKey,
+  );
+  assertNonNull(promotedVersionDetails);
+  expect(promotedVersionDetails.origin).toEqual({
+    __typename: 'SchemaVersionPromoteOrigin',
+    schemaVersionId: publishedVersion.id,
+  });
+  expect(promotedVersionDetails.sdl).toContain('b: String!');
+});

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -409,6 +409,9 @@ export class SchemaVersionHelper {
         } satisfies ResolversUnionTypes<any>['SubgraphDiff'];
       }
       if (edge.type === 'added') {
+        invariant(!!edge.node.service_name, 'node of edge cannot be null');
+        invariant(!!edge.node.service_url, 'url of edge cannot be null');
+
         return {
           __typename: 'SubgraphDiffAdded',
           subgraphVersion: {

--- a/packages/services/api/src/modules/schema/providers/schema-version-store.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-store.ts
@@ -1777,7 +1777,7 @@ export type SchemaLogDiffInput = {
 
 const SchemaLogWithEdgesModel = z.union([
   SchemaLogEdgeAddedModel.extend({
-    node: CompositePushSchemaLogModel,
+    node: z.union([CompositePushSchemaLogModel, SinglePushSchemaLogModel]),
   }),
   SchemaLogEdgeChangedModel.extend({
     node: z.union([CompositePushSchemaLogModel, SinglePushSchemaLogModel]),


### PR DESCRIPTION
### Background

This fixes schema version promotion for single-schema projects.

Previously, promoting a version could fail because the composition result only accepted composite schema logs.

The fix adds support for single-schema logs and includes an integration test covering promotion of multiple monolith schema versions.
