### PR TITLE
Dont store or build schemas if encountering stitched errors

### DIFF
--- a/.changeset/social-drinks-speak.md
+++ b/.changeset/social-drinks-speak.md
@@ -1,0 +1,6 @@
+---
+'hive': patch
+---
+
+Optimize memory for composition worker stitching schemas. Don't store or build the schemas if there
+are stitched errors

--- a/packages/services/schema/src/composition/stitching.ts
+++ b/packages/services/schema/src/composition/stitching.ts
@@ -69,7 +69,7 @@ export type ComposeStitchingArgs = {
 
 export async function composeStitching(args: ComposeStitchingArgs) {
   const errors: Array<CompositionErrorType> = [];
-  const subschemas: GraphQLSchema[] = [];
+  let subschemas: GraphQLSchema[] = [];
   for (const schema of args.schemas) {
     // parse inside a loop instead of using map to avoid holding on to the parsed schema
     // in memory. This matters for large schemas.
@@ -77,7 +77,8 @@ export async function composeStitching(args: ComposeStitchingArgs) {
     const stitchedErrors = validateStitchedSchema(parsed);
     if (stitchedErrors.length) {
       errors.push(...stitchedErrors);
-    } else {
+      subschemas = []; // no need to store subschemas if there are errors. It wont be used.
+    } else if (!errors.length) {
       subschemas.push(
         buildASTSchema(trimDescriptions(parsed), {
           assumeValid: true,


### PR DESCRIPTION
### Background

We're trying to reduce the memory usage on composition worker

### Description

If validation fails then we dont run stitching and therefore dont need to build or store the subschemas. This is an optimization for this edge case. It should also return faster in this case since it's not building the schemas.