### PR TITLE
allow fractional metric alert threshold values

### DIFF
--- a/packages/web/app/src/components/target/alerts/alert-form.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-form.tsx
@@ -828,6 +828,7 @@ export function AlertForm(props: AlertFormProps) {
                           <FormControl>
                             <Input
                               type="number"
+                              step="any"
                               min={0}
                               max={valueMax}
                               placeholder={valuePlaceholder}


### PR DESCRIPTION
This PR fixes the threshold value input, which previously had no `step`, so the browser's default `step=1` rejected values like `0.5` before React Hook Form ever saw them. Added `step="any"`...decimals were already supported end to end (`threshold_value` is `double precision`).
