### PR TITLE
Hide resolutions from insights ui for input types

### DIFF
--- a/.changeset/good-dingos-change.md
+++ b/.changeset/good-dingos-change.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Hide resolutions from insights ui for input types

--- a/packages/web/app/src/pages/target-insights-coordinate.tsx
+++ b/packages/web/app/src/pages/target-insights-coordinate.tsx
@@ -192,8 +192,9 @@ function SchemaCoordinateView(props: {
   const title = kind === 'GraphQLEnumType' ? `${typeName} (${props.coordinate})` : props.coordinate;
   const fieldLevelMetricsDisplayState = query.data?.target?.fieldLevelMetricsDisplayState;
   const showFieldLevelMetrics =
-    fieldLevelMetricsDisplayState === FieldLevelMetricsDisplayState.On ||
-    fieldLevelMetricsDisplayState === FieldLevelMetricsDisplayState.OnWithWarning;
+    (fieldLevelMetricsDisplayState === FieldLevelMetricsDisplayState.On ||
+      fieldLevelMetricsDisplayState === FieldLevelMetricsDisplayState.OnWithWarning) &&
+    kind !== 'GraphQLInputObjectType';
 
   if (query.error) {
     return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;


### PR DESCRIPTION
### Background

Added resolutions to UI for enhanced usage insights. But inputs dont resolve

### Description

Filters this new portion of the UI from input objects since this will always be 0