### PR TITLE
Change target label from Apollo Federation to just Federation

### DIFF
--- a/packages/web/app/src/pages/organization.tsx
+++ b/packages/web/app/src/pages/organization.tsx
@@ -42,7 +42,7 @@ const ProjectCard_ProjectFragment = graphql(`
 `);
 
 const projectTypeFullNames = {
-  [ProjectType.Federation]: 'Apollo Federation',
+  [ProjectType.Federation]: 'Federation',
   [ProjectType.Stitching]: 'Schema Stitching',
   [ProjectType.Single]: 'Monolithic Schema',
 };


### PR DESCRIPTION
### Background

With Open Federation, the federated spec is not just Apollo anymore.

### Description

Adjusting our terminology keeps in line with the ecosystem's changes and better represents our offering