### PR TITLE
Upgrade federation-composition to support oneOf directive in the public SDL

### DIFF
--- a/.changeset/famous-lizards-dress.md
+++ b/.changeset/famous-lizards-dress.md
@@ -1,0 +1,8 @@
+---
+'@graphql-hive/cli': patch
+'hive': patch
+---
+
+Upgrade `@theguild/federation-composition` to support oneOf directive in public sdl
+
+https://github.com/graphql-hive/federation-composition/releases/tag/v0.23.3

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -26,7 +26,7 @@
     "@hive/server": "workspace:*",
     "@hive/service-common": "workspace:*",
     "@hive/storage": "workspace:*",
-    "@theguild/federation-composition": "0.23.2",
+    "@theguild/federation-composition": "0.23.3",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@types/async-retry": "1.4.8",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@sentry/cli": "2.40.0",
     "@swc/core": "1.13.5",
     "@theguild/eslint-config": "0.12.1",
-    "@theguild/federation-composition": "0.23.2",
+    "@theguild/federation-composition": "0.23.3",
     "@theguild/prettier-config": "2.0.7",
     "@types/node": "24.13.3",
     "bob-the-bundler": "7.0.1",

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -60,7 +60,7 @@
     "@oclif/core": "3.26.6",
     "@oclif/plugin-help": "6.2.36",
     "@oclif/plugin-update": "4.7.16",
-    "@theguild/federation-composition": "0.23.2",
+    "@theguild/federation-composition": "0.23.3",
     "cli-table3": "0.6.5",
     "colors": "1.4.0",
     "env-ci": "7.3.0",

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -46,7 +46,7 @@
     "@sentry/node": "7.120.2",
     "@sentry/types": "7.120.2",
     "@slack/web-api": "7.10.0",
-    "@theguild/federation-composition": "0.23.2",
+    "@theguild/federation-composition": "0.23.3",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@types/bcryptjs": "2.4.6",

--- a/packages/services/demo/federation/package.json
+++ b/packages/services/demo/federation/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@apollo/subgraph": "2.13.2",
-    "@theguild/federation-composition": "0.23.2",
+    "@theguild/federation-composition": "0.23.3",
     "graphql": "16.9.0",
     "graphql-yoga": "5.13.3"
   },

--- a/packages/services/schema/__tests__/federation.spec.ts
+++ b/packages/services/schema/__tests__/federation.spec.ts
@@ -1,5 +1,6 @@
 import { parse } from 'graphql';
 import { composeAndValidate } from '@apollo/federation';
+import { composeServices as hiveComposeAndValidate } from '@theguild/federation-composition';
 
 test('patch', () => {
   const result = composeAndValidate([
@@ -51,4 +52,35 @@ test('patch', () => {
   expect(result.errors!.map(e => e.message)).toContainEqual(
     expect.stringMatching('Unknown type "Review"'),
   );
+});
+
+test('oneOf directive', async () => {
+  const serviceA = /* GraphQL */ `
+    type Query {
+      query(input: Input): Boolean
+    }
+
+    input Input @oneOf {
+      id: ID
+      string: String
+    }
+  `;
+
+  const result = await hiveComposeAndValidate([
+    {
+      typeDefs: parse(serviceA),
+      name: 'service-a',
+      url: 'http://localhost:4001',
+    },
+  ]);
+
+  expect(result.errors).toBeUndefined();
+  // if condition for typing
+  if (result.errors === undefined) {
+    expect(result.supergraphSdl).toContain(`directive @oneOf on INPUT_OBJECT`);
+    expect(result.supergraphSdl).toContain(`input Input @join__type(graph: SERVICE_A)  @oneOf`);
+
+    expect(result.publicSdl).toContain(`directive @oneOf on INPUT_OBJECT`);
+    expect(result.publicSdl).toContain(`input Input @oneOf`);
+  }
 });

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -16,7 +16,7 @@
     "@graphql-tools/utils": "11.1.0",
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.120.2",
-    "@theguild/federation-composition": "0.23.2",
+    "@theguild/federation-composition": "0.23.3",
     "@trpc/server": "10.45.3",
     "@types/async-retry": "1.4.8",
     "@types/ioredis-mock": "8.2.5",

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -38,7 +38,7 @@
     "@hive/workflows": "workspace:*",
     "@sentry/node": "7.120.2",
     "@swc/core": "1.13.5",
-    "@theguild/federation-composition": "0.23.2",
+    "@theguild/federation-composition": "0.23.3",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@whatwg-node/server": "0.10.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: 0.12.1
         version: 0.12.1(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3)
       '@theguild/federation-composition':
-        specifier: 0.23.2
-        version: 0.23.2(graphql@16.9.0)
+        specifier: 0.23.3
+        version: 0.23.3(graphql@16.9.0)
       '@theguild/prettier-config':
         specifier: 2.0.7
         version: 2.0.7(prettier@3.4.2)
@@ -353,8 +353,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/services/storage
       '@theguild/federation-composition':
-        specifier: 0.23.2
-        version: 0.23.2(graphql@16.9.0)
+        specifier: 0.23.3
+        version: 0.23.3(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -529,8 +529,8 @@ importers:
         specifier: 4.7.16
         version: 4.7.16
       '@theguild/federation-composition':
-        specifier: 0.23.2
-        version: 0.23.2(graphql@16.9.0)
+        specifier: 0.23.3
+        version: 0.23.3(graphql@16.9.0)
       cli-table3:
         specifier: 0.6.5
         version: 0.6.5
@@ -1169,8 +1169,8 @@ importers:
         specifier: 7.10.0
         version: 7.10.0
       '@theguild/federation-composition':
-        specifier: 0.23.2
-        version: 0.23.2(graphql@16.9.0)
+        specifier: 0.23.3
+        version: 0.23.3(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -1415,8 +1415,8 @@ importers:
         specifier: 2.13.2
         version: 2.13.2(graphql@16.9.0)
       '@theguild/federation-composition':
-        specifier: 0.23.2
-        version: 0.23.2(graphql@16.9.0)
+        specifier: 0.23.3
+        version: 0.23.3(graphql@16.9.0)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -1527,8 +1527,8 @@ importers:
         specifier: 7.120.2
         version: 7.120.2
       '@theguild/federation-composition':
-        specifier: 0.23.2
-        version: 0.23.2(graphql@16.9.0)
+        specifier: 0.23.3
+        version: 0.23.3(graphql@16.9.0)
       '@trpc/server':
         specifier: 10.45.3
         version: 10.45.3
@@ -1653,8 +1653,8 @@ importers:
         specifier: 1.13.5
         version: 1.13.5
       '@theguild/federation-composition':
-        specifier: 0.23.2
-        version: 0.23.2(graphql@16.9.0)
+        specifier: 0.23.3
+        version: 0.23.3(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -10529,8 +10529,8 @@ packages:
     peerDependencies:
       graphql: ^16.0.0
 
-  '@theguild/federation-composition@0.23.2':
-    resolution: {integrity: sha512-Xpdbm+MwSEUVIViZZxyngbG2O9pBLYKJAUctv7iAeUXGtM45qYCA810bRqKOkizVKVpMRLATz3srfTcBKRSqcQ==}
+  '@theguild/federation-composition@0.23.3':
+    resolution: {integrity: sha512-dXUTrIqqfErS9QWdLOn2WqrKvcVtclBkuGMH78uENA19x8LsatnVaV/FkTlvpWlbHlmTxbgP1yZm1ig8GyjvkQ==}
     engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.0.0
@@ -31700,7 +31700,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@theguild/federation-composition@0.23.2(graphql@16.9.0)':
+  '@theguild/federation-composition@0.23.3(graphql@16.9.0)':
     dependencies:
       constant-case: 3.0.4
       debug: 4.4.3(supports-color@8.1.1)


### PR DESCRIPTION
### Background

oneOf is currently only being composed into the supergraph. The package is filtering out the directive from the public SDL

### Description

Upgrades federation-composition package to support outputting the directive definition in the public sdl

### Checklist

- [X] Testing
