### PR TITLE
improve changeset

### DIFF
--- a/.changeset/famous-lizards-dress.md
+++ b/.changeset/famous-lizards-dress.md
@@ -3,6 +3,5 @@
 'hive': patch
 ---
 
-Upgrade `@theguild/federation-composition` to support oneOf directive in public sdl
+Retain the `@oneOf` directive in the schema sdl. (Upgrade [`@theguild/federation-composition`](https://github.com/graphql-hive/federation-composition/releases/tag/v0.23.3))
 
-https://github.com/graphql-hive/federation-composition/releases/tag/v0.23.3

--- a/.changeset/famous-lizards-dress.md
+++ b/.changeset/famous-lizards-dress.md
@@ -3,5 +3,5 @@
 'hive': patch
 ---
 
-Retain the `@oneOf` directive in the schema sdl. (Upgrade [`@theguild/federation-composition`](https://github.com/graphql-hive/federation-composition/releases/tag/v0.23.3))
+Retain the `@oneOf` directive definition in the schema sdl. (Upgrade [`@theguild/federation-composition`](https://github.com/graphql-hive/federation-composition/releases/tag/v0.23.3))
 


### PR DESCRIPTION
Retain the `@oneOf` directive in the schema sdl after upgrading.

<!--
Before Contributing, please review the contribution guide:
https://the-guild.dev/graphql/hive/docs/schema-registry/contributing
--->

### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for developing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
