### PR TITLE
fix: add missing tslib dependency to core

### DIFF
--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -54,7 +54,8 @@
     "events": "^3.3.0",
     "js-md5": "0.8.3",
     "lodash.sortby": "^4.7.0",
-    "tiny-lru": "^11.4.7"
+    "tiny-lru": "^11.4.7",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@apollo/federation": "0.38.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,6 +611,9 @@ importers:
       tiny-lru:
         specifier: ^11.4.7
         version: 11.4.7
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
     devDependencies:
       '@apollo/federation':
         specifier: 0.38.1
@@ -633,9 +636,6 @@ importers:
       nock:
         specifier: 14.0.10
         version: 14.0.10
-      tslib:
-        specifier: 2.8.1
-        version: 2.8.1
       vitest:
         specifier: 4.1.3
         version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@7.3.6(@types/node@25.5.0)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.31.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))


### PR DESCRIPTION
closes https://github.com/graphql-hive/console/issues/8315