### PR TITLE
feat: improve federation supergraph formatting

### DIFF
--- a/.changeset/every-games-refuse.md
+++ b/.changeset/every-games-refuse.md
@@ -1,0 +1,6 @@
+---
+'hive': minor
+---
+
+Improve supergraph artifact formatting by reducing excessive whitespace for federation type
+definitions

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -29,7 +29,7 @@
     "@hive/service-common": "workspace:*",
     "@hive/storage": "workspace:*",
     "@hive/workflows": "workspace:*",
-    "@theguild/federation-composition": "0.23.3",
+    "@theguild/federation-composition": "0.24.0",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@types/async-retry": "1.4.8",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -29,7 +29,7 @@
     "@hive/service-common": "workspace:*",
     "@hive/storage": "workspace:*",
     "@hive/workflows": "workspace:*",
-    "@theguild/federation-composition": "0.24.0",
+    "@theguild/federation-composition": "0.24.1",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@types/async-retry": "1.4.8",

--- a/integration-tests/tests/api/schema/composite.spec.ts
+++ b/integration-tests/tests/api/schema/composite.spec.ts
@@ -268,7 +268,7 @@ describe('Federation projects support @oneOf directive natively', () => {
 
     const supergraphSdl = details?.supergraph;
     expect(supergraphSdl).toContain(`directive @oneOf on INPUT_OBJECT`);
-    expect(supergraphSdl).toContain(`input Input @join__type(graph: SERVICE_A)  @oneOf`);
+    expect(supergraphSdl).toContain(`input Input @join__type(graph: SERVICE_A) @oneOf`);
 
     const publicSdl = details?.sdl;
     expect(publicSdl).toContain(`directive @oneOf on INPUT_OBJECT`);
@@ -322,7 +322,7 @@ describe('Federation projects support @oneOf directive natively', () => {
     const supergraphSdl = details.target.schemaCheck.supergraphSDL;
     assert(supergraphSdl);
     expect(supergraphSdl).toContain(`directive @oneOf on INPUT_OBJECT`);
-    expect(supergraphSdl).toContain(`input Input @join__type(graph: SERVICE_A)  @oneOf`);
+    expect(supergraphSdl).toContain(`input Input @join__type(graph: SERVICE_A) @oneOf`);
 
     const publicSdl = details.target.schemaCheck.compositeSchemaSDL;
     assert(publicSdl);
@@ -377,7 +377,7 @@ describe('Federation projects support @oneOf directive natively', () => {
     assert(details);
     const supergraphSdl = details.supergraph;
     expect(supergraphSdl).toContain(`directive @oneOf on INPUT_OBJECT`);
-    expect(supergraphSdl).toContain(`input Input @join__type(graph: SERVICE_A)  @oneOf`);
+    expect(supergraphSdl).toContain(`input Input @join__type(graph: SERVICE_A) @oneOf`);
 
     const sdl = details.sdl;
     expect(sdl).toContain(`directive @oneOf on INPUT_OBJECT`);

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@sentry/cli": "2.40.0",
     "@swc/core": "1.13.5",
     "@theguild/eslint-config": "0.12.1",
-    "@theguild/federation-composition": "0.23.3",
+    "@theguild/federation-composition": "0.24.0",
     "@theguild/prettier-config": "2.0.7",
     "@types/node": "24.13.3",
     "bob-the-bundler": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@sentry/cli": "2.40.0",
     "@swc/core": "1.13.5",
     "@theguild/eslint-config": "0.12.1",
-    "@theguild/federation-composition": "0.24.0",
+    "@theguild/federation-composition": "0.24.1",
     "@theguild/prettier-config": "2.0.7",
     "@types/node": "24.13.3",
     "bob-the-bundler": "7.0.1",

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -60,7 +60,7 @@
     "@oclif/core": "3.26.6",
     "@oclif/plugin-help": "6.2.36",
     "@oclif/plugin-update": "4.7.16",
-    "@theguild/federation-composition": "0.24.0",
+    "@theguild/federation-composition": "0.24.1",
     "cli-table3": "0.6.5",
     "colors": "1.4.0",
     "env-ci": "7.3.0",

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -60,7 +60,7 @@
     "@oclif/core": "3.26.6",
     "@oclif/plugin-help": "6.2.36",
     "@oclif/plugin-update": "4.7.16",
-    "@theguild/federation-composition": "0.23.3",
+    "@theguild/federation-composition": "0.24.0",
     "cli-table3": "0.6.5",
     "colors": "1.4.0",
     "env-ci": "7.3.0",

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -49,7 +49,7 @@
     "@sentry/node": "7.120.2",
     "@sentry/types": "7.120.2",
     "@slack/web-api": "7.10.0",
-    "@theguild/federation-composition": "0.24.0",
+    "@theguild/federation-composition": "0.24.1",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@types/bcryptjs": "2.4.6",

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -49,7 +49,7 @@
     "@sentry/node": "7.120.2",
     "@sentry/types": "7.120.2",
     "@slack/web-api": "7.10.0",
-    "@theguild/federation-composition": "0.23.3",
+    "@theguild/federation-composition": "0.24.0",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@types/bcryptjs": "2.4.6",

--- a/packages/services/demo/federation/package.json
+++ b/packages/services/demo/federation/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@apollo/subgraph": "2.13.2",
-    "@theguild/federation-composition": "0.23.3",
+    "@theguild/federation-composition": "0.24.0",
     "graphql": "16.9.0",
     "graphql-yoga": "5.13.3"
   },

--- a/packages/services/demo/federation/package.json
+++ b/packages/services/demo/federation/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@apollo/subgraph": "2.13.2",
-    "@theguild/federation-composition": "0.24.0",
+    "@theguild/federation-composition": "0.24.1",
     "graphql": "16.9.0",
     "graphql-yoga": "5.13.3"
   },

--- a/packages/services/schema/__tests__/federation.spec.ts
+++ b/packages/services/schema/__tests__/federation.spec.ts
@@ -1,5 +1,6 @@
-import { parse } from 'graphql';
+import { parse, print } from 'graphql';
 import { composeAndValidate } from '@apollo/federation';
+import { composeFederationV2 } from '../src/lib/compose';
 
 test('patch', () => {
   const result = composeAndValidate([
@@ -51,4 +52,29 @@ test('patch', () => {
   expect(result.errors!.map(e => e.message)).toContainEqual(
     expect.stringMatching('Unknown type "Review"'),
   );
+});
+
+test('native federation formats the composed supergraph', () => {
+  const result = composeFederationV2([
+    {
+      typeDefs: parse(/* GraphQL */ `
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])
+
+        type Product @key(fields: "id") {
+          id: ID!
+        }
+
+        type Query {
+          product: Product
+        }
+      `),
+      name: 'products',
+      url: 'https://products.example.com/graphql',
+    },
+  ]);
+
+  expect(result.type).toBe('success');
+  if (result.type === 'success') {
+    expect(result.result.supergraph).toBe(print(parse(result.result.supergraph)));
+  }
 });

--- a/packages/services/schema/__tests__/federation.spec.ts
+++ b/packages/services/schema/__tests__/federation.spec.ts
@@ -1,4 +1,4 @@
-import { parse, print } from 'graphql';
+import { parse } from 'graphql';
 import { composeAndValidate } from '@apollo/federation';
 import { composeFederationV2 } from '../src/lib/compose';
 

--- a/packages/services/schema/__tests__/federation.spec.ts
+++ b/packages/services/schema/__tests__/federation.spec.ts
@@ -54,7 +54,7 @@ test('patch', () => {
   );
 });
 
-test('native federation formats the composed supergraph', () => {
+test('native federation formats the composed supergraph', ({ expect }) => {
   const result = composeFederationV2([
     {
       typeDefs: parse(/* GraphQL */ `
@@ -74,7 +74,64 @@ test('native federation formats the composed supergraph', () => {
   ]);
 
   expect(result.type).toBe('success');
-  if (result.type === 'success') {
-    expect(result.result.supergraph).toBe(print(parse(result.result.supergraph)));
-  }
+  expect(result.result.supergraph).toMatchInlineSnapshot(`
+    schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+      query: Query
+    }
+
+    directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+    directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+    directive @join__field(
+      graph: join__Graph
+      requires: join__FieldSet
+      provides: join__FieldSet
+      type: String
+      external: Boolean
+      override: String
+      usedOverridden: Boolean
+    ) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+    directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+    directive @join__type(
+      graph: join__Graph!
+      key: join__FieldSet
+      extension: Boolean! = false
+      resolvable: Boolean! = true
+      isInterfaceObject: Boolean! = false
+    ) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+    directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+    scalar join__FieldSet
+
+    directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+    scalar link__Import
+
+    enum link__Purpose {
+      """
+      \`SECURITY\` features provide metadata necessary to securely resolve fields.
+      """
+      SECURITY
+      """
+      \`EXECUTION\` features provide metadata necessary for operation execution.
+      """
+      EXECUTION
+    }
+
+    enum join__Graph {
+      PRODUCTS @join__graph(name: "products", url: "https://products.example.com/graphql")
+    }
+
+    type Product @join__type(graph: PRODUCTS, key: "id") {
+      id: ID!
+    }
+
+    type Query @join__type(graph: PRODUCTS) {
+      product: Product
+    }
+  `);
 });

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -16,7 +16,7 @@
     "@graphql-tools/utils": "11.1.0",
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.120.2",
-    "@theguild/federation-composition": "0.24.0",
+    "@theguild/federation-composition": "0.24.1",
     "@trpc/server": "10.45.3",
     "@types/async-retry": "1.4.8",
     "@types/ioredis-mock": "8.2.5",

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -16,7 +16,7 @@
     "@graphql-tools/utils": "11.1.0",
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.120.2",
-    "@theguild/federation-composition": "0.23.3",
+    "@theguild/federation-composition": "0.24.0",
     "@trpc/server": "10.45.3",
     "@types/async-retry": "1.4.8",
     "@types/ioredis-mock": "8.2.5",

--- a/packages/services/schema/src/composition/federation.ts
+++ b/packages/services/schema/src/composition/federation.ts
@@ -260,11 +260,16 @@ export const createComposeFederation = (deps: ComposeFederationDeps) =>
           contract.filter.removeUnreachableTypesFromPublicApiSchema === true &&
           compositionResult.type === 'success'
         ) {
-          let supergraphSDL = parse(compositionResult.result.supergraph);
-          const { resolveImportName } = extractLinkImplementations(supergraphSDL);
+          const supergraphDocumentNode =
+            compositionResult.result.supergraphDocumentNode ??
+            parse(compositionResult.result.supergraph);
+          const publicDocumentNode =
+            compositionResult.result.sdlDocumentNode ?? parse(compositionResult.result.sdl);
+
+          const { resolveImportName } = extractLinkImplementations(supergraphDocumentNode);
           const result = addInaccessibleToUnreachableTypes(resolveImportName, {
-            supergraphSdl: compositionResult.result.supergraph,
-            publicSdl: compositionResult.result.sdl,
+            supergraphDocumentNode,
+            publicDocumentNode,
           });
 
           return {

--- a/packages/services/schema/src/composition/federation.ts
+++ b/packages/services/schema/src/composition/federation.ts
@@ -171,7 +171,7 @@ export const createComposeFederation = (deps: ComposeFederationDeps) =>
           extractMetadata(typeDefs, name),
         );
         const supergraphDocumentNode =
-          composed.result.sdlDocumentNode ?? parse(composed.result.supergraph);
+          composed.result.supergraphDocumentNode ?? parse(composed.result.supergraph);
         const { resolveImportName } = extractLinkImplementations(supergraphDocumentNode);
         const tagDirectiveName = resolveImportName('https://specs.apollo.dev/tag', '@tag');
         const tagStrategy = createTagDirectiveNameExtractionStrategy(tagDirectiveName);

--- a/packages/services/schema/src/composition/federation.ts
+++ b/packages/services/schema/src/composition/federation.ts
@@ -170,12 +170,12 @@ export const createComposeFederation = (deps: ComposeFederationDeps) =>
         const subgraphsMetadata = subgraphs.map(({ name, typeDefs }) =>
           extractMetadata(typeDefs, name),
         );
-        const supergraphDocumentNode =
-          composed.result.supergraphDocumentNode ?? parse(composed.result.supergraph);
-        const { resolveImportName } = extractLinkImplementations(supergraphDocumentNode);
+        const { resolveImportName } = extractLinkImplementations(
+          composed.result.supergraphDocumentNode,
+        );
         const tagDirectiveName = resolveImportName('https://specs.apollo.dev/tag', '@tag');
         const tagStrategy = createTagDirectiveNameExtractionStrategy(tagDirectiveName);
-        const tags = extractTagsFromDocument(supergraphDocumentNode, tagStrategy);
+        const tags = extractTagsFromDocument(composed.result.supergraphDocumentNode, tagStrategy);
         const schemaMetadata = mergeMetadata(...subgraphsMetadata);
         const metadataAttributes = new SetMap<string, string>();
         for (const [_coord, attrs] of schemaMetadata) {
@@ -261,11 +261,8 @@ export const createComposeFederation = (deps: ComposeFederationDeps) =>
           contract.filter.removeUnreachableTypesFromPublicApiSchema === true &&
           compositionResult.type === 'success'
         ) {
-          const supergraphDocumentNode =
-            compositionResult.result.supergraphDocumentNode ??
-            parse(compositionResult.result.supergraph);
-          const publicDocumentNode =
-            compositionResult.result.sdlDocumentNode ?? parse(compositionResult.result.sdl);
+          const supergraphDocumentNode = compositionResult.result.supergraphDocumentNode;
+          const publicDocumentNode = compositionResult.result.sdlDocumentNode;
 
           const { resolveImportName } = extractLinkImplementations(supergraphDocumentNode);
           const result = addInaccessibleToUnreachableTypes(resolveImportName, {

--- a/packages/services/schema/src/composition/federation.ts
+++ b/packages/services/schema/src/composition/federation.ts
@@ -170,11 +170,12 @@ export const createComposeFederation = (deps: ComposeFederationDeps) =>
         const subgraphsMetadata = subgraphs.map(({ name, typeDefs }) =>
           extractMetadata(typeDefs, name),
         );
-        const supergraphSDL = parse(composed.result.supergraph);
-        const { resolveImportName } = extractLinkImplementations(supergraphSDL);
+        const supergraphDocumentNode =
+          composed.result.sdlDocumentNode ?? parse(composed.result.supergraph);
+        const { resolveImportName } = extractLinkImplementations(supergraphDocumentNode);
         const tagDirectiveName = resolveImportName('https://specs.apollo.dev/tag', '@tag');
         const tagStrategy = createTagDirectiveNameExtractionStrategy(tagDirectiveName);
-        const tags = extractTagsFromDocument(supergraphSDL, tagStrategy);
+        const tags = extractTagsFromDocument(supergraphDocumentNode, tagStrategy);
         const schemaMetadata = mergeMetadata(...subgraphsMetadata);
         const metadataAttributes = new SetMap<string, string>();
         for (const [_coord, attrs] of schemaMetadata) {

--- a/packages/services/schema/src/lib/compose.ts
+++ b/packages/services/schema/src/lib/compose.ts
@@ -51,13 +51,13 @@ const ExternalCompositionResultModel = z.union([
   ExternalCompositionResultFailureModel,
 ]);
 
-type ExternalCompositionResultSuccess = z.TypeOf<typeof ExternalCompositionResultSuccessModel>;
-
-type ComposerMethodResultSuccess = Exclude<ExternalCompositionResultSuccess, 'result'> & {
-  result: ExternalCompositionResultSuccess['result'] & {
-    /** allow passing in the document nodes from the native composition to avoid an additional print and parse cycle. */
-    supergraphDocumentNode?: DocumentNode;
-    sdlDocumentNode?: DocumentNode;
+type ComposerMethodResultSuccess = {
+  type: 'success';
+  result: {
+    sdl: string;
+    supergraph: string;
+    supergraphDocumentNode: DocumentNode;
+    sdlDocumentNode: DocumentNode;
   };
 };
 
@@ -91,11 +91,15 @@ export function composeFederationV1(
     };
   }
 
+  const sdl = printSchema(result.schema);
+
   return {
     type: 'success',
     result: {
+      sdl,
+      sdlDocumentNode: parse(sdl),
       supergraph: result.supergraphSdl,
-      sdl: printSchema(result.schema),
+      supergraphDocumentNode: parse(result.supergraphSdl),
     },
   };
 }
@@ -253,11 +257,15 @@ export async function composeExternalFederation(args: {
 
     await checkExternalCompositionCompatibility(args.logger, parseResult.data.result.sdl);
 
+    const supergraph = parseResult.data.result.supergraph;
+    const sdl = parseResult.data.result.sdl;
     return {
       type: 'success',
       result: {
-        supergraph: parseResult.data.result.supergraph,
-        sdl: parseResult.data.result.sdl,
+        supergraph,
+        supergraphDocumentNode: parse(supergraph),
+        sdl,
+        sdlDocumentNode: parse(sdl),
       },
     };
   }

--- a/packages/services/schema/src/lib/compose.ts
+++ b/packages/services/schema/src/lib/compose.ts
@@ -10,7 +10,6 @@ import * as Sentry from '@sentry/node';
 import {
   composeServices as nativeComposeServices,
   compositionHasErrors as nativeCompositionHasErrors,
-  transformSupergraphToPublicSchema,
 } from '@theguild/federation-composition';
 import type { ExternalComposition } from '../types';
 import { toValidationError } from './errors';
@@ -125,7 +124,7 @@ export function composeFederationV2(
       type: 'success',
       result: {
         supergraph: result.supergraphSdl,
-        sdl: print(transformSupergraphToPublicSchema(parse(result.supergraphSdl))),
+        sdl: result.publicSdl,
       },
       includesNetworkError: false,
       includesException: false,
@@ -244,7 +243,7 @@ export async function composeExternalFederation(args: {
       type: 'success',
       result: {
         supergraph: parseResult.data.result.supergraph,
-        sdl: print(transformSupergraphToPublicSchema(parse(parseResult.data.result.supergraph))),
+        sdl: parseResult.data.result.sdl,
       },
       includesNetworkError: false,
       includesException: false,

--- a/packages/services/schema/src/lib/compose.ts
+++ b/packages/services/schema/src/lib/compose.ts
@@ -138,13 +138,9 @@ export function composeFederationV2(
       type: 'success',
       result: {
         supergraph: result.supergraphSdl,
-        get supergraphDocumentNode() {
-          return result.supergraphDocumentNode;
-        },
+        supergraphDocumentNode: result.supergraphDocumentNode,
         sdl: result.publicSdl,
-        get sdlDocumentNode() {
-          return result.publicDocumentNode;
-        },
+        sdlDocumentNode: result.publicDocumentNode,
       },
     } as const;
   } catch (error) {

--- a/packages/services/schema/src/lib/compose.ts
+++ b/packages/services/schema/src/lib/compose.ts
@@ -24,35 +24,51 @@ interface BrokerPayload {
   body: string;
 }
 
+const ExternalCompositionResultSuccessModel = z.object({
+  type: z.literal('success'),
+  result: z.object({
+    supergraph: z.string(),
+    sdl: z.string(),
+  }),
+});
+
+const ExternalCompositionResultFailureModel = z.object({
+  type: z.literal('failure'),
+  result: z.object({
+    supergraph: z.string().nullish(),
+    sdl: z.string().nullish(),
+    errors: z.array(
+      z.object({
+        message: z.string(),
+        source: z.union([z.literal('composition'), z.literal('graphql')]).default('graphql'),
+      }),
+    ),
+  }),
+});
+
 const ExternalCompositionResultModel = z.union([
-  z.object({
-    type: z.literal('success'),
-    result: z.object({
-      supergraph: z.string(),
-      sdl: z.string(),
-    }),
-  }),
-  z.object({
-    type: z.literal('failure'),
-    result: z.object({
-      supergraph: z.string().nullish(),
-      sdl: z.string().nullish(),
-      errors: z.array(
-        z.object({
-          message: z.string(),
-          source: z.union([z.literal('composition'), z.literal('graphql')]).default('graphql'),
-        }),
-      ),
-    }),
-  }),
+  ExternalCompositionResultSuccessModel,
+  ExternalCompositionResultFailureModel,
 ]);
 
-export type ComposerMethodResult = z.TypeOf<typeof ExternalCompositionResultModel> & {
+type ExternalCompositionResultSuccess = z.TypeOf<typeof ExternalCompositionResultSuccessModel>;
+
+type ComposerMethodResultSuccess = Exclude<ExternalCompositionResultSuccess, 'result'> & {
+  result: ExternalCompositionResultSuccess['result'] & {
+    /** allow passing in the document nodes from the native composition to avoid an additional print and parse cycle. */
+    supergraphDocumentNode?: DocumentNode;
+    sdlDocumentNode?: DocumentNode;
+  };
+};
+
+type ComposerMethodResultError = z.TypeOf<typeof ExternalCompositionResultFailureModel> & {
   /** The result contains a network error */
   includesNetworkError: boolean;
   /** The result contains an internal unexpected exception */
   includesException: boolean;
 };
+
+export type ComposerMethodResult = ComposerMethodResultError | ComposerMethodResultSuccess;
 
 export function composeFederationV1(
   subgraphs: Array<{
@@ -81,8 +97,6 @@ export function composeFederationV1(
       supergraph: result.supergraphSdl,
       sdl: printSchema(result.schema),
     },
-    includesNetworkError: false,
-    includesException: false,
   };
 }
 
@@ -124,10 +138,14 @@ export function composeFederationV2(
       type: 'success',
       result: {
         supergraph: result.supergraphSdl,
+        get supergraphDocumentNode() {
+          return result.supergraphDocumentNode;
+        },
         sdl: result.publicSdl,
+        get sdlDocumentNode() {
+          return result.publicDocumentNode;
+        },
       },
-      includesNetworkError: false,
-      includesException: false,
     } as const;
   } catch (error) {
     logger?.error('Unexpected error during composition.');
@@ -245,8 +263,6 @@ export async function composeExternalFederation(args: {
         supergraph: parseResult.data.result.supergraph,
         sdl: parseResult.data.result.sdl,
       },
-      includesNetworkError: false,
-      includesException: false,
     };
   }
 

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -37,7 +37,7 @@
     "@hive/workflows": "workspace:*",
     "@sentry/node": "7.120.2",
     "@swc/core": "1.13.5",
-    "@theguild/federation-composition": "0.24.0",
+    "@theguild/federation-composition": "0.24.1",
     "@trpc/server": "10.45.3",
     "@whatwg-node/server": "0.10.17",
     "dotenv": "16.4.7",

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -37,7 +37,7 @@
     "@hive/workflows": "workspace:*",
     "@sentry/node": "7.120.2",
     "@swc/core": "1.13.5",
-    "@theguild/federation-composition": "0.23.3",
+    "@theguild/federation-composition": "0.24.0",
     "@trpc/server": "10.45.3",
     "@whatwg-node/server": "0.10.17",
     "dotenv": "16.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: 0.12.1
         version: 0.12.1(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3)
       '@theguild/federation-composition':
-        specifier: 0.23.3
-        version: 0.23.3(graphql@16.9.0)
+        specifier: 0.24.0
+        version: 0.24.0(graphql@16.9.0)
       '@theguild/prettier-config':
         specifier: 2.0.7
         version: 2.0.7(prettier@3.4.2)
@@ -362,8 +362,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/services/workflows
       '@theguild/federation-composition':
-        specifier: 0.23.3
-        version: 0.23.3(graphql@16.9.0)
+        specifier: 0.24.0
+        version: 0.24.0(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -541,8 +541,8 @@ importers:
         specifier: 4.7.16
         version: 4.7.16
       '@theguild/federation-composition':
-        specifier: 0.23.3
-        version: 0.23.3(graphql@16.9.0)
+        specifier: 0.24.0
+        version: 0.24.0(graphql@16.9.0)
       cli-table3:
         specifier: 0.6.5
         version: 0.6.5
@@ -1201,8 +1201,8 @@ importers:
         specifier: 7.10.0
         version: 7.10.0
       '@theguild/federation-composition':
-        specifier: 0.23.3
-        version: 0.23.3(graphql@16.9.0)
+        specifier: 0.24.0
+        version: 0.24.0(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -1438,8 +1438,8 @@ importers:
         specifier: 2.13.2
         version: 2.13.2(graphql@16.9.0)
       '@theguild/federation-composition':
-        specifier: 0.23.3
-        version: 0.23.3(graphql@16.9.0)
+        specifier: 0.24.0
+        version: 0.24.0(graphql@16.9.0)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -1547,8 +1547,8 @@ importers:
         specifier: 7.120.2
         version: 7.120.2
       '@theguild/federation-composition':
-        specifier: 0.23.3
-        version: 0.23.3(graphql@16.9.0)
+        specifier: 0.24.0
+        version: 0.24.0(graphql@16.9.0)
       '@trpc/server':
         specifier: 10.45.3
         version: 10.45.3
@@ -1667,8 +1667,8 @@ importers:
         specifier: 1.13.5
         version: 1.13.5
       '@theguild/federation-composition':
-        specifier: 0.23.3
-        version: 0.23.3(graphql@16.9.0)
+        specifier: 0.24.0
+        version: 0.24.0(graphql@16.9.0)
       '@trpc/server':
         specifier: 10.45.3
         version: 10.45.3
@@ -10475,8 +10475,8 @@ packages:
     peerDependencies:
       graphql: ^16.0.0
 
-  '@theguild/federation-composition@0.23.3':
-    resolution: {integrity: sha512-dXUTrIqqfErS9QWdLOn2WqrKvcVtclBkuGMH78uENA19x8LsatnVaV/FkTlvpWlbHlmTxbgP1yZm1ig8GyjvkQ==}
+  '@theguild/federation-composition@0.24.0':
+    resolution: {integrity: sha512-W18OiV0ZIhY5kFK+1DBJArrqJ1Ygw65OJzLhDuJ83ulgekKgUw5vcBgI2Lk/E2u4KS7JWSTQTcsvNVNxkAfiSA==}
     engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.0.0
@@ -31642,7 +31642,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@theguild/federation-composition@0.23.3(graphql@16.9.0)':
+  '@theguild/federation-composition@0.24.0(graphql@16.9.0)':
     dependencies:
       constant-case: 3.0.4
       debug: 4.4.3(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: 0.12.1
         version: 0.12.1(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3)
       '@theguild/federation-composition':
-        specifier: 0.24.0
-        version: 0.24.0(graphql@16.9.0)
+        specifier: 0.24.1
+        version: 0.24.1(graphql@16.9.0)
       '@theguild/prettier-config':
         specifier: 2.0.7
         version: 2.0.7(prettier@3.4.2)
@@ -362,8 +362,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/services/workflows
       '@theguild/federation-composition':
-        specifier: 0.24.0
-        version: 0.24.0(graphql@16.9.0)
+        specifier: 0.24.1
+        version: 0.24.1(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -541,8 +541,8 @@ importers:
         specifier: 4.7.16
         version: 4.7.16
       '@theguild/federation-composition':
-        specifier: 0.24.0
-        version: 0.24.0(graphql@16.9.0)
+        specifier: 0.24.1
+        version: 0.24.1(graphql@16.9.0)
       cli-table3:
         specifier: 0.6.5
         version: 0.6.5
@@ -1201,8 +1201,8 @@ importers:
         specifier: 7.10.0
         version: 7.10.0
       '@theguild/federation-composition':
-        specifier: 0.24.0
-        version: 0.24.0(graphql@16.9.0)
+        specifier: 0.24.1
+        version: 0.24.1(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -1438,8 +1438,8 @@ importers:
         specifier: 2.13.2
         version: 2.13.2(graphql@16.9.0)
       '@theguild/federation-composition':
-        specifier: 0.24.0
-        version: 0.24.0(graphql@16.9.0)
+        specifier: 0.24.1
+        version: 0.24.1(graphql@16.9.0)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -1547,8 +1547,8 @@ importers:
         specifier: 7.120.2
         version: 7.120.2
       '@theguild/federation-composition':
-        specifier: 0.24.0
-        version: 0.24.0(graphql@16.9.0)
+        specifier: 0.24.1
+        version: 0.24.1(graphql@16.9.0)
       '@trpc/server':
         specifier: 10.45.3
         version: 10.45.3
@@ -1667,8 +1667,8 @@ importers:
         specifier: 1.13.5
         version: 1.13.5
       '@theguild/federation-composition':
-        specifier: 0.24.0
-        version: 0.24.0(graphql@16.9.0)
+        specifier: 0.24.1
+        version: 0.24.1(graphql@16.9.0)
       '@trpc/server':
         specifier: 10.45.3
         version: 10.45.3
@@ -10475,8 +10475,8 @@ packages:
     peerDependencies:
       graphql: ^16.0.0
 
-  '@theguild/federation-composition@0.24.0':
-    resolution: {integrity: sha512-W18OiV0ZIhY5kFK+1DBJArrqJ1Ygw65OJzLhDuJ83ulgekKgUw5vcBgI2Lk/E2u4KS7JWSTQTcsvNVNxkAfiSA==}
+  '@theguild/federation-composition@0.24.1':
+    resolution: {integrity: sha512-NBjo7F10Z8pShdrGHXgElEntWJ9JAC9zlTv+mrRU8PY513d98FvtX0sPLE7hS/rMRWfPsSUMjgOO9uwstQ2onA==}
     engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.0.0
@@ -31642,7 +31642,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@theguild/federation-composition@0.24.0(graphql@16.9.0)':
+  '@theguild/federation-composition@0.24.1(graphql@16.9.0)':
     dependencies:
       constant-case: 3.0.4
       debug: 4.4.3(supports-color@8.1.1)


### PR DESCRIPTION
Replaces the following with less whitespace:

```
schema
    @link(url: "https://specs.apollo.dev/link/v1.0")
    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
    
    
    @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
    
    
    
    @link(url: "https://docs.commercetools.com/api/feature/v1.0", import: ["@feature"])
```

**As a bonus** this also avoids `parse(print(schemaSdl))` cycles for the native composition.