### PR TITLE
Rust gateway plugin support

### DIFF
--- a/.changeset/lazy-stars-build.md
+++ b/.changeset/lazy-stars-build.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway-plugin-console-sdk': patch
+'@graphql-hive/core': patch
+---
+
+Support Rust query planner execution by setting default operation root type name in
+collected payload's "paths" if not returned in subgraph call request info.

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -21,6 +21,7 @@
     "@graphql-hive/core": "workspace:*",
     "@graphql-hive/gateway-plugin-console-sdk": "workspace:*",
     "@graphql-hive/gateway-runtime": "^1.0.0 || ^2.0.0",
+    "@graphql-hive/router-runtime": "^1.4.0",
     "@graphql-typed-document-node/core": "3.2.0",
     "@hive/commerce": "workspace:*",
     "@hive/postgres": "workspace:*",

--- a/integration-tests/tests/gateway-plugin-console-sdk/plugin.spec.ts
+++ b/integration-tests/tests/gateway-plugin-console-sdk/plugin.spec.ts
@@ -9,6 +9,7 @@ import { describe, expect, test } from 'vitest';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { useHive } from '@graphql-hive/gateway-plugin-console-sdk';
 import { createGatewayRuntime } from '@graphql-hive/gateway-runtime';
+import { unifiedGraphHandler, useQueryPlan } from '@graphql-hive/router-runtime';
 import { createServer } from '@hive/service-common';
 import { composeServices, ServiceDefinition } from '@theguild/federation-composition';
 
@@ -48,12 +49,15 @@ async function createSubgraphService(name: string, modulesOrSDL: ModulesOrSDL) {
   };
 }
 
-async function setup(subgraphs: {
-  [key: string]: {
-    typeDefs: DocumentNode;
-    resolvers: any;
-  };
-}) {
+async function setup(
+  subgraphs: {
+    [key: string]: {
+      typeDefs: DocumentNode;
+      resolvers: any;
+    };
+  },
+  gatewayType: 'js' | 'rust',
+) {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
   const {
@@ -95,14 +99,20 @@ async function setup(subgraphs: {
   );
   const supergraph = composeServices(services);
   expect(supergraph.errors).toBeUndefined();
-  const gateway = createGatewayRuntime({
+  const jsGateway = createGatewayRuntime({
     supergraph: supergraph.supergraphSdl!,
     plugins: () => [plugin],
   });
 
+  const rustGateway = createGatewayRuntime({
+    unifiedGraphHandler: unifiedGraphHandler as any,
+    supergraph: supergraph.supergraphSdl!,
+    plugins: () => [plugin, useQueryPlan() as any],
+  });
+
   return {
     target,
-    gateway,
+    gateway: gatewayType === 'js' ? jsGateway : rustGateway,
     waitForRequestsCollected,
     readSchemaCoordinateStats,
     readErrorCodes,
@@ -110,7 +120,7 @@ async function setup(subgraphs: {
   };
 }
 
-describe('GraphQL Hive Plugin', () => {
+describe.each(['js', 'rust'] as const)('GraphQL Hive Plugin (%s)', gatewayType => {
   test('usage data includes subgraph request data', async () => {
     const subgraphs = {
       products: {
@@ -135,7 +145,7 @@ describe('GraphQL Hive Plugin', () => {
     };
 
     const { readSchemaCoordinateStats, target, gateway, token, waitForRequestsCollected } =
-      await setup(subgraphs);
+      await setup(subgraphs, gatewayType);
 
     const request = new Request('http://localhost:4000/graphql', {
       method: 'POST',
@@ -237,7 +247,7 @@ describe('GraphQL Hive Plugin', () => {
     };
 
     const { readSchemaCoordinateStats, target, gateway, token, waitForRequestsCollected } =
-      await setup(subgraphs);
+      await setup(subgraphs, gatewayType);
 
     const request = new Request('http://localhost:4000/graphql', {
       method: 'POST',
@@ -306,7 +316,7 @@ describe('GraphQL Hive Plugin', () => {
     });
   });
 
-  test('supports abstract type', async () => {
+  test.skipIf(gatewayType === 'rust')('supports abstract type', async () => {
     const subgraphs = {
       products: {
         typeDefs: parse(/* GraphQL */ `
@@ -334,7 +344,10 @@ describe('GraphQL Hive Plugin', () => {
       },
     };
 
-    const { readSchemaCoordinateStats, gateway, waitForRequestsCollected } = await setup(subgraphs);
+    const { readSchemaCoordinateStats, gateway, waitForRequestsCollected } = await setup(
+      subgraphs,
+      gatewayType,
+    );
 
     const request = new Request('http://localhost:4000/graphql', {
       method: 'POST',
@@ -375,14 +388,18 @@ describe('GraphQL Hive Plugin', () => {
       to: new Date().toISOString(),
     };
 
+    // @note the rust gateway doesn't track the implemented type: "GoodieBag" here.
     await pollFor(async () => {
       const productStats = await readSchemaCoordinateStats('Product', period);
       const goodieStats = await readSchemaCoordinateStats('GoodieBag', period);
+      const productRes = productStats.target?.schemaCoordinateStats.totalResolutions;
+      const goodieRes = goodieStats.target?.schemaCoordinateStats.totalResolutions;
 
-      return (
-        productStats.target?.schemaCoordinateStats.totalResolutions === 1 &&
-        goodieStats.target?.schemaCoordinateStats.totalResolutions === 1
-      );
+      const success = productRes === 1 && goodieRes === 1;
+      if (!success) {
+        console.warn(`"Product" resolutions: ${productRes}\n"GoodieBag" resolutions: ${goodieRes}`);
+      }
+      return success;
     });
   });
 
@@ -409,7 +426,7 @@ describe('GraphQL Hive Plugin', () => {
         },
       },
     };
-    const { gateway, waitForRequestsCollected } = await setup(subgraphs);
+    const { gateway, waitForRequestsCollected } = await setup(subgraphs, gatewayType);
     const query = /* GraphQL */ `
       {
         product {
@@ -441,7 +458,7 @@ describe('GraphQL Hive Plugin', () => {
     });
   });
 
-  test('errors are tracked', async () => {
+  test.skipIf(gatewayType === 'rust')('errors are tracked', async () => {
     const thrownErrorCode = 'OOPSIE';
     const subgraphs = {
       products: {
@@ -497,7 +514,7 @@ describe('GraphQL Hive Plugin', () => {
       gateway,
       token,
       waitForRequestsCollected,
-    } = await setup(subgraphs);
+    } = await setup(subgraphs, gatewayType);
 
     const request = new Request('http://localhost:4000/graphql', {
       method: 'POST',
@@ -524,6 +541,8 @@ describe('GraphQL Hive Plugin', () => {
 
     const usageCollected = waitForRequestsCollected(1);
     const result = await gateway.handle(request);
+
+    // @note that the rust gateway returns the error path as ["users"].
     await expect(result.json()).resolves.toMatchInlineSnapshot(`
       {
         data: {
@@ -648,7 +667,10 @@ describe('GraphQL Hive Plugin', () => {
       },
     };
 
-    const { readErrorCodes, gateway, waitForRequestsCollected } = await setup(subgraphs);
+    const { readErrorCodes, gateway, waitForRequestsCollected } = await setup(
+      subgraphs,
+      gatewayType,
+    );
 
     const request = new Request('http://localhost:4000/graphql', {
       method: 'POST',
@@ -689,6 +711,77 @@ describe('GraphQL Hive Plugin', () => {
       const code = errorCodes.target?.schemaCoordinateStats?.errorCodes?.edges?.[0]?.node?.code;
 
       return code === thrownErrorCode;
+    });
+  });
+
+  test('supports named root types', async () => {
+    const subgraphs = {
+      products: {
+        typeDefs: parse(/* GraphQL */ `
+          schema {
+            query: RootQuery
+          }
+          type RootQuery {
+            product: Product
+          }
+
+          interface Product {
+            id: ID!
+          }
+
+          type GoodieBag implements Product @key(fields: "id") {
+            id: ID!
+          }
+        `),
+        resolvers: {
+          RootQuery: {
+            product: () => ({ __typename: 'GoodieBag', id: 1 }),
+          },
+        },
+      },
+    };
+    const { gateway, waitForRequestsCollected, readSchemaCoordinateStats } = await setup(
+      subgraphs,
+      gatewayType,
+    );
+    const query = /* GraphQL */ `
+      {
+        product {
+          id
+        }
+      }
+    `;
+
+    const usageCollected = waitForRequestsCollected(1);
+    const result = await gateway.handle(
+      new Request('http://localhost:4000/graphql', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json',
+        },
+        body: JSON.stringify({ query }),
+      }),
+    );
+
+    const response = await result.json();
+    await usageCollected;
+    expect(response).toEqual({
+      data: {
+        product: {
+          id: '1',
+        },
+      },
+    });
+    pollFor(async () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const period = {
+        from: yesterday.toISOString(),
+        to: new Date().toISOString(),
+      };
+      const stats = await readSchemaCoordinateStats('RootQuery', period);
+      return stats.target?.schemaCoordinateStats.totalResolutions === 1;
     });
   });
 });

--- a/packages/libraries/core/src/client/add-hive-typenames.ts
+++ b/packages/libraries/core/src/client/add-hive-typenames.ts
@@ -1,14 +1,15 @@
 import {
   DefinitionNode,
   getNamedType,
+  GraphQLSchema,
   isAbstractType,
   isCompositeType,
   isObjectType,
+  OperationTypeNode,
   SelectionNode,
   type DocumentNode,
   type FieldNode,
   type GraphQLCompositeType,
-  type GraphQLSchema,
   type InlineFragmentNode,
   type Kind, // in order to support older graphql versions, do not rely on Kind for runtime
   type SelectionSetNode,
@@ -20,6 +21,17 @@ const TYPENAME_FIELD: FieldNode = {
   name: { kind: 'Name' as Kind.NAME, value: '__typename' },
   alias: { kind: 'Name' as Kind.NAME, value: HIVE_INTERNAL_TYPENAME },
 };
+
+export function getDefinedRootType(
+  schema: GraphQLSchema,
+  operationType: OperationTypeNode | undefined,
+) {
+  return !operationType || operationType === 'query'
+    ? schema.getQueryType()
+    : operationType === 'mutation'
+      ? schema.getMutationType()
+      : schema.getSubscriptionType();
+}
 
 /**
  * Recursively adds the typename to every selection set whose parent type is
@@ -42,13 +54,7 @@ export function addHiveTypenames(document: DocumentNode, schema: GraphQLSchema):
     let newDef = def;
 
     if (def.kind === 'OperationDefinition') {
-      const rootType =
-        def.operation === 'query'
-          ? schema.getQueryType()
-          : def.operation === 'mutation'
-            ? schema.getMutationType()
-            : schema.getSubscriptionType();
-
+      const rootType = getDefinedRootType(schema, def.operation);
       if (rootType) {
         const newSelectionSet = walkSelectionSet(def.selectionSet, rootType, false, schema);
         if (newSelectionSet !== def.selectionSet) {

--- a/packages/libraries/core/src/client/usage.ts
+++ b/packages/libraries/core/src/client/usage.ts
@@ -3,12 +3,14 @@ import {
   GraphQLSchema,
   Kind,
   OperationDefinitionNode,
+  OperationTypeNode,
   TypeInfo,
   type ExecutionArgs,
 } from 'graphql';
 import { lru } from 'tiny-lru';
 import { normalizeOperation } from '../normalize/operation.js';
 import { version } from '../version.js';
+import { getDefinedRootType } from './add-hive-typenames.js';
 import { createAgent } from './agent.js';
 import { collectSchemaCoordinates } from './collect-schema-coordinates.js';
 import { dynamicSampling, randomSampling } from './sampling.js';
@@ -281,6 +283,9 @@ export function createUsage(pluginOptions: HiveInternalPluginOptions): UsageColl
            * We still want to track the field metrics, so create an artificial
            * fetch that represents the local lookup.
            */
+          const rootPath =
+            getDefinedRootType(args.args.schema, rootOperation.operation ?? OperationTypeNode.QUERY)
+              ?.name ?? 'Query';
 
           fetches = [
             {
@@ -290,7 +295,7 @@ export function createUsage(pluginOptions: HiveInternalPluginOptions): UsageColl
               subgraph: '',
               subgraphSchema: args.args.schema,
               type: 'ROOT',
-              paths: rootOperation.operation,
+              paths: rootPath,
               result, // make sure this isnt taking too much memory to store. Can this be stripped out?
             },
           ];

--- a/packages/libraries/core/src/index.ts
+++ b/packages/libraries/core/src/index.ts
@@ -22,4 +22,8 @@ export {
   type CDNArtifactFetcher,
 } from './client/cdn-artifact-fetcher.js';
 export type { CircuitBreakerConfiguration } from './client/circuit-breaker.js';
-export { addHiveTypenames, hideInjectedTypenames } from './client/add-hive-typenames.js';
+export {
+  addHiveTypenames,
+  hideInjectedTypenames,
+  getDefinedRootType,
+} from './client/add-hive-typenames.js';

--- a/packages/libraries/core/tests/usage.spec.ts
+++ b/packages/libraries/core/tests/usage.spec.ts
@@ -770,34 +770,55 @@ test('should not send excluded operation name data to Hive', async () => {
   expect(report.size).toEqual(2);
   expect(Object.keys(report.map)).toHaveLength(2);
 
-  const key = Object.keys(report.map)[0];
-  const record = report.map[key];
-
-  // operation
-  expect(record.operation).toMatch('mutation deleteProject');
-  expect(record.operationName).toMatch('deleteProject');
-  // fields
-  expect(record.fields).toMatchInlineSnapshot(`
-    [
-      Mutation.deleteProject,
-      Mutation.deleteProject.selector,
-      DeleteProjectPayload.selector,
-      ProjectSelector.organization,
-      ProjectSelector.project,
-      DeleteProjectPayload.deletedProject,
-      Project.id,
-      Project.cleanId,
-      Project.name,
-      Project.type,
-      ProjectType.FEDERATION,
-      ProjectType.STITCHING,
-      ProjectType.SINGLE,
-      ProjectType.CUSTOM,
-      ProjectSelectorInput.organization,
-      ID,
-      ProjectSelectorInput.project,
-    ]
-  `);
+  for (const hash of Object.keys(report.map)) {
+    const op = report.map[hash];
+    if (op.operation.includes('mutation deleteProject')) {
+      expect(op.operationName).toMatch('deleteProject');
+      // fields
+      expect(op.fields).toMatchInlineSnapshot(`
+        [
+          Mutation.deleteProject,
+          Mutation.deleteProject.selector,
+          DeleteProjectPayload.selector,
+          ProjectSelector.organization,
+          ProjectSelector.project,
+          DeleteProjectPayload.deletedProject,
+          Project.id,
+          Project.cleanId,
+          Project.name,
+          Project.type,
+          ProjectType.FEDERATION,
+          ProjectType.STITCHING,
+          ProjectType.SINGLE,
+          ProjectType.CUSTOM,
+          ProjectSelectorInput.organization,
+          ID,
+          ProjectSelectorInput.project,
+        ]
+      `);
+    } else if (op.operation.includes('query getProject')) {
+      expect(op.operationName).toMatch('getProject');
+      expect(op.fields).toMatchInlineSnapshot(`
+        [
+          Query.project,
+          Query.project.selector,
+          Project.id,
+          Project.cleanId,
+          Project.name,
+          Project.type,
+          ProjectType.FEDERATION,
+          ProjectType.STITCHING,
+          ProjectType.SINGLE,
+          ProjectType.CUSTOM,
+          ProjectSelectorInput.organization,
+          ID,
+          ProjectSelectorInput.project,
+        ]
+      `);
+    } else {
+      throw new Error('Expected operation not found');
+    }
+  }
 
   // Operations
   const operations = report.operations;
@@ -807,8 +828,7 @@ test('should not send excluded operation name data to Hive', async () => {
   }
 
   const operation = operations[0];
-
-  expect(operation.operationMapKey).toEqual(key);
+  expect(Object.keys(report.map)).toContain(operation.operationMapKey);
   expect(operation.timestamp).toEqual(expect.any(Number));
   // execution
   expect(operation.execution.duration).toBeGreaterThanOrEqual(18 * 1_000_000); // >=18ms in microseconds

--- a/packages/libraries/gateway-plugin-console-sdk/src/index.ts
+++ b/packages/libraries/gateway-plugin-console-sdk/src/index.ts
@@ -131,7 +131,7 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
     },
     onParse(parseCtx) {
       return ctx => {
-        if (ctx.result.kind === 'document' && fieldLevelMetricsEnabled && operationCache) {
+        if (ctx.result.kind === 'Document' && fieldLevelMetricsEnabled && operationCache) {
           // We need __typename on every object in the subgraph result so we can
           // resolve abstract types (unions/interfaces) to concrete type coordinates
           // when recording field-level metrics downstream.

--- a/packages/libraries/gateway-plugin-console-sdk/src/index.ts
+++ b/packages/libraries/gateway-plugin-console-sdk/src/index.ts
@@ -1,8 +1,15 @@
-import { DocumentNode, GraphQLSchema, Kind, responsePathAsArray, type GraphQLError } from 'graphql';
+import {
+  GraphQLSchema,
+  OperationTypeNode,
+  responsePathAsArray,
+  type DocumentNode,
+  type GraphQLError,
+} from 'graphql';
 import { lru } from 'tiny-lru';
 import {
   addHiveTypenames,
   createHive as createHiveClient,
+  getDefinedRootType,
   hideInjectedTypenames,
   isAsyncIterable,
   isHiveClient,
@@ -94,14 +101,16 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
        * This is added in the "onExecute" hook to the entire document. So subgraph
        * calls should also include this field.
        */
-
       const finishSubRequest = collection.subrequest({
         subgraph: subgraphName,
         type: isEntityRequest(executionRequest.document) ? 'ENTITY' : 'ROOT',
         /** @NOTE this field's format supports batched requests, but onSubgraphExecute does not. */
         paths: executionRequest.info?.path
           ? [responsePathAsArray(executionRequest.info.path).join('.')]
-          : [],
+          : getDefinedRootType(
+              subgraphSchema,
+              executionRequest.operationType ?? OperationTypeNode.QUERY,
+            )?.name,
       });
 
       return function onSubgraphExecuteDone({ result }) {
@@ -122,7 +131,7 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
     },
     onParse(parseCtx) {
       return ctx => {
-        if (ctx.result.kind === Kind.DOCUMENT && fieldLevelMetricsEnabled && operationCache) {
+        if (ctx.result.kind === 'document' && fieldLevelMetricsEnabled && operationCache) {
           // We need __typename on every object in the subgraph result so we can
           // resolve abstract types (unions/interfaces) to concrete type coordinates
           // when recording field-level metrics downstream.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,9 @@ importers:
       '@graphql-hive/gateway-runtime':
         specifier: ^1.0.0 || ^2.0.0
         version: 2.9.10(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)(ws@8.21.0)
+      '@graphql-hive/router-runtime':
+        specifier: ^1.4.0
+        version: 1.4.22(@types/node@25.5.0)(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.9.0)
@@ -1485,7 +1488,7 @@ importers:
     devDependencies:
       '@graphql-eslint/eslint-plugin':
         specifier: 3.20.1
-        version: 3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@24.13.3)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
+        version: 3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
       '@hive/service-common':
         specifier: workspace:*
         version: link:../service-common
@@ -4301,11 +4304,36 @@ packages:
       ioredis:
         optional: true
 
+  '@graphql-hive/pubsub@2.2.1':
+    resolution: {integrity: sha512-3WdvICSTCFHIY/Fk3YGSAgnYpP3j1UeDoBTzrfRKRm7PsgDtx3Y970GtkM15H9uJzEX6SrYifTB1HznCsc2Axg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@nats-io/jetstream': ^3
+      '@nats-io/nats-core': ^3
+      ioredis: 5.10.1
+    peerDependenciesMeta:
+      '@nats-io/jetstream':
+        optional: true
+      '@nats-io/nats-core':
+        optional: true
+      ioredis:
+        optional: true
+
   '@graphql-hive/render-laboratory@0.1.10':
     resolution: {integrity: sha512-/6FMnb7i5jBBgYsYFDOKEGnKGZivBRcEkuZ585QhwHlhThb01/Idv7j4z7NZ5zaTByFaF8TtfVN0nXqy175Jyg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       graphql-yoga: ^5
+
+  '@graphql-hive/router-query-planner@0.0.38':
+    resolution: {integrity: sha512-KTvconFeSdKejudY6hUrfP8nvkxp+bg2uuNqbIZF1pmlFzjlDHGoUO8qpvKxdmWijXSuEcQBzWnn4rpMkzgC/A==}
+    engines: {bun: ^1, node: '>=20'}
+
+  '@graphql-hive/router-runtime@1.4.22':
+    resolution: {integrity: sha512-XDsLCfDlecAGUjO8kVwkXk4iufP/vJ2CH9PCL44tcu/BeOrjo8C4kt9ykI/BUN24/gx4ykNCGIK0D2D5LdQSJA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@graphql-hive/signal@1.0.0':
     resolution: {integrity: sha512-RiwLMc89lTjvyLEivZ/qxAC5nBHoS2CtsWFSOsN35sxG9zoo5Z+JsFHM8MlvmO9yt+MJNIyC5MLE1rsbOphlag==}
@@ -4493,8 +4521,20 @@ packages:
     peerDependencies:
       graphql: '*'
 
+  '@graphql-mesh/cross-helpers@0.4.16':
+    resolution: {integrity: sha512-REoxExKojt2PsBmCYY80B1BAtkZAlux8nRS3iLAgsHm2lzn4kl/nmfgaUs6oo/QEpMjDRl/BCl7AFMKt8GHxRg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: '*'
+
   '@graphql-mesh/fusion-runtime@1.10.10':
     resolution: {integrity: sha512-YfjOqvCqcnRVI49wZby6JpKx9fpEwXpjHSn016mmJLbPRO0kZyGHUTAB+KabVgEhaA/0fzgEgaSmV55NrZaxug==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-mesh/fusion-runtime@1.11.6':
+    resolution: {integrity: sha512-/znaIK+vRD3xa/zYPkYCQozvVFOtQi1hg5GedfiV4c42bKnJrDMjAt3K0ORhIq+n4CwchrNNKTGb3eXiiwh7ng==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -4548,8 +4588,20 @@ packages:
     peerDependencies:
       graphql: '*'
 
+  '@graphql-mesh/string-interpolation@0.5.18':
+    resolution: {integrity: sha512-iVZETGGWNzmhNVZoxoIJSyuVNKVTpR1FMIb3xsNFnwtiCauzQHcKTcIZTA+IOe7vhMSCLIYOoj9p/XPTrQIfpg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: '*'
+
   '@graphql-mesh/transport-common@1.0.17':
     resolution: {integrity: sha512-iZXrFvryEHqOEc62DpXbKmHdMM4Ojoppct53XEeCPaKTSgKejwsqRh4QrcuILMmlW4JhOLas6VCIItNSEVQVyw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      graphql: ^15.9.0 || ^16.9.0
+
+  '@graphql-mesh/transport-common@1.0.20':
+    resolution: {integrity: sha512-Vo3gIqPcvFHcO18WhTynomFjLhDcy7C7PufQ8kGwF+4jIOslLjliaU3K6fTV7WxX1SzGe+GswhSJY4Yebaae7Q==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       graphql: ^15.9.0 || ^16.9.0
@@ -4578,8 +4630,26 @@ packages:
     peerDependencies:
       graphql: '*'
 
+  '@graphql-mesh/types@0.104.30':
+    resolution: {integrity: sha512-jEJsFfimxkAqNRJKbxFklOy0tpCUzG56gI/77P0V7Ea/B4OBw6b8+yd+7hj1DZ6pEP+yC0IuYLa1aZlasBpzaQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: '*'
+
+  '@graphql-mesh/types@0.105.1':
+    resolution: {integrity: sha512-OvArNUYW7b/nA4eW9BvmLa3k6SShwL3qpVZlXFjEZJ/WHg7kSqsEGekZIWf133e7GsVKDnsBQB0vBdqwK8H1cg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: '*'
+
   '@graphql-mesh/utils@0.104.36':
     resolution: {integrity: sha512-6n+7vbVdcLMeGBW7SRKppBUDUb8InCPD2doBw3nwbAWp1eU0kJfH3rLGrOEFAnlHhnXZEFJYKXu8YT8FnofdkA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: '*'
+
+  '@graphql-mesh/utils@0.104.38':
+    resolution: {integrity: sha512-Vo9QNOBnsH1RpFbw128PIEjvxiJjmH9GCLarP1o+WkfvM3bXlSnV+6tkCXsQCvBFAseOsR8bq5xPNsypxadPVA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: '*'
@@ -4598,6 +4668,12 @@ packages:
 
   '@graphql-tools/batch-delegate@10.0.28':
     resolution: {integrity: sha512-pxheJV3BTlhEDYLHN0eL2mmyp9Qkt1GXCiVdvxQilp700qZ4SCfqU/+ZFzOo9Qf802Tst9Z57BvwIjJu0lV8AA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/batch-delegate@10.0.29':
+    resolution: {integrity: sha512-BpudKJ1di2buUlQmWQfCvs+kAM9xWjM319gYB2R0UPOw7bExWEXiNkgCm6tOUDUYK6pGa0/xgZjXaTjtQAEl9w==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -4674,6 +4750,12 @@ packages:
 
   '@graphql-tools/delegate@12.1.0':
     resolution: {integrity: sha512-g1vDjYKzPwqnnxcBxwVUdAUqCZdx995RFtoyyy2CNzjXBxUOAZHgw/F2LKXhwnVWdtTsT20bb8hPqUIuNmetDQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/delegate@12.1.1':
+    resolution: {integrity: sha512-BiePOU2Nev9KDpAEOw25isTm6y/Ea6Sb3c/aH0P9s25c/6mzluvpEo66nnA9vWeirIRScS7rUtN0Jv3P02h3VA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -4802,6 +4884,12 @@ packages:
   '@graphql-tools/executor@1.5.0':
     resolution: {integrity: sha512-3HzAxfexmynEWwRB56t/BT+xYKEYLGPvJudR1jfs+XZX8bpfqujEhqVFoxmkpEE8BbFcKuBNoQyGkTi1eFJ+hA==}
     engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/federation@4.4.12':
+    resolution: {integrity: sha512-hyrwPg/EkPcG0X1/CIlNq3QeTx0eL08gL1k6lRzRXVY5L47uaAuCCFVVaKEvVVPV6hBkr3eoCywJ00FoDMkwdA==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
@@ -5014,6 +5102,12 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
+  '@graphql-tools/stitch@10.2.2':
+    resolution: {integrity: sha512-jQgXfvULLESRhItx0DlqiVeMVHK32wputGRdoeezWPzAlP9ALHMacatE09OdB1ICftF+RDlbRULNSeE1mExqJA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   '@graphql-tools/stitching-directives@3.1.38':
     resolution: {integrity: sha512-5q4H9sAnPEVhrnB/UUI1aXKVqXYh3EUMqknS+3lwa823lBaSL7b/YK1VloHMRWYPHJexFo7CtRNaO4dAAPSqBg==}
     engines: {node: '>=18.0.0'}
@@ -5022,6 +5116,12 @@ packages:
 
   '@graphql-tools/stitching-directives@4.0.24':
     resolution: {integrity: sha512-n8nZma1jJ8foItej4ncDHE1tCmTYY+sbG9hDIh5c9+Wc0Dbg3SQjp6MQZF9P3qktRX4+fq+2Lu4iEZFo0BhIwA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/stitching-directives@4.0.27':
+    resolution: {integrity: sha512-alHttMyNBrY9XVPfsUvmbFGHDjgjq6Ob1TS/+CFSHQZ2J6LCrHsMxVLTmmJi5grntjMl74xEKrCym4DFbGRAuA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -5134,6 +5234,12 @@ packages:
 
   '@graphql-tools/wrap@11.1.20':
     resolution: {integrity: sha512-nustNS7MhcyomrhSVJvb5HFjyPtWE+XAH7qBoy1n6zokC6UwFnagyHJFuHKllTz4ONcKw91BdDogHuW9KC3cUA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/wrap@11.1.21':
+    resolution: {integrity: sha512-28a+cTtDONeO+Bg+241biALEHdZuIyFk7libduztuh+Ecwk5hCZgLVFn1S5yJXgvMvkm9+MRVSRQaWILsyougA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -8887,6 +8993,9 @@ packages:
 
   '@repeaterjs/repeater@3.0.6':
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
+
+  '@repeaterjs/repeater@3.1.0':
+    resolution: {integrity: sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==}
 
   '@reteps/dockerfmt-darwin-arm64@0.5.4':
     resolution: {integrity: sha512-urMqV+dQyvVI8/WrXwClX9e1PEyS35wFdwJjpZYmL09AkV4Io5U1oam8UBKK7jZk0+YsdF88ay6e86Kn6DIyQg==}
@@ -22283,6 +22392,29 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@graphql-eslint/eslint-plugin@3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.29.7)(graphql@16.9.0)
+      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.7)(graphql@16.9.0)
+      '@graphql-tools/utils': 9.2.1(graphql@16.9.0)
+      chalk: 4.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+      fast-glob: 3.3.3
+      graphql: 16.9.0
+      graphql-config: 4.5.0(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
+      graphql-depth-limit: 1.1.0(graphql@16.9.0)
+      lodash.lowercase: 4.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - bufferutil
+      - cosmiconfig-toml-loader
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   '@graphql-hive/core@0.21.1(graphql@16.14.2)(pino@10.3.0)':
     dependencies:
       '@graphql-hive/logger': 1.1.0(pino@10.3.0)
@@ -22643,6 +22775,14 @@ snapshots:
     optionalDependencies:
       ioredis: 5.10.1
 
+  '@graphql-hive/pubsub@2.2.1(ioredis@5.10.1)':
+    dependencies:
+      '@repeaterjs/repeater': 3.0.6
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+    optionalDependencies:
+      ioredis: 5.10.1
+
   '@graphql-hive/render-laboratory@0.1.10(@tanstack/react-form@1.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@24.13.3)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(date-fns@4.1.0)(graphql-yoga@5.21.1(graphql@16.14.2))(graphql@16.14.2)(lucide-react@0.548.0(react@18.3.1))(lz-string@1.5.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(subscriptions-transport-ws@0.11.0(graphql@16.14.2))(tslib@2.8.1)(zod@4.3.6)':
     dependencies:
       '@graphql-hive/laboratory': 0.1.9(@tanstack/react-form@1.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@24.13.3)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(date-fns@4.1.0)(graphql@16.14.2)(lucide-react@0.548.0(react@18.3.1))(lz-string@1.5.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(subscriptions-transport-ws@0.11.0(graphql@16.14.2))(tslib@2.8.1)(zod@4.3.6)
@@ -22666,6 +22806,31 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
       - zod
+
+  '@graphql-hive/router-query-planner@0.0.38': {}
+
+  '@graphql-hive/router-runtime@1.4.22(@types/node@25.5.0)(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)':
+    dependencies:
+      '@envelop/core': 5.5.1
+      '@graphql-hive/router-query-planner': 0.0.38
+      '@graphql-mesh/fusion-runtime': 1.11.6(@types/node@25.5.0)(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)
+      '@graphql-mesh/transport-common': 1.0.20(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)
+      '@graphql-mesh/utils': 0.104.38(graphql@16.9.0)(ioredis@5.10.1)
+      '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
+      '@graphql-tools/executor': 1.5.0(graphql@16.9.0)
+      '@graphql-tools/executor-common': 1.0.6(graphql@16.9.0)
+      '@graphql-tools/federation': 4.4.12(@types/node@25.5.0)(graphql@16.9.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.9.0
+    transitivePeerDependencies:
+      - '@logtape/logtape'
+      - '@nats-io/jetstream'
+      - '@nats-io/nats-core'
+      - '@types/node'
+      - ioredis
+      - pino
+      - winston
 
   '@graphql-hive/signal@1.0.0': {}
 
@@ -23000,6 +23165,12 @@ snapshots:
       graphql: 16.9.0
       path-browserify: 1.0.1
 
+  '@graphql-mesh/cross-helpers@0.4.16(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/utils': 11.2.2(graphql@16.9.0)
+      graphql: 16.9.0
+      path-browserify: 1.0.1
+
   '@graphql-mesh/fusion-runtime@1.10.10(@types/node@24.13.3)(graphql@16.14.2)(ioredis@5.10.1)(pino@10.3.0)':
     dependencies:
       '@envelop/core': 5.5.1
@@ -23087,6 +23258,38 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@logtape/logtape'
+      - '@nats-io/nats-core'
+      - '@types/node'
+      - ioredis
+      - pino
+      - winston
+
+  '@graphql-mesh/fusion-runtime@1.11.6(@types/node@25.5.0)(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)':
+    dependencies:
+      '@envelop/core': 5.5.1
+      '@envelop/instrumentation': 1.0.0
+      '@graphql-hive/logger': 1.1.1(pino@10.3.0)
+      '@graphql-mesh/cross-helpers': 0.4.14(graphql@16.9.0)
+      '@graphql-mesh/transport-common': 1.0.20(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)
+      '@graphql-mesh/types': 0.105.1(graphql@16.9.0)(ioredis@5.10.1)
+      '@graphql-mesh/utils': 0.104.38(graphql@16.9.0)(ioredis@5.10.1)
+      '@graphql-tools/batch-execute': 10.0.9(graphql@16.9.0)
+      '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
+      '@graphql-tools/executor': 1.5.0(graphql@16.9.0)
+      '@graphql-tools/federation': 4.4.12(@types/node@25.5.0)(graphql@16.9.0)
+      '@graphql-tools/merge': 9.2.2(graphql@16.9.0)
+      '@graphql-tools/stitch': 10.2.2(graphql@16.9.0)
+      '@graphql-tools/stitching-directives': 4.0.27(graphql@16.9.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
+      '@graphql-tools/wrap': 11.1.21(graphql@16.9.0)
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.9.0
+      graphql-yoga: 5.21.1(graphql@16.9.0)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@logtape/logtape'
+      - '@nats-io/jetstream'
       - '@nats-io/nats-core'
       - '@types/node'
       - ioredis
@@ -23253,6 +23456,14 @@ snapshots:
       lodash.get: 4.4.2
       tslib: 2.8.1
 
+  '@graphql-mesh/string-interpolation@0.5.18(graphql@16.9.0)':
+    dependencies:
+      dayjs: 1.11.21
+      graphql: 16.9.0
+      json-pointer: 0.6.2
+      lodash.get: 4.4.2
+      tslib: 2.8.1
+
   '@graphql-mesh/transport-common@1.0.17(graphql@16.14.2)(ioredis@5.10.1)(pino@10.3.0)':
     dependencies:
       '@envelop/core': 5.5.1
@@ -23286,6 +23497,26 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@logtape/logtape'
+      - '@nats-io/nats-core'
+      - ioredis
+      - pino
+      - winston
+
+  '@graphql-mesh/transport-common@1.0.20(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)':
+    dependencies:
+      '@envelop/core': 5.5.1
+      '@graphql-hive/logger': 1.1.1(pino@10.3.0)
+      '@graphql-hive/pubsub': 2.2.1(ioredis@5.10.1)
+      '@graphql-hive/signal': 2.0.0
+      '@graphql-mesh/types': 0.105.1(graphql@16.9.0)(ioredis@5.10.1)
+      '@graphql-tools/executor': 1.5.0(graphql@16.9.0)
+      '@graphql-tools/executor-common': 1.0.6(graphql@16.9.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@logtape/logtape'
+      - '@nats-io/jetstream'
       - '@nats-io/nats-core'
       - ioredis
       - pino
@@ -23388,6 +23619,37 @@ snapshots:
       - '@nats-io/nats-core'
       - ioredis
 
+  '@graphql-mesh/types@0.104.30(graphql@16.9.0)(ioredis@5.10.1)':
+    dependencies:
+      '@graphql-hive/pubsub': 2.1.1(ioredis@5.10.1)
+      '@graphql-tools/batch-delegate': 10.0.28(graphql@16.9.0)
+      '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
+      '@graphql-tools/utils': 11.2.2(graphql@16.9.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@repeaterjs/repeater': 3.1.0
+      '@whatwg-node/disposablestack': 0.0.6
+      graphql: 16.9.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@nats-io/nats-core'
+      - ioredis
+
+  '@graphql-mesh/types@0.105.1(graphql@16.9.0)(ioredis@5.10.1)':
+    dependencies:
+      '@graphql-hive/pubsub': 2.2.1(ioredis@5.10.1)
+      '@graphql-tools/batch-delegate': 10.0.29(graphql@16.9.0)
+      '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
+      '@graphql-tools/utils': 11.2.2(graphql@16.9.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@repeaterjs/repeater': 3.1.0
+      '@whatwg-node/disposablestack': 0.0.6
+      graphql: 16.9.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@nats-io/jetstream'
+      - '@nats-io/nats-core'
+      - ioredis
+
   '@graphql-mesh/utils@0.104.36(graphql@16.14.2)(ioredis@5.10.1)':
     dependencies:
       '@envelop/instrumentation': 1.0.0
@@ -23422,6 +23684,30 @@ snapshots:
       '@graphql-tools/delegate': 12.0.19(graphql@16.9.0)
       '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
       '@graphql-tools/wrap': 11.1.18(graphql@16.9.0)
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
+      dset: 3.1.4
+      graphql: 16.9.0
+      js-yaml: 4.3.0
+      lodash.get: 4.4.2
+      lodash.topath: 4.5.2
+      tiny-lru: 13.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@nats-io/nats-core'
+      - ioredis
+
+  '@graphql-mesh/utils@0.104.38(graphql@16.9.0)(ioredis@5.10.1)':
+    dependencies:
+      '@envelop/instrumentation': 1.0.0
+      '@graphql-mesh/cross-helpers': 0.4.16(graphql@16.9.0)
+      '@graphql-mesh/string-interpolation': 0.5.18(graphql@16.9.0)
+      '@graphql-mesh/types': 0.104.30(graphql@16.9.0)(ioredis@5.10.1)
+      '@graphql-tools/batch-delegate': 10.0.28(graphql@16.9.0)
+      '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
+      '@graphql-tools/utils': 11.2.2(graphql@16.9.0)
+      '@graphql-tools/wrap': 11.1.20(graphql@16.9.0)
       '@whatwg-node/disposablestack': 0.0.6
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
@@ -23474,6 +23760,15 @@ snapshots:
   '@graphql-tools/batch-delegate@10.0.28(graphql@16.9.0)':
     dependencies:
       '@graphql-tools/delegate': 12.1.0(graphql@16.9.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
+      '@whatwg-node/promise-helpers': 1.3.2
+      dataloader: 2.2.3
+      graphql: 16.9.0
+      tslib: 2.8.1
+
+  '@graphql-tools/batch-delegate@10.0.29(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
       '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
@@ -23638,6 +23933,18 @@ snapshots:
       tslib: 2.8.1
 
   '@graphql-tools/delegate@12.1.0(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/batch-execute': 10.0.9(graphql@16.9.0)
+      '@graphql-tools/executor': 1.5.0(graphql@16.9.0)
+      '@graphql-tools/schema': 10.0.29(graphql@16.9.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
+      '@repeaterjs/repeater': 3.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      dataloader: 2.2.3
+      graphql: 16.9.0
+      tslib: 2.8.1
+
+  '@graphql-tools/delegate@12.1.1(graphql@16.9.0)':
     dependencies:
       '@graphql-tools/batch-execute': 10.0.9(graphql@16.9.0)
       '@graphql-tools/executor': 1.5.0(graphql@16.9.0)
@@ -23965,6 +24272,26 @@ snapshots:
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.9.0
       tslib: 2.8.1
+
+  '@graphql-tools/federation@4.4.12(@types/node@25.5.0)(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
+      '@graphql-tools/executor': 1.5.0(graphql@16.9.0)
+      '@graphql-tools/executor-http': 3.3.0(@types/node@25.5.0)(graphql@16.9.0)
+      '@graphql-tools/merge': 9.2.2(graphql@16.9.0)
+      '@graphql-tools/schema': 10.0.29(graphql@16.9.0)
+      '@graphql-tools/stitch': 10.2.2(graphql@16.9.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
+      '@graphql-tools/wrap': 11.1.21(graphql@16.9.0)
+      '@graphql-yoga/typed-event-target': 3.0.2
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/events': 0.1.2
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.9.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@graphql-tools/federation@4.4.8(@types/node@24.13.3)(graphql@16.14.2)':
     dependencies:
@@ -24435,6 +24762,19 @@ snapshots:
       graphql: 16.9.0
       tslib: 2.8.1
 
+  '@graphql-tools/stitch@10.2.2(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/batch-delegate': 10.0.29(graphql@16.9.0)
+      '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
+      '@graphql-tools/executor': 1.5.0(graphql@16.9.0)
+      '@graphql-tools/merge': 9.2.2(graphql@16.9.0)
+      '@graphql-tools/schema': 10.0.29(graphql@16.9.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
+      '@graphql-tools/wrap': 11.1.21(graphql@16.9.0)
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.9.0
+      tslib: 2.8.1
+
   '@graphql-tools/stitching-directives@3.1.38(graphql@16.9.0)':
     dependencies:
       '@graphql-tools/delegate': 10.2.23(graphql@16.9.0)
@@ -24452,6 +24792,13 @@ snapshots:
   '@graphql-tools/stitching-directives@4.0.24(graphql@16.9.0)':
     dependencies:
       '@graphql-tools/delegate': 12.0.19(graphql@16.9.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
+      graphql: 16.9.0
+      tslib: 2.8.1
+
+  '@graphql-tools/stitching-directives@4.0.27(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
       '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
       graphql: 16.9.0
       tslib: 2.8.1
@@ -24753,6 +25100,15 @@ snapshots:
   '@graphql-tools/wrap@11.1.20(graphql@16.9.0)':
     dependencies:
       '@graphql-tools/delegate': 12.1.0(graphql@16.9.0)
+      '@graphql-tools/schema': 10.0.29(graphql@16.9.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.9.0
+      tslib: 2.8.1
+
+  '@graphql-tools/wrap@11.1.21(graphql@16.9.0)':
+    dependencies:
+      '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
       '@graphql-tools/schema': 10.0.29(graphql@16.9.0)
       '@graphql-tools/utils': 11.1.0(graphql@16.9.0)
       '@whatwg-node/promise-helpers': 1.3.2
@@ -29509,6 +29865,8 @@ snapshots:
   '@repeaterjs/repeater@3.0.4': {}
 
   '@repeaterjs/repeater@3.0.6': {}
+
+  '@repeaterjs/repeater@3.1.0': {}
 
   '@reteps/dockerfmt-darwin-arm64@0.5.4':
     optional: true


### PR DESCRIPTION
### Background

Hive gateway using the rust query planner does not populate the path in the execution request info object if it's the root ("query"). Previously, the usage client would default to `[]`, but an empty array fails validation in usage service.

### Description

This change corrects the default value for the usage client and gateway plugin "paths" field, and better supports named root types.

I also added a test showing support for named root types, and run tests for both the js gateway and js gateway with the rust query planner.

There are two tests that fail due to minor discrepancies in the engine at this time. These are flagged with `skipIf` conditions until the cause is addressed.

### Checklist

- [X] Testing
