### PR TITLE
Track composition worker memory

### DIFF
--- a/.changeset/modern-badgers-fall.md
+++ b/.changeset/modern-badgers-fall.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Track schema composition worker memory usage; add to schema service dashboard

--- a/deployment/grafana-dashboards/Schema-Service.json
+++ b/deployment/grafana-dashboards/Schema-Service.json
@@ -661,9 +661,288 @@
       ],
       "title": "Timeouts",
       "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROM_DATASOURCE_UID"
+      },
+      "description": "Current memory usage across workers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisShow": false,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(composition_worker_memory_used_bytes) by (instance)",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Worker Memory Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROM_DATASOURCE_UID"
+      },
+      "description": "P95 of composition cache value size",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisShow": false,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(composition_cache_value_size_bytes_bucket[$__rate_interval])) by (le))",
+          "instant": false,
+          "legendFormat": "P95 Size",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Value Size (P95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROM_DATASOURCE_UID"
+      },
+      "description": "P95 of worker duration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisShow": false,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(composition_worker_duration_ms_bucket[$__rate_interval])) by (le))",
+          "instant": false,
+          "legendFormat": "P95 Duration",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Worker Duration (P95)",
+      "type": "timeseries"
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 38,
   "tags": [],
   "templating": {

--- a/deployment/services/schema.ts
+++ b/deployment/services/schema.ts
@@ -43,6 +43,7 @@ export function deploySchema({
         SCHEMA_CACHE_TTL_MS: '65000' /* 65s */,
         SCHEMA_CACHE_SUCCESS_TTL_MS: String(hourInMS * 2),
         COMPOSITION_WORKER_MAX_OLD_GENERATION_SIZE_MB: '716',
+        COMPOSITION_WORKER_TRACK_MEMORY_USAGE: '1',
         OPENTELEMETRY_COLLECTOR_ENDPOINT:
           observability.enabled && observability.tracingEndpoint
             ? observability.tracingEndpoint

--- a/packages/services/schema/src/composition-scheduler.ts
+++ b/packages/services/schema/src/composition-scheduler.ts
@@ -12,6 +12,7 @@ import {
 
 type WorkerRunArgs = {
   data: CompositionEvent['data'];
+  targetId?: string;
   requestId: string;
   abortSignal: AbortSignal;
 };
@@ -181,6 +182,7 @@ export class CompositionScheduler {
         event: 'composition',
         id: taskId,
         data: args.data,
+        targetId: args.targetId,
         taskId,
         requestId: args.requestId,
       } satisfies CompositionEvent);

--- a/packages/services/schema/src/composition-scheduler.ts
+++ b/packages/services/schema/src/composition-scheduler.ts
@@ -3,11 +3,17 @@ import { Worker } from 'node:worker_threads';
 import fastq from 'fastq';
 import * as Sentry from '@sentry/node';
 import { registerWorkerLogging, type Logger } from '../../api/src/modules/shared/providers/logger';
-import type { CompositionEvent, CompositionResultEvent } from './composition-worker';
+import type {
+  CompositionEvent,
+  CompositionResultEvent,
+  ErrorResultEvent,
+  TrackMetricEvent,
+} from './composition-worker';
 import {
   compositionQueueDurationMS,
   compositionTotalDurationMS,
   compositionWorkerDurationMS,
+  compositionWorkerMemoryUsedBytes,
 } from './metrics';
 
 type WorkerRunArgs = {
@@ -127,18 +133,24 @@ export class CompositionScheduler {
 
     registerWorkerLogging(this.logger, worker, name);
 
-    worker.on(
-      'message',
-      (data: CompositionResultEvent | { event: 'error'; id: string; err: Error }) => {
-        if (data.event === 'error') {
-          workerState?.task.reject(data.err);
-        }
+    worker.on('message', (data: CompositionResultEvent | ErrorResultEvent | TrackMetricEvent) => {
+      if (data.event === 'error') {
+        workerState?.task.reject(data.err);
+      }
 
-        if (data.event === 'compositionResult') {
-          workerState?.task.resolve(data);
+      if (data.event === 'compositionResult') {
+        workerState?.task.resolve(data);
+      }
+
+      if (data.event === 'metric') {
+        if (data.type === 'heapUsed') {
+          compositionWorkerMemoryUsedBytes.set(
+            { target: workerState?.args.targetId, type: workerState?.args.data.type },
+            data.value,
+          );
         }
-      },
-    );
+      }
+    });
 
     const { logger: baseLogger } = this;
 

--- a/packages/services/schema/src/composition-worker.ts
+++ b/packages/services/schema/src/composition-worker.ts
@@ -8,6 +8,13 @@ import { createComposeFederation, type ComposeFederationArgs } from './compositi
 import { composeSingle, type ComposeSingleArgs } from './composition/single';
 import { composeStitching, type ComposeStitchingArgs } from './composition/stitching';
 import type { env } from './environment';
+import { compositionWorkerMemoryUsedBytes } from './metrics';
+
+type ErrorResultEvent = {
+  event: 'error';
+  id: string;
+  err: unknown;
+};
 
 export function createCompositionWorker(args: {
   baseLogger: Logger;
@@ -33,6 +40,16 @@ export function createCompositionWorker(args: {
       event: message.event,
     });
     logger.debug('processing message');
+    const postResult = (result: CompositionResultEvent | ErrorResultEvent) => {
+      args.port.postMessage(result);
+
+      if (args.env.compositionWorker.trackMemoryUsage) {
+        compositionWorkerMemoryUsedBytes.set(
+          { target: message.targetId, type: 'federation' },
+          process.memoryUsage().heapUsed,
+        );
+      }
+    };
 
     try {
       if (message.event === 'composition') {
@@ -44,7 +61,7 @@ export function createCompositionWorker(args: {
           });
           const composed = await composeFederation(message.data.args);
 
-          args.port.postMessage({
+          postResult({
             event: 'compositionResult',
             id: message.id,
             data: {
@@ -73,7 +90,7 @@ export function createCompositionWorker(args: {
 
         if (message.data.type === 'single') {
           const result = await composeSingle(message.data.args);
-          args.port.postMessage({
+          postResult({
             event: 'compositionResult',
             id: message.id,
             data: {
@@ -86,7 +103,7 @@ export function createCompositionWorker(args: {
 
         if (message.data.type === 'stitching') {
           const result = await composeStitching(message.data.args);
-          args.port.postMessage({
+          postResult({
             event: 'compositionResult',
             id: message.id,
             data: {
@@ -106,7 +123,7 @@ export function createCompositionWorker(args: {
         message.id,
       );
       baseLogger.error(String(err));
-      args.port.postMessage({
+      postResult({
         event: 'error',
         id: message.id,
         err,
@@ -123,6 +140,7 @@ export type CompositionEvent = {
   id: string;
   event: 'composition';
   requestId: string;
+  targetId?: string;
   taskId: string;
   data:
     | {

--- a/packages/services/schema/src/composition-worker.ts
+++ b/packages/services/schema/src/composition-worker.ts
@@ -8,7 +8,6 @@ import { createComposeFederation, type ComposeFederationArgs } from './compositi
 import { composeSingle, type ComposeSingleArgs } from './composition/single';
 import { composeStitching, type ComposeStitchingArgs } from './composition/stitching';
 import type { env } from './environment';
-import { compositionWorkerMemoryUsedBytes } from './metrics';
 
 export type ErrorResultEvent = {
   event: 'error';

--- a/packages/services/schema/src/composition-worker.ts
+++ b/packages/services/schema/src/composition-worker.ts
@@ -10,10 +10,17 @@ import { composeStitching, type ComposeStitchingArgs } from './composition/stitc
 import type { env } from './environment';
 import { compositionWorkerMemoryUsedBytes } from './metrics';
 
-type ErrorResultEvent = {
+export type ErrorResultEvent = {
   event: 'error';
   id: string;
   err: unknown;
+};
+
+export type TrackMetricEvent = {
+  event: 'metric';
+} & {
+  type: 'heapUsed';
+  value: number;
 };
 
 export function createCompositionWorker(args: {
@@ -44,10 +51,12 @@ export function createCompositionWorker(args: {
       args.port.postMessage(result);
 
       if (args.env.compositionWorker.trackMemoryUsage) {
-        compositionWorkerMemoryUsedBytes.set(
-          { target: message.targetId, type: message.data.type },
-          process.memoryUsage().heapUsed,
-        );
+        // send metric back to main thread so it can be reported
+        args.port.postMessage({
+          event: 'metric',
+          type: 'heapUsed',
+          value: process.memoryUsage().heapUsed,
+        } satisfies TrackMetricEvent);
       }
     };
 

--- a/packages/services/schema/src/composition-worker.ts
+++ b/packages/services/schema/src/composition-worker.ts
@@ -45,7 +45,7 @@ export function createCompositionWorker(args: {
 
       if (args.env.compositionWorker.trackMemoryUsage) {
         compositionWorkerMemoryUsedBytes.set(
-          { target: message.targetId, type: 'federation' },
+          { target: message.targetId, type: message.data.type },
           process.memoryUsage().heapUsed,
         );
       }

--- a/packages/services/schema/src/environment.ts
+++ b/packages/services/schema/src/environment.ts
@@ -38,6 +38,9 @@ const EnvironmentModel = zod.object({
   AWS_REGION: emptyString(zod.string().optional()),
   COMPOSITION_WORKER_COUNT: zod.number().min(1).default(4),
   COMPOSITION_WORKER_MAX_OLD_GENERATION_SIZE_MB: NumberFromString(1).optional().default(512),
+  COMPOSITION_WORKER_TRACK_MEMORY_USAGE: emptyString(
+    zod.union([zod.literal('1'), zod.literal('0')]),
+  ).optional(),
 });
 
 const RequestBrokerModel = zod.union([
@@ -206,5 +209,6 @@ export const env = {
   compositionWorker: {
     count: base.COMPOSITION_WORKER_COUNT,
     maxOldGenerationSizeMb: base.COMPOSITION_WORKER_MAX_OLD_GENERATION_SIZE_MB,
+    trackMemoryUsage: base.COMPOSITION_WORKER_TRACK_MEMORY_USAGE === '1',
   },
 } as const;

--- a/packages/services/schema/src/metrics.ts
+++ b/packages/services/schema/src/metrics.ts
@@ -38,3 +38,9 @@ export const compositionCacheValueSizeBytes = new metrics.Histogram({
   help: 'The size of the cache entries.',
   buckets: [200, 500, 1_000, 2_000, 3_000, 4_000, 5_000, 7_000, 10_000, 15_000, 20_000, 30_000],
 });
+
+export const compositionWorkerMemoryUsedBytes = new metrics.Gauge({
+  name: 'composition_worker_memory_used_bytes',
+  help: 'Amount of memory used by the composition worker',
+  labelNames: ['target', 'type'],
+});


### PR DESCRIPTION
### Background

The composition worker can crash when the heap memory limit is exceeded. We see occasional crashes and can track those back to targets from the traced request, but it's currently not easy to observe how memory is being impacted over time for a target.

### Description

This adds a new metric for composition worker memory, and displays it on the schema service dashboard