### PR TITLE
Fix usage collector error catching

### DIFF
--- a/.changeset/puny-roses-shine.md
+++ b/.changeset/puny-roses-shine.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/core': patch
+---
+
+Fix usage collector error catching.
+
+When async event collection fails, the error is now caught internally and logged rather than leaking an unhandled promise rejection that would crash the node application.

--- a/packages/libraries/core/src/client/agent.ts
+++ b/packages/libraries/core/src/client/agent.ts
@@ -126,9 +126,11 @@ export function createAgent<TEvent>(
     if (event instanceof Promise) {
       const promise = captureAsync(event);
       inProgressCaptures.push(promise);
-      void promise.finally(() => {
-        inProgressCaptures = inProgressCaptures.filter(p => p !== promise);
-      });
+      void promise
+        .catch(e => logger.error('Failed to capture async event (error=%o)', e))
+        .finally(() => {
+          inProgressCaptures = inProgressCaptures.filter(p => p !== promise);
+        });
     } else {
       captureSync(event);
     }
@@ -227,7 +229,7 @@ export function createAgent<TEvent>(
     }
 
     if (inProgressCaptures.length) {
-      await Promise.all(inProgressCaptures);
+      await Promise.allSettled(inProgressCaptures);
     }
 
     await send({

--- a/packages/libraries/core/tests/client/agent.spec.ts
+++ b/packages/libraries/core/tests/client/agent.spec.ts
@@ -1,0 +1,41 @@
+import { createHiveTestingLogger } from 'test-utils.js';
+import { createAgent } from '../../src/client/agent.js';
+
+describe('createAgent', () => {
+  it('should gracefully handle and log rejected promises passed to capture()', async () => {
+    const mockLogger = createHiveTestingLogger();
+    const unhandledRejectionSpy = vi.fn();
+    process.on('unhandledRejection', unhandledRejectionSpy);
+
+    let d = new Set();
+    const data = {
+      clear: () => d.clear(),
+      set: (v: unknown) => d.add(v),
+      size: () => d.size,
+    };
+
+    const agent = createAgent(
+      {
+        endpoint: 'http://localhost/test',
+        token: 'test-token',
+        logger: mockLogger as any,
+      },
+      {
+        data,
+        body: () => 'test-body',
+      },
+    );
+
+    const err = new Error('Testing');
+    const rejectedPromise = Promise.reject(err);
+
+    agent.capture(rejectedPromise);
+    await expect(agent.dispose()).resolves.not.toThrow(); // wait for the capture to be resolved/rejected
+    expect(mockLogger.getLogs()).toEqual(
+      expect.stringContaining('[ERR] Failed to capture async event (error={})'),
+    );
+    process.off('unhandledRejection', unhandledRejectionSpy);
+    expect(unhandledRejectionSpy).not.toHaveBeenCalled();
+    expect(data.size()).toBe(0);
+  });
+});


### PR DESCRIPTION
### Background

The usage client is capable of crashing a node application due to an unhandled error if collectSchemaCoordinates throws.

### Description

Captures this error and reports it as intended.

### Checklist

- [X] Error handling and logging
- [X] Testing
