### PR TITLE
fix: allow login for linked identity admin

### DIFF
--- a/integration-tests/tests/api/auth/scim.spec.ts
+++ b/integration-tests/tests/api/auth/scim.spec.ts
@@ -3865,6 +3865,120 @@ test.concurrent(
 );
 
 test.concurrent(
+  'organization admin cannot bypass provisioning enforced by another organization',
+  async ({ expect }) => {
+    const seed = initSeed();
+    const domain =
+      humanId({
+        separator: '',
+        capitalize: false,
+      }) + '.local';
+    const adminEmail = 'admin@' + domain;
+    const admin = await seed.createOwner(true, adminEmail);
+    await admin.createOrg();
+
+    const enforcingOwner = await seed.createOwner();
+    const enforcingOrg = await enforcingOwner.createOrg();
+    await enforcingOrg.setFeatureFlag('scim', true);
+    const oidc = await enforcingOrg.createOIDCIntegration();
+    await oidc.registerFakeDomain(domain);
+    await oidc.createMockServerAndUpdateIntegrationEndpoints({
+      oidcForVerifiedDomainsRequired: true,
+      userProvisioningRequired: true,
+    });
+
+    const response = await fetch(baseUrl + '/auth-api/signin', {
+      method: 'POST',
+      body: JSON.stringify({
+        formFields: [
+          { id: 'email', value: adminEmail },
+          { id: 'password', value: 'ilikebigturtlesandicannotlie47' },
+        ],
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toMatchObject({
+      status: 'SIGN_IN_NOT_ALLOWED',
+    });
+  },
+);
+
+test.concurrent(
+  'organization admin can still sign in via a linked email/password identity if provisioning is enforced',
+  async ({ expect }) => {
+    const seed = initSeed();
+    const domain =
+      humanId({
+        separator: '',
+        capitalize: false,
+      }) + '.local';
+    const ownerEmail = 'admin@' + domain;
+    const owner = await seed.createOwner(true, ownerEmail);
+    const org = await owner.createOrg();
+    await org.setFeatureFlag('scim', true);
+    const oidc = await org.createOIDCIntegration();
+    await oidc.registerFakeDomain(domain);
+    await oidc.createMockServerAndUpdateIntegrationEndpoints({
+      oidcForVerifiedDomainsRequired: true,
+      userProvisioningRequired: true,
+    });
+
+    const { pool } = await seed.createDbConnection();
+    const supertokensStore = new SuperTokensStore(pool, new NoopLogger());
+    const oidcIdentity = await supertokensStore.createOIDCUser({
+      email: ownerEmail,
+      externalId: crypto.randomUUID(),
+      oidcIntegrationId: oidc.oidcIntegration.id,
+    });
+    const storage = await createStorage(seed.getPGConnectionString(), 1);
+
+    try {
+      const linkedUser = await storage.ensureUserExists({
+        email: ownerEmail,
+        firstName: null,
+        lastName: null,
+        oidcIntegration: oidc.oidcIntegration,
+        superTokensUserId: oidcIdentity.userId,
+      });
+      invariant(linkedUser.ok, 'Expected the OIDC identity to be linked to the owner.');
+
+      await pool.query(psql`
+        UPDATE "users"
+        SET "supertoken_user_id" = ${oidcIdentity.userId}
+        WHERE "id" = ${linkedUser.user.id}
+      `);
+
+      const response = await fetch(baseUrl + '/auth-api/signin', {
+        method: 'POST',
+        body: JSON.stringify({
+          formFields: [
+            { id: 'email', value: ownerEmail },
+            { id: 'password', value: 'ilikebigturtlesandicannotlie47' },
+          ],
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      expect(response.status).toEqual(200);
+      expect(await response.json()).toMatchObject({
+        status: 'OK',
+        user: {
+          emails: [ownerEmail],
+        },
+      });
+    } finally {
+      await storage.destroy();
+    }
+  },
+);
+
+test.concurrent(
   'provisioned user leverages groups for deriving the users authorization',
   async ({ expect }) => {
     const seed = initSeed();

--- a/packages/services/api/src/modules/organization/providers/provisioned-users-store.ts
+++ b/packages/services/api/src/modules/organization/providers/provisioned-users-store.ts
@@ -353,11 +353,29 @@ export class ProvisionedUsersStore {
     return await this.pool.oneFirst(query).then(z.number().parse);
   }
 
-  async isUserWithIdAdminOfAnyOrganization(userId: string) {
+  /** Find out whether any supertoken identity linked to the identity is allowed to access the organization. */
+  async isIdentityAdminOfOrganization(superTokensUserId: string, organizationId: string) {
     const query = psql`
       SELECT TRUE as "exists"
-      FROM "organizations"
-      WHERE "user_id" = ${userId}
+      FROM "organizations" "o"
+      WHERE
+        "o"."id" = ${organizationId}
+        AND EXISTS (
+          SELECT 1
+          FROM "users" "u"
+          WHERE
+            "u"."id" = "o"."user_id"
+            AND (
+              "u"."supertoken_user_id" = ${superTokensUserId}
+              OR EXISTS (
+                SELECT 1
+                FROM "users_linked_identities" "uli"
+                WHERE
+                  "uli"."user_id" = "u"."id"
+                  AND "uli"."identity_id" = ${superTokensUserId}
+              )
+            )
+          )
       LIMIT 1
     `;
 

--- a/packages/services/server/src/supertokens-at-home.ts
+++ b/packages/services/server/src/supertokens-at-home.ts
@@ -101,25 +101,24 @@ export async function registerSupertokensAtHome(
       };
     }
 
-    if (user) {
-      const hiveUser = await storage.getUserBySuperTokenId({ superTokensUserId: user.userId });
+    if (!user) {
+      return {
+        type: 'error' as const,
+      };
+    }
 
-      if (hiveUser) {
-        const usersStore = new ProvisionedUsersStore(storage.pool);
-        const isUserAdminOfAnyOrganization = await usersStore.isUserWithIdAdminOfAnyOrganization(
-          hiveUser.id,
-        );
+    const isUserAdminOfOrganization = await new ProvisionedUsersStore(
+      storage.pool,
+    ).isIdentityAdminOfOrganization(user.userId, oidcIntegration.linkedOrganizationId);
 
-        if (isUserAdminOfAnyOrganization) {
-          return {
-            type: 'success' as const,
-          };
-        }
-      }
+    if (!isUserAdminOfOrganization) {
+      return {
+        type: 'error' as const,
+      };
     }
 
     return {
-      type: 'error' as const,
+      type: 'success' as const,
     };
   }
 


### PR DESCRIPTION
If you are an organization owner, but your identity is linked instead of direct it locks you out from email+password login.