### PR TITLE
Fix link to composition compatibility report

### DIFF
--- a/.changeset/ready-ends-lead.md
+++ b/.changeset/ready-ends-lead.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Fix link to composition compatibility report

--- a/packages/web/app/src/components/layouts/target.tsx
+++ b/packages/web/app/src/components/layouts/target.tsx
@@ -474,6 +474,8 @@ function FederationModalContent(props: {
   projectSlug: string;
   targetSlug: string;
 }) {
+  // reference local machine and not the docker container
+  const dockerCdnUrl = props.cdnUrl.replace('http://localhost:', 'http://host.docker.internal:');
   const authenticateSection = (
     <p>
       Replace "{'<hive_cdn_access_key>'}" with a{' '}
@@ -526,7 +528,7 @@ function FederationModalContent(props: {
             multiline
             value={`docker run --name hive-gateway --rm -p 4000:4000 \\
   ghcr.io/graphql-hive/gateway supergraph \\
-  "${props.cdnUrl}" \\
+  "${dockerCdnUrl}" \\
   --hive-cdn-key '<hive_cdn_access_key>'`}
           />
         </div>
@@ -552,7 +554,7 @@ function FederationModalContent(props: {
         <InputCopy
           multiline
           value={`docker run --name hive-router --rm -p 4000:4000 \\
-  --env HIVE_CDN_ENDPOINT="${props.cdnUrl}" \\
+  --env HIVE_CDN_ENDPOINT="${dockerCdnUrl}" \\
   --env HIVE_CDN_KEY="<hive_cdn_access_key>" \\
   ghcr.io/graphql-hive/router`}
         />
@@ -578,7 +580,7 @@ function FederationModalContent(props: {
         <InputCopy
           multiline
           value={`docker run --name apollo-router -p 4000:4000 --rm \\
-  --env HIVE_CDN_ENDPOINT="${props.cdnUrl}" \\
+  --env HIVE_CDN_ENDPOINT="${dockerCdnUrl}" \\
   --env HIVE_CDN_KEY="<hive_cdn_access_key>"
   ghcr.io/graphql-hive/apollo-router`}
         />
@@ -604,7 +606,7 @@ function FederationModalContent(props: {
         <InputCopy
           multiline
           value={`docker run --name grafbase-gateway -p 5000:5000 --rm \\
-  --env HIVE_CDN_ENDPOINT="${props.cdnUrl}" \\
+  --env HIVE_CDN_ENDPOINT="${dockerCdnUrl}" \\
   --env HIVE_CDN_KEY="<hive_cdn_access_key>"
   ghcr.io/grafbase/gateway`}
         />

--- a/packages/web/app/src/components/project/settings/native-composition.tsx
+++ b/packages/web/app/src/components/project/settings/native-composition.tsx
@@ -319,7 +319,8 @@ export function NativeCompositionSettings(props: {
                   To determine the cause of this issue, view the{' '}
                   <Link
                     variant="primary"
-                    href={`/native-composition-compatibility-report/${projectQuery.data.project.id}`}
+                    target="_blank"
+                    to={`/native-composition-compatibility-report/${projectQuery.data.project.id}`}
                   >
                     Native Composition Report
                   </Link>


### PR DESCRIPTION
### Background

Compatibility report link doesn't work

### Description

Fixes link for compatibility report.
Also addresses an issue with specifically the local cdn urls. This uses the default docker host local url to reference the machine's service rather than using localhost, which in docker uses the docker container's localhost.