### PR TITLE
Upgrade grafana pulumi provider + standardize dashboard naming

### DIFF
--- a/.changeset/ripe-mails-tan.md
+++ b/.changeset/ripe-mails-tan.md
@@ -1,0 +1,6 @@
+---
+'hive': patch
+---
+
+Standardizes Grafana dashboard names to their file names with a `hive-` prefix. Existing bookmarks
+will need to be updated.

--- a/.changeset/ripe-mails-tan.md
+++ b/.changeset/ripe-mails-tan.md
@@ -1,6 +1,0 @@
----
-'hive': patch
----
-
-Standardizes Grafana dashboard names to their file names with a `hive-` prefix. Existing bookmarks
-will need to be updated.

--- a/deployment/package.json
+++ b/deployment/package.json
@@ -8,7 +8,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@lbrlabs/pulumi-grafana": "0.1.0",
     "@manypkg/get-packages": "2.2.2",
     "@pulumi/aws": "7.12.0",
     "@pulumi/cloudflare": "4.16.0",
@@ -17,6 +16,7 @@
     "@pulumi/kubernetesx": "0.1.6",
     "@pulumi/pulumi": "3.214.0",
     "@pulumi/random": "4.18.2",
+    "@pulumiverse/grafana": "2.34.1",
     "js-yaml": "4.2.0",
     "pg-connection-string": "2.9.1",
     "prettier": "3.4.2"

--- a/deployment/services/grafana-alerts.ts
+++ b/deployment/services/grafana-alerts.ts
@@ -1,4 +1,4 @@
-import { Folder, RuleGroup } from '@lbrlabs/pulumi-grafana';
+import { alerting, oss } from '@pulumiverse/grafana';
 
 /**
  * Provisions Grafana alert rules that target the Prometheus metrics exposed by
@@ -17,7 +17,7 @@ import { Folder, RuleGroup } from '@lbrlabs/pulumi-grafana';
 export function deployGrafanaAlerts(envName: string) {
   // Separate folder from dashboards keeps the alerts list scoped and makes it
   // clear what's machine-managed vs. operator-edited.
-  const folder = new Folder('grafana-hive-alerts-folder', {
+  const folder = new oss.Folder('grafana-hive-alerts-folder', {
     title: `Hive Alerts (${envName})`,
   });
 
@@ -26,7 +26,7 @@ export function deployGrafanaAlerts(envName: string) {
   // `orgId: 1` is the default "Main Org" — Folder and Dashboard fall back to
   // the provider's configured org when omitted, but RuleGroup validates the
   // property at construct time and throws if missing.
-  const ruleGroup = new RuleGroup('metric-alerts-evaluator', {
+  const ruleGroup = new alerting.RuleGroup('metric-alerts-evaluator', {
     orgId: '1',
     folderUid: folder.uid,
     name: 'metric-alerts-evaluator',

--- a/deployment/services/grafana-alerts.ts
+++ b/deployment/services/grafana-alerts.ts
@@ -19,6 +19,7 @@ export function deployGrafanaAlerts(envName: string) {
   // clear what's machine-managed vs. operator-edited.
   const folder = new oss.Folder('grafana-hive-alerts-folder', {
     title: `Hive Alerts (${envName})`,
+    uid: 'hive-alerts',
   });
 
   // Single rule group for the metric-alerts feature; evaluation interval

--- a/deployment/services/grafana.ts
+++ b/deployment/services/grafana.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync } from 'fs';
 import { join, parse } from 'path';
-import { Dashboard, Folder } from '@lbrlabs/pulumi-grafana';
 import * as pulumi from '@pulumi/pulumi';
+import { oss } from '@pulumiverse/grafana';
 
 const dashboardDirectory = join(__dirname, '../grafana-dashboards/');
 
@@ -20,7 +20,7 @@ export function deployGrafana(envName: string, tableSuffix: string) {
   const availableFiles = readdirSync(dashboardDirectory).filter(
     f => f.endsWith('.json') && !excludedDashboards.includes(f),
   );
-  const folder = new Folder('grafana-hive-folder', {
+  const folder = new oss.Folder('grafana-hive-folder', {
     title: `Hive Monitoring (${envName})`,
   });
 
@@ -52,7 +52,7 @@ export function deployGrafana(envName: string, tableSuffix: string) {
       delete configJson.version;
     }
 
-    return new Dashboard(`dashboard-${identifier.toLowerCase()}`, {
+    return new oss.Dashboard(`dashboard-${identifier.toLowerCase()}`, {
       folder: folder.id,
       configJson: JSON.stringify(configJson, null, 2),
     });

--- a/deployment/services/grafana.ts
+++ b/deployment/services/grafana.ts
@@ -22,6 +22,7 @@ export function deployGrafana(envName: string, tableSuffix: string) {
   );
   const folder = new oss.Folder('grafana-hive-folder', {
     title: `Hive Monitoring (${envName})`,
+    uid: 'hive-monitoring',
   });
 
   const params = new pulumi.Config('grafanaDashboards').requireObject<Record<string, string>>(
@@ -44,16 +45,13 @@ export function deployGrafana(envName: string, tableSuffix: string) {
 
     const configJson = JSON.parse(configString);
 
-    if ('uid' in configJson) {
-      delete configJson.uid;
-    }
-
-    if ('version' in configJson) {
-      delete configJson.version;
-    }
+    // Pin a stable uid from the filename so dashboard URLs survive redeploys
+    configJson.uid = `hive-${identifier.toLowerCase().replace(/^hive-/, '')}`;
+    delete configJson.id;
+    delete configJson.version;
 
     return new oss.Dashboard(`dashboard-${identifier.toLowerCase()}`, {
-      folder: folder.id,
+      folder: folder.uid,
       configJson: JSON.stringify(configJson, null, 2),
     });
   });

--- a/deployment/services/grafana.ts
+++ b/deployment/services/grafana.ts
@@ -10,16 +10,7 @@ const dashboardDirectory = join(__dirname, '../grafana-dashboards/');
  * @param tableSuffix suffix for the table names (production, staging, dev)
  */
 export function deployGrafana(envName: string, tableSuffix: string) {
-  // Dashboards excluded from provisioning:
-  const excludedDashboards = [
-    'ClickHouse-Latency.json', // temp workaround
-    // #8114: the outdated provider churns this dashboard's uid/folder on Grafana
-    // 13, so it's managed manually in the UI until the provider upgrade.
-    'Metric-Alerts.json',
-  ];
-  const availableFiles = readdirSync(dashboardDirectory).filter(
-    f => f.endsWith('.json') && !excludedDashboards.includes(f),
-  );
+  const availableFiles = readdirSync(dashboardDirectory).filter(f => f.endsWith('.json'));
   const folder = new oss.Folder('grafana-hive-folder', {
     title: `Hive Monitoring (${envName})`,
     uid: 'hive-monitoring',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,9 +254,6 @@ importers:
 
   deployment:
     dependencies:
-      '@lbrlabs/pulumi-grafana':
-        specifier: 0.1.0
-        version: 0.1.0(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.13.3)(typescript@5.7.3))(typescript@5.7.3)
       '@manypkg/get-packages':
         specifier: 2.2.2
         version: 2.2.2
@@ -281,6 +278,9 @@ importers:
       '@pulumi/random':
         specifier: 4.18.2
         version: 4.18.2(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.13.3)(typescript@5.7.3))(typescript@5.7.3)
+      '@pulumiverse/grafana':
+        specifier: 2.34.1
+        version: 2.34.1(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.13.3)(typescript@5.7.3))(typescript@5.7.3)
       js-yaml:
         specifier: 4.3.0
         version: 4.3.0
@@ -5941,9 +5941,6 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
-  '@lbrlabs/pulumi-grafana@0.1.0':
-    resolution: {integrity: sha512-REc/LQOy17O9jbZnBNm4tLjLJKxOfLaWPIB2CFiAtM1VzwU3FzZQFs0K+XGkuZwWdB+tl2/VHdHv+FqsUrit2w==}
-
   '@lezer/common@1.5.1':
     resolution: {integrity: sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==}
 
@@ -7591,6 +7588,9 @@ packages:
 
   '@pulumi/random@4.18.2':
     resolution: {integrity: sha512-jC0HfgkFKwgUGmocM7Tw6UyOrpLFXGO8kYfV6f5Q9R/yziaVxEVPQ0Uup2HfosDh926EZHJrt2EUIJHWCyOvFA==}
+
+  '@pulumiverse/grafana@2.34.1':
+    resolution: {integrity: sha512-NWB2a25zP897sAnmYjpq2lzDGIP8e3o7VY0naPXTG2eiksgvvzbRbciFNFyYObYkQVT7dHUFXtS/0Yj8BWB/FQ==}
 
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
@@ -25875,16 +25875,6 @@ snapshots:
       - typescript
       - yaml
 
-  '@lbrlabs/pulumi-grafana@0.1.0(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.13.3)(typescript@5.7.3))(typescript@5.7.3)':
-    dependencies:
-      '@pulumi/pulumi': 3.214.0(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.13.3)(typescript@5.7.3))(typescript@5.7.3)
-    transitivePeerDependencies:
-      - bluebird
-      - kerberos
-      - supports-color
-      - ts-node
-      - typescript
-
   '@lezer/common@1.5.1': {}
 
   '@lezer/highlight@1.2.3':
@@ -28347,6 +28337,16 @@ snapshots:
       - supports-color
 
   '@pulumi/random@4.18.2(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.13.3)(typescript@5.7.3))(typescript@5.7.3)':
+    dependencies:
+      '@pulumi/pulumi': 3.214.0(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.13.3)(typescript@5.7.3))(typescript@5.7.3)
+    transitivePeerDependencies:
+      - bluebird
+      - kerberos
+      - supports-color
+      - ts-node
+      - typescript
+
+  '@pulumiverse/grafana@2.34.1(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.13.3)(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
       '@pulumi/pulumi': 3.214.0(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.13.3)(typescript@5.7.3))(typescript@5.7.3)
     transitivePeerDependencies:


### PR DESCRIPTION
This PR migrates the Pulumi provisioning provider to `@pulumiverse/grafana`. 

It also implements standardized naming for all of the dashboards...slugs derived from the file name and prefixed with `hive-`. Additionally, this PR re-includes the two dashboards that had previously been excluded.
 