### PR TITLE
feat: make tracking OOM memory issues in schema worker easier

### DIFF
--- a/packages/services/api/src/modules/schema/providers/artifact-storage-writer.ts
+++ b/packages/services/api/src/modules/schema/providers/artifact-storage-writer.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { Inject } from 'graphql-modules';
 import { buildArtifactStorageKey } from '@hive/cdn-script/artifact-storage-reader';
 import { traceFn } from '@hive/service-common';
@@ -181,5 +182,36 @@ export class ArtifactStorageWriter {
       args.artifactType,
       args.contractName,
     );
+  }
+
+  async writeSDLForDebugPurposes(subgraphs: Array<{ sdl: string; name?: string }>) {
+    const hashBuilder = createHash('sha256');
+    for (const subgraph of subgraphs) {
+      hashBuilder.update(subgraph.sdl);
+      if (subgraph.name) {
+        hashBuilder.update(subgraph.name);
+      }
+    }
+
+    const hash = hashBuilder.digest('hex');
+
+    const firstMirror = this.s3Mirrors[0];
+    const url = [firstMirror.endpoint, firstMirror.bucket, 'debug-artifacts', hash + '.json'].join(
+      '/',
+    );
+
+    await firstMirror.client.fetch(url, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(subgraphs),
+      aws: {
+        // This boolean makes Google Cloud Storage & AWS happy.
+        signQuery: true,
+      },
+    });
+
+    return { id: hash.substring(0, 10), url };
   }
 }

--- a/packages/services/api/src/modules/schema/providers/orchestrator/composition-orchestrator.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrator/composition-orchestrator.ts
@@ -1,7 +1,7 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
 import { abortSignalAny } from '@graphql-hive/signal';
 import type { ContractsInputType, SchemaBuilderApi } from '@hive/schema';
-import { traceFn } from '@hive/service-common';
+import { trace, traceFn } from '@hive/service-common';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
 import {
   ComposeAndValidateResult,
@@ -10,6 +10,7 @@ import {
   SchemaObject,
 } from '../../../../shared/entities';
 import { Logger } from '../../../shared/providers/logger';
+import { ArtifactStorageWriter } from '../artifact-storage-writer';
 import type { SchemaServiceConfig } from './tokens';
 import { SCHEMA_SERVICE_CONFIG } from './tokens';
 
@@ -44,6 +45,7 @@ export class CompositionOrchestrator {
 
   constructor(
     logger: Logger,
+    private artifactStorageWriter: ArtifactStorageWriter,
     @Inject(SCHEMA_SERVICE_CONFIG) serviceConfig: SchemaServiceConfig,
     @Inject(CONTEXT) context: GraphQLModules.ModuleContext,
   ) {
@@ -159,6 +161,21 @@ export class CompositionOrchestrator {
           signal: abortSignalAny([this.incomingRequestAbortSignal, timeoutAbortSignal]),
         },
       );
+
+      // If a composition error happens due to OOM we write the subgraphs to S3
+      // This makes it easier to reproduce and debug the issue
+      if (result.errors.some(error => error.code === 'ERR_WORKER_OUT_OF_MEMORY')) {
+        const span = trace.getActiveSpan();
+        if (span) {
+          const result = await this.artifactStorageWriter.writeSDLForDebugPurposes(
+            schemas.map(s => ({ sdl: s.raw, name: s.source })),
+          );
+          trace
+            .getActiveSpan()
+            ?.setAttribute(`hive.composition.subgraphs.${result.id}`, result.url);
+        }
+      }
+
       return result;
     } catch (err) {
       // In case of a timeout error we return something the user can process

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -1754,6 +1754,10 @@ export class SchemaPublisher {
       }),
     ]);
 
+    trace.getActiveSpan()?.setAttributes({
+      'hive.latestSchemaVersion.id': latestVersion?.version.id ?? 'no prior version',
+    });
+
     function increaseSchemaPublishCountMetric(conclusion: 'rejected' | 'accepted' | 'ignored') {
       schemaPublishCount.inc({
         model: 'modern',

--- a/packages/services/schema/src/api.ts
+++ b/packages/services/schema/src/api.ts
@@ -171,6 +171,7 @@ export const schemaBuilderApiRouter = t.router({
                 message:
                   'Composition exceeded resource limits. Please contact the Hive Console Team.',
                 source: 'composition',
+                code: 'ERR_WORKER_OUT_OF_MEMORY',
               },
             ],
             sdl: null,

--- a/packages/services/schema/src/composition/shared.ts
+++ b/packages/services/schema/src/composition/shared.ts
@@ -4,6 +4,7 @@ import type { Metadata } from '../types';
 export type CompositionErrorType = {
   message: string;
   source: CompositionErrorSource;
+  code?: string;
 };
 
 type ContractResult<T> = {


### PR DESCRIPTION
In case of an oom issue, write all the subgraphs as an artifact to s3 and add a reference to that on the trace.

I tested the flow locally by:

Setting low memory
<img width="1654" height="1252" alt="image" src="https://github.com/user-attachments/assets/47423fcd-66ec-4748-b29a-6cf1d44748af" />
Publishing a highe schema, causing an OOM for the worker thread
<img width="1796" height="902" alt="image" src="https://github.com/user-attachments/assets/a80b4741-dbaa-442c-968c-926bfa2d9598" />

The trace is now populated with some reference:
<img width="2522" height="1032" alt="image" src="https://github.com/user-attachments/assets/ca04e887-5ece-4304-89f7-e0f722259913" />

And an artifact is written to our S3 bucket containing all the subgraphs involved in the composition: 
<img width="1698" height="948" alt="image" src="https://github.com/user-attachments/assets/32c060ec-9026-4b46-839d-bc298dde5772" />
<img width="2414" height="1690" alt="image" src="https://github.com/user-attachments/assets/bc55b56b-fc9d-4cf8-beba-2b1d81634fee" />

