### PR TITLE
feat: SCIM provisioning conflict resolutions

### DIFF
--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -6,7 +6,7 @@ import type {
   AddMetricAlertRuleInput,
   AnswerOrganizationTransferRequestInput,
   AssignMemberRoleInput,
-  ConfirmScimAccountTakeoverInput,
+  ConfirmScimManagementForMemberInput,
   CreateContractInput,
   CreateMemberRoleInput,
   CreateOrganizationAccessTokenInput,
@@ -2248,14 +2248,16 @@ export function createOIDCIntegration(
   });
 }
 
-export function confirmSCIMAccountTakeover(
-  input: ConfirmScimAccountTakeoverInput,
+export function confirmSCIMManagementForMember(
+  input: ConfirmScimManagementForMemberInput,
   authToken: string,
 ) {
   return execute({
     document: graphql(`
-      mutation TestKit_ConfirmSCIMAccountTakeover($input: ConfirmSCIMAccountTakeoverInput!) {
-        confirmSCIMAccountTakeover(input: $input) {
+      mutation TestKit_ConfirmSCIMManagementForMember(
+        $input: ConfirmSCIMManagementForMemberInput!
+      ) {
+        confirmSCIMManagementForMember(input: $input) {
           ok {
             confirmedMember {
               id

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -6,6 +6,7 @@ import type {
   AddMetricAlertRuleInput,
   AnswerOrganizationTransferRequestInput,
   AssignMemberRoleInput,
+  ConfirmScimAccountTakeoverInput,
   CreateContractInput,
   CreateMemberRoleInput,
   CreateOrganizationAccessTokenInput,
@@ -2238,6 +2239,36 @@ export function createOIDCIntegration(
               authorizationEndpoint
               additionalScopes
             }
+          }
+        }
+      }
+    `),
+    variables: { input },
+    authToken,
+  });
+}
+
+export function confirmSCIMAccountTakeover(
+  input: ConfirmScimAccountTakeoverInput,
+  authToken: string,
+) {
+  return execute({
+    document: graphql(`
+      mutation TestKit_ConfirmSCIMAccountTakeover($input: ConfirmSCIMAccountTakeoverInput!) {
+        confirmSCIMAccountTakeover(input: $input) {
+          ok {
+            confirmedMember {
+              id
+              user {
+                id
+                provisionInfo {
+                  provisioningStatus
+                }
+              }
+            }
+          }
+          error {
+            message
           }
         }
       }

--- a/integration-tests/tests/api/auth/scim.spec.ts
+++ b/integration-tests/tests/api/auth/scim.spec.ts
@@ -2,7 +2,7 @@ import humanId from 'human-id';
 import {
   addGroupMappingToGroup,
   assignMemberRole,
-  confirmSCIMAccountTakeover,
+  confirmSCIMManagementForMember,
   createMemberRole,
   createOrganization,
   createPersonalAccessToken,
@@ -32,14 +32,14 @@ import { fetchPermissions } from '../access-tokens/shared';
 
 const baseUrl = await getServiceHost('server', 3001).then(r => `http://${r}`);
 
-const MembersByProvisioningTakeoverApprovalQuery = graphql(`
-  query MembersByProvisioningTakeoverApproval(
+const MembersBySCIMManagementConfirmationQuery = graphql(`
+  query MembersBySCIMManagementConfirmation(
     $organizationId: ID!
-    $needsProvisioningTakeoverApproval: Boolean!
+    $needsSCIMManagementConfirmation: Boolean!
   ) {
     organization(reference: { byId: $organizationId }) {
-      pendingProvisioningTakeoverApprovalsCount
-      members(filters: { needsProvisioningTakeoverApproval: $needsProvisioningTakeoverApproval }) {
+      pendingSCIMManagementConfirmationsCount
+      members(filters: { needsSCIMManagementConfirmation: $needsSCIMManagementConfirmation }) {
         edges {
           node {
             user {
@@ -3702,13 +3702,13 @@ test.concurrent(
           FROM "users"
           WHERE "id" = ${scimUser.body.id}
         `),
-      ).toEqual('pendingAdoption');
+      ).toEqual('pendingConfirmation');
 
       const membersNeedingApproval = await execute({
-        document: MembersByProvisioningTakeoverApprovalQuery,
+        document: MembersBySCIMManagementConfirmationQuery,
         variables: {
           organizationId: org.organization.id,
-          needsProvisioningTakeoverApproval: true,
+          needsSCIMManagementConfirmation: true,
         },
         authToken: owner.ownerToken,
       }).then(r => r.expectNoGraphQLErrors());
@@ -3718,19 +3718,17 @@ test.concurrent(
         {
           id: scimUser.body.id,
           provisionInfo: {
-            provisioningStatus: 'pendingAdoption',
+            provisioningStatus: 'pendingConfirmation',
           },
         },
       ]);
-      expect(membersNeedingApproval.organization?.pendingProvisioningTakeoverApprovalsCount).toBe(
-        1,
-      );
+      expect(membersNeedingApproval.organization?.pendingSCIMManagementConfirmationsCount).toBe(1);
 
       const membersNotNeedingApproval = await execute({
-        document: MembersByProvisioningTakeoverApprovalQuery,
+        document: MembersBySCIMManagementConfirmationQuery,
         variables: {
           organizationId: org.organization.id,
-          needsProvisioningTakeoverApproval: false,
+          needsSCIMManagementConfirmation: false,
         },
         authToken: owner.ownerToken,
       }).then(r => r.expectNoGraphQLErrors());
@@ -3738,12 +3736,12 @@ test.concurrent(
         membersNotNeedingApproval.organization?.members.edges.map(edge => edge.node.user.id),
       ).not.toContain(scimUser.body.id);
 
-      const takeoverInput = {
+      const managementInput = {
         organization: { byId: org.organization.id },
         member: { byId: scimUser.body.id },
       };
-      const unauthorizedErrors = await confirmSCIMAccountTakeover(
-        takeoverInput,
+      const unauthorizedErrors = await confirmSCIMManagementForMember(
+        managementInput,
         accessToken.privateAccessKey,
       ).then(r => r.expectGraphQLErrors());
 
@@ -3753,11 +3751,12 @@ test.concurrent(
         },
       ]);
 
-      const confirmation = await confirmSCIMAccountTakeover(takeoverInput, owner.ownerToken).then(
-        r => r.expectNoGraphQLErrors(),
-      );
+      const confirmation = await confirmSCIMManagementForMember(
+        managementInput,
+        owner.ownerToken,
+      ).then(r => r.expectNoGraphQLErrors());
 
-      expect(confirmation.confirmSCIMAccountTakeover.ok?.confirmedMember.user).toMatchObject({
+      expect(confirmation.confirmSCIMManagementForMember.ok?.confirmedMember.user).toMatchObject({
         id: scimUser.body.id,
         provisionInfo: {
           provisioningStatus: 'active',
@@ -3772,26 +3771,26 @@ test.concurrent(
       ).toEqual('active');
 
       const membersAfterConfirmation = await execute({
-        document: MembersByProvisioningTakeoverApprovalQuery,
+        document: MembersBySCIMManagementConfirmationQuery,
         variables: {
           organizationId: org.organization.id,
-          needsProvisioningTakeoverApproval: true,
+          needsSCIMManagementConfirmation: true,
         },
         authToken: owner.ownerToken,
       }).then(r => r.expectNoGraphQLErrors());
       expect(membersAfterConfirmation.organization).toMatchObject({
-        pendingProvisioningTakeoverApprovalsCount: 0,
+        pendingSCIMManagementConfirmationsCount: 0,
         members: {
           edges: [],
         },
       });
 
-      const repeatedConfirmation = await confirmSCIMAccountTakeover(
-        takeoverInput,
+      const repeatedConfirmation = await confirmSCIMManagementForMember(
+        managementInput,
         owner.ownerToken,
       ).then(r => r.expectNoGraphQLErrors());
 
-      expect(repeatedConfirmation.confirmSCIMAccountTakeover).toEqual({
+      expect(repeatedConfirmation.confirmSCIMManagementForMember).toEqual({
         ok: null,
         error: {
           message: 'Pending SCIM provisioning conflict not found.',

--- a/integration-tests/tests/api/auth/scim.spec.ts
+++ b/integration-tests/tests/api/auth/scim.spec.ts
@@ -3724,18 +3724,6 @@ test.concurrent(
       ]);
       expect(membersNeedingApproval.organization?.pendingSCIMManagementConfirmationsCount).toBe(1);
 
-      const membersNotNeedingApproval = await execute({
-        document: MembersBySCIMManagementConfirmationQuery,
-        variables: {
-          organizationId: org.organization.id,
-          needsSCIMManagementConfirmation: false,
-        },
-        authToken: owner.ownerToken,
-      }).then(r => r.expectNoGraphQLErrors());
-      expect(
-        membersNotNeedingApproval.organization?.members.edges.map(edge => edge.node.user.id),
-      ).not.toContain(scimUser.body.id);
-
       const managementInput = {
         organization: { byId: org.organization.id },
         member: { byId: scimUser.body.id },

--- a/integration-tests/tests/api/auth/scim.spec.ts
+++ b/integration-tests/tests/api/auth/scim.spec.ts
@@ -38,6 +38,7 @@ const MembersByProvisioningTakeoverApprovalQuery = graphql(`
     $needsProvisioningTakeoverApproval: Boolean!
   ) {
     organization(reference: { byId: $organizationId }) {
+      hasPendingProvisioningTakeoverApprovals
       members(filters: { needsProvisioningTakeoverApproval: $needsProvisioningTakeoverApproval }) {
         edges {
           node {
@@ -3721,6 +3722,9 @@ test.concurrent(
           },
         },
       ]);
+      expect(membersNeedingApproval.organization?.hasPendingProvisioningTakeoverApprovals).toBe(
+        true,
+      );
 
       const membersNotNeedingApproval = await execute({
         document: MembersByProvisioningTakeoverApprovalQuery,
@@ -3766,6 +3770,21 @@ test.concurrent(
           WHERE "id" = ${scimUser.body.id}
         `),
       ).toEqual('active');
+
+      const membersAfterConfirmation = await execute({
+        document: MembersByProvisioningTakeoverApprovalQuery,
+        variables: {
+          organizationId: org.organization.id,
+          needsProvisioningTakeoverApproval: true,
+        },
+        authToken: owner.ownerToken,
+      }).then(r => r.expectNoGraphQLErrors());
+      expect(membersAfterConfirmation.organization).toMatchObject({
+        hasPendingProvisioningTakeoverApprovals: false,
+        members: {
+          edges: [],
+        },
+      });
 
       const repeatedConfirmation = await confirmSCIMAccountTakeover(
         takeoverInput,

--- a/integration-tests/tests/api/auth/scim.spec.ts
+++ b/integration-tests/tests/api/auth/scim.spec.ts
@@ -15,7 +15,9 @@ import {
   updateMe,
   updateMemberRole,
 } from 'testkit/flow';
+import { graphql } from 'testkit/gql';
 import { ResourceAssignmentModeType } from 'testkit/gql/graphql';
+import { execute } from 'testkit/graphql';
 import { initSeed } from 'testkit/seed';
 import { getServiceHost } from 'testkit/utils';
 import z from 'zod';
@@ -29,6 +31,28 @@ import { createScimTestkit } from '../../../testkit/scim';
 import { fetchPermissions } from '../access-tokens/shared';
 
 const baseUrl = await getServiceHost('server', 3001).then(r => `http://${r}`);
+
+const MembersByProvisioningTakeoverApprovalQuery = graphql(`
+  query MembersByProvisioningTakeoverApproval(
+    $organizationId: ID!
+    $needsProvisioningTakeoverApproval: Boolean!
+  ) {
+    organization(reference: { byId: $organizationId }) {
+      members(filters: { needsProvisioningTakeoverApproval: $needsProvisioningTakeoverApproval }) {
+        edges {
+          node {
+            user {
+              id
+              provisionInfo {
+                provisioningStatus
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`);
 
 function newUserValues() {
   return {
@@ -3678,6 +3702,37 @@ test.concurrent(
           WHERE "id" = ${scimUser.body.id}
         `),
       ).toEqual('pendingAdoption');
+
+      const membersNeedingApproval = await execute({
+        document: MembersByProvisioningTakeoverApprovalQuery,
+        variables: {
+          organizationId: org.organization.id,
+          needsProvisioningTakeoverApproval: true,
+        },
+        authToken: owner.ownerToken,
+      }).then(r => r.expectNoGraphQLErrors());
+      expect(
+        membersNeedingApproval.organization?.members.edges.map(edge => edge.node.user),
+      ).toEqual([
+        {
+          id: scimUser.body.id,
+          provisionInfo: {
+            provisioningStatus: 'pendingAdoption',
+          },
+        },
+      ]);
+
+      const membersNotNeedingApproval = await execute({
+        document: MembersByProvisioningTakeoverApprovalQuery,
+        variables: {
+          organizationId: org.organization.id,
+          needsProvisioningTakeoverApproval: false,
+        },
+        authToken: owner.ownerToken,
+      }).then(r => r.expectNoGraphQLErrors());
+      expect(
+        membersNotNeedingApproval.organization?.members.edges.map(edge => edge.node.user.id),
+      ).not.toContain(scimUser.body.id);
 
       const takeoverInput = {
         organization: { byId: org.organization.id },

--- a/integration-tests/tests/api/auth/scim.spec.ts
+++ b/integration-tests/tests/api/auth/scim.spec.ts
@@ -37,7 +37,6 @@ function newUserValues() {
     emails: [{ primary: true, value: 'marty@mcfly.dev', type: 'work' }],
     locale: 'en-US',
     externalId: crypto.randomUUID(),
-    password: 'fq77ZD37',
     active: true,
   };
 }
@@ -79,6 +78,7 @@ describe.concurrent('/Users', () => {
       const owner = await seed.createOwner();
       const org = await owner.createOrg();
       await org.setFeatureFlag('scim', true);
+      const { pool } = await seed.createDbConnection();
       const { registerFakeDomain } = await org.createOIDCIntegration();
       const domain = await registerFakeDomain();
       const userEmail = 'marty@' + domain;
@@ -102,7 +102,6 @@ describe.concurrent('/Users', () => {
         locale: 'en-US',
         externalId: externalUserId,
         groups: [],
-        password: 'fq77ZD37',
         active: true,
       });
       expect(usersPostResponse.headers.get('content-type')).toBe('application/scim+json');
@@ -127,6 +126,13 @@ describe.concurrent('/Users', () => {
           location: baseUrl + '/scim/v2/Users/' + usersPostResponse.body.id,
         },
       });
+      expect(
+        await pool.oneFirst(psql`
+          SELECT "provisioning_status"
+          FROM "users"
+          WHERE "id" = ${usersPostResponse.body.id}
+        `),
+      ).toEqual('active');
     });
     test.concurrent(
       'create new user without emails infers email from userName',
@@ -192,7 +198,6 @@ describe.concurrent('/Users', () => {
           locale: 'en-US',
           externalId: externalUserId,
           groups: [],
-          password: 'foobars',
           active: true,
         });
 
@@ -246,7 +251,6 @@ describe.concurrent('/Users', () => {
           locale: 'en-US',
           externalId: externalUserId,
           groups: [],
-          password: 'fq77ZD37',
           active: true,
         },
         { expectedStatus: 400 },
@@ -290,7 +294,6 @@ describe.concurrent('/Users', () => {
           locale: 'en-US',
           externalId: externalUserId,
           groups: [],
-          password: 'foobars',
           active: true,
         });
         const conflictUsersPostResponse = await scim.createUser(
@@ -303,7 +306,6 @@ describe.concurrent('/Users', () => {
             locale: 'en-US',
             externalId: externalUserId,
             groups: [],
-            password: 'fq77ZD37',
             active: true,
           },
           { expectedStatus: 409 },
@@ -346,7 +348,6 @@ describe.concurrent('/Users', () => {
         locale: 'en-US',
         externalId: externalUserId,
         groups: [],
-        password: 'fq77ZD37',
         active: false,
       });
 
@@ -405,7 +406,6 @@ describe.concurrent('/Users', () => {
             locale: 'en-US',
             externalId: externalUserId,
             groups: [],
-            password: 'fq77ZD37',
             active: true,
           },
           { expectedStatus: 404 },
@@ -448,7 +448,6 @@ describe.concurrent('/Users', () => {
         locale: 'en-US',
         externalId: externalUserId,
         groups: [],
-        password: 'fq77ZD37',
         active: true,
       });
 
@@ -461,7 +460,6 @@ describe.concurrent('/Users', () => {
         locale: 'en-US',
         externalId: externalUserId,
         groups: [],
-        password: 'fq77ZD37',
         active: false,
       });
       expect(usersPutResponse.body).toEqual({
@@ -507,7 +505,6 @@ describe.concurrent('/Users', () => {
         locale: 'en-US',
         externalId: externalUserId,
         groups: [],
-        password: 'fq77ZD37',
         active: true,
       });
 
@@ -520,7 +517,6 @@ describe.concurrent('/Users', () => {
         locale: 'en-US',
         externalId: externalUserId,
         groups: [],
-        password: 'fq77ZD37',
         active: false,
       });
       expect(usersPutResponse.body).toMatchObject({
@@ -557,7 +553,6 @@ describe.concurrent('/Users', () => {
         locale: 'en-US',
         externalId: externalUserId,
         groups: [],
-        password: 'fq77ZD37',
         active: true,
       });
 
@@ -1068,7 +1063,6 @@ describe.concurrent('/Users', () => {
         locale: 'en-US',
         externalId: externalUserId,
         groups: [],
-        password: 'fq77ZD37',
         active: true,
       });
       const usersPatchResponse = await scim.patchUser(
@@ -2438,7 +2432,6 @@ describe.concurrent('/Groups', () => {
         locale: 'en-US',
         externalId: 'userExternalId',
         groups: [],
-        password: 'fq77ZD37',
         active: true,
       });
       const putResponse = await scim.patchGroup(postResponse.body.id, {
@@ -3417,7 +3410,6 @@ describe.concurrent('provider flows', () => {
         locale: 'en-US',
         externalId: externalUserId,
         groups: [],
-        password: 'fq77ZD37',
         active: true,
       });
       expect(usersPostResponse.body).toEqual({
@@ -3506,7 +3498,6 @@ describe.concurrent('provider flows', () => {
           locale: 'en-US',
           externalId: externalUserId,
           groups: [],
-          password: 'fq77ZD37',
           active: true,
         });
 
@@ -3627,8 +3618,8 @@ describe.concurrent('provider flows', () => {
 });
 
 test.concurrent(
-  'externalId (sub) conflict with existing OIDC user takes over the user',
-  async () => {
+  'externalId (sub) conflict with existing OIDC user creates a pending adoption',
+  async ({ expect }) => {
     const seed = initSeed();
     const owner = await seed.createOwner();
     const org = await owner.createOrg();
@@ -3673,11 +3664,19 @@ test.concurrent(
       };
       const scim = createScimTestkit({ baseUrl, headers });
 
-      await scim.createUser({
+      const scimUser = await scim.createUser({
         ...newUserValues(),
         externalId: subOrExternalId,
         emails: [{ primary: true, type: 'work', value: email }],
       });
+
+      expect(
+        await pool.oneFirst(psql`
+          SELECT "provisioning_status"
+          FROM "users"
+          WHERE "id" = ${scimUser.body.id}
+        `),
+      ).toEqual('pendingAdoption');
     } finally {
       await storage.destroy();
     }

--- a/integration-tests/tests/api/auth/scim.spec.ts
+++ b/integration-tests/tests/api/auth/scim.spec.ts
@@ -161,6 +161,45 @@ describe.concurrent('/Users', () => {
       ).toEqual('active');
     });
     test.concurrent(
+      're-creating an active provisioned user fails and preserves its provisioning status',
+      async ({ expect }) => {
+        const seed = initSeed();
+        const owner = await seed.createOwner();
+        const org = await owner.createOrg();
+        await org.setFeatureFlag('scim', true);
+        const { pool } = await seed.createDbConnection();
+        const { registerFakeDomain } = await org.createOIDCIntegration();
+        const domain = await registerFakeDomain();
+        const accessToken = await org.createOrganizationAccessToken({
+          permissions: ['scim:provision'],
+          resources: { mode: ResourceAssignmentModeType.Granular },
+        });
+        const scim = createScimTestkit({
+          baseUrl,
+          headers: {
+            'Content-Type': 'application/scim+json',
+            Authorization: 'Bearer ' + accessToken.privateAccessKey,
+          },
+        });
+        const externalId = crypto.randomUUID();
+        const email = 'marty.mcfly@' + domain;
+        const user = {
+          ...newUserValues(),
+          userName: email,
+          emails: [{ primary: true, value: email, type: 'work' }],
+          externalId,
+        };
+        const createdUser = await scim.createUser(user);
+
+        const recreateResponse = await scim.createUser(user, { expectedStatus: 409 });
+
+        expect(recreateResponse.body).toMatchObject({
+          detail: 'A user with the same external id already exists.',
+          status: 409,
+        });
+      },
+    );
+    test.concurrent(
       'create new user without emails infers email from userName',
       async ({ expect }) => {
         const seed = initSeed();

--- a/integration-tests/tests/api/auth/scim.spec.ts
+++ b/integration-tests/tests/api/auth/scim.spec.ts
@@ -3865,6 +3865,120 @@ test.concurrent(
 );
 
 test.concurrent(
+  'organization admin cannot bypass provisioning enforced by another organization',
+  async ({ expect }) => {
+    const seed = initSeed();
+    const domain =
+      humanId({
+        separator: '',
+        capitalize: false,
+      }) + '.local';
+    const adminEmail = 'admin@' + domain;
+    const admin = await seed.createOwner(true, adminEmail);
+    await admin.createOrg();
+
+    const enforcingOwner = await seed.createOwner();
+    const enforcingOrg = await enforcingOwner.createOrg();
+    await enforcingOrg.setFeatureFlag('scim', true);
+    const oidc = await enforcingOrg.createOIDCIntegration();
+    await oidc.registerFakeDomain(domain);
+    await oidc.createMockServerAndUpdateIntegrationEndpoints({
+      oidcForVerifiedDomainsRequired: true,
+      userProvisioningRequired: true,
+    });
+
+    const response = await fetch(baseUrl + '/auth-api/signin', {
+      method: 'POST',
+      body: JSON.stringify({
+        formFields: [
+          { id: 'email', value: adminEmail },
+          { id: 'password', value: 'ilikebigturtlesandicannotlie47' },
+        ],
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toMatchObject({
+      status: 'SIGN_IN_NOT_ALLOWED',
+    });
+  },
+);
+
+test.concurrent(
+  'organization admin can still sign in via a linked email/password identity if provisioning is enforced',
+  async ({ expect }) => {
+    const seed = initSeed();
+    const domain =
+      humanId({
+        separator: '',
+        capitalize: false,
+      }) + '.local';
+    const ownerEmail = 'admin@' + domain;
+    const owner = await seed.createOwner(true, ownerEmail);
+    const org = await owner.createOrg();
+    await org.setFeatureFlag('scim', true);
+    const oidc = await org.createOIDCIntegration();
+    await oidc.registerFakeDomain(domain);
+    await oidc.createMockServerAndUpdateIntegrationEndpoints({
+      oidcForVerifiedDomainsRequired: true,
+      userProvisioningRequired: true,
+    });
+
+    const { pool } = await seed.createDbConnection();
+    const supertokensStore = new SuperTokensStore(pool, new NoopLogger());
+    const oidcIdentity = await supertokensStore.createOIDCUser({
+      email: ownerEmail,
+      externalId: crypto.randomUUID(),
+      oidcIntegrationId: oidc.oidcIntegration.id,
+    });
+    const storage = await createStorage(seed.getPGConnectionString(), 1);
+
+    try {
+      const linkedUser = await storage.ensureUserExists({
+        email: ownerEmail,
+        firstName: null,
+        lastName: null,
+        oidcIntegration: oidc.oidcIntegration,
+        superTokensUserId: oidcIdentity.userId,
+      });
+      invariant(linkedUser.ok, 'Expected the OIDC identity to be linked to the owner.');
+
+      await pool.query(psql`
+        UPDATE "users"
+        SET "supertoken_user_id" = ${oidcIdentity.userId}
+        WHERE "id" = ${linkedUser.user.id}
+      `);
+
+      const response = await fetch(baseUrl + '/auth-api/signin', {
+        method: 'POST',
+        body: JSON.stringify({
+          formFields: [
+            { id: 'email', value: ownerEmail },
+            { id: 'password', value: 'ilikebigturtlesandicannotlie47' },
+          ],
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      expect(response.status).toEqual(200);
+      expect(await response.json()).toMatchObject({
+        status: 'OK',
+        user: {
+          emails: [ownerEmail],
+        },
+      });
+    } finally {
+      await storage.destroy();
+    }
+  },
+);
+
+test.concurrent(
   'provisioned user leverages groups for deriving the users authorization',
   async ({ expect }) => {
     const seed = initSeed();

--- a/integration-tests/tests/api/auth/scim.spec.ts
+++ b/integration-tests/tests/api/auth/scim.spec.ts
@@ -2,6 +2,7 @@ import humanId from 'human-id';
 import {
   addGroupMappingToGroup,
   assignMemberRole,
+  confirmSCIMAccountTakeover,
   createMemberRole,
   createOrganization,
   createPersonalAccessToken,
@@ -3677,6 +3678,51 @@ test.concurrent(
           WHERE "id" = ${scimUser.body.id}
         `),
       ).toEqual('pendingAdoption');
+
+      const takeoverInput = {
+        organization: { byId: org.organization.id },
+        member: { byId: scimUser.body.id },
+      };
+      const unauthorizedErrors = await confirmSCIMAccountTakeover(
+        takeoverInput,
+        accessToken.privateAccessKey,
+      ).then(r => r.expectGraphQLErrors());
+
+      expect(unauthorizedErrors).toMatchObject([
+        {
+          message: `No access (reason: "Missing permission for performing 'member:modify' on resource")`,
+        },
+      ]);
+
+      const confirmation = await confirmSCIMAccountTakeover(takeoverInput, owner.ownerToken).then(
+        r => r.expectNoGraphQLErrors(),
+      );
+
+      expect(confirmation.confirmSCIMAccountTakeover.ok?.confirmedMember.user).toMatchObject({
+        id: scimUser.body.id,
+        provisionInfo: {
+          provisioningStatus: 'active',
+        },
+      });
+      expect(
+        await pool.oneFirst(psql`
+          SELECT "provisioning_status"
+          FROM "users"
+          WHERE "id" = ${scimUser.body.id}
+        `),
+      ).toEqual('active');
+
+      const repeatedConfirmation = await confirmSCIMAccountTakeover(
+        takeoverInput,
+        owner.ownerToken,
+      ).then(r => r.expectNoGraphQLErrors());
+
+      expect(repeatedConfirmation.confirmSCIMAccountTakeover).toEqual({
+        ok: null,
+        error: {
+          message: 'Pending SCIM account takeover not found.',
+        },
+      });
     } finally {
       await storage.destroy();
     }

--- a/integration-tests/tests/api/auth/scim.spec.ts
+++ b/integration-tests/tests/api/auth/scim.spec.ts
@@ -38,7 +38,7 @@ const MembersByProvisioningTakeoverApprovalQuery = graphql(`
     $needsProvisioningTakeoverApproval: Boolean!
   ) {
     organization(reference: { byId: $organizationId }) {
-      hasPendingProvisioningTakeoverApprovals
+      pendingProvisioningTakeoverApprovalsCount
       members(filters: { needsProvisioningTakeoverApproval: $needsProvisioningTakeoverApproval }) {
         edges {
           node {
@@ -3722,8 +3722,8 @@ test.concurrent(
           },
         },
       ]);
-      expect(membersNeedingApproval.organization?.hasPendingProvisioningTakeoverApprovals).toBe(
-        true,
+      expect(membersNeedingApproval.organization?.pendingProvisioningTakeoverApprovalsCount).toBe(
+        1,
       );
 
       const membersNotNeedingApproval = await execute({
@@ -3780,7 +3780,7 @@ test.concurrent(
         authToken: owner.ownerToken,
       }).then(r => r.expectNoGraphQLErrors());
       expect(membersAfterConfirmation.organization).toMatchObject({
-        hasPendingProvisioningTakeoverApprovals: false,
+        pendingProvisioningTakeoverApprovalsCount: 0,
         members: {
           edges: [],
         },
@@ -3794,7 +3794,7 @@ test.concurrent(
       expect(repeatedConfirmation.confirmSCIMAccountTakeover).toEqual({
         ok: null,
         error: {
-          message: 'Pending SCIM account takeover not found.',
+          message: 'Pending SCIM provisioning conflict not found.',
         },
       });
     } finally {

--- a/packages/migrations/src/actions/2026.08.06T00-00-00.scim-provisioning-status.ts
+++ b/packages/migrations/src/actions/2026.08.06T00-00-00.scim-provisioning-status.ts
@@ -1,0 +1,18 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+export default {
+  name: '2026.08.06T00-00-00.scim-provisioning-status.ts',
+  run: ({ psql }) => psql`
+    ALTER TABLE "users"
+      ADD COLUMN "provisioning_status" TEXT NULL
+    ;
+
+    UPDATE
+      "users"
+    SET
+      "provisioning_status" = 'active'
+    WHERE
+      "provisioned_by_organization_id" IS NOT NULL
+    ;
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2026.08.07T00-00-00.scim-pending-confirmation-index.ts
+++ b/packages/migrations/src/actions/2026.08.07T00-00-00.scim-pending-confirmation-index.ts
@@ -7,9 +7,9 @@ export default {
     {
       name: 'users pending SCIM provisioning conflict index',
       query: psql`
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS "users_pending_scim_account_takeover"
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "users_pending_scim_management_confirmation"
         ON "users" ("provisioned_by_organization_id", "id")
-        WHERE "provisioning_status" = 'pendingAdoption'
+        WHERE "provisioning_status" = 'pendingConfirmation'
       `,
     },
   ],

--- a/packages/migrations/src/actions/2026.08.07T00-00-00.scim-pending-takeover-index.ts
+++ b/packages/migrations/src/actions/2026.08.07T00-00-00.scim-pending-takeover-index.ts
@@ -1,0 +1,16 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+export default {
+  name: '2026.08.07T00-00-00.scim-pending-takeover-index.ts',
+  noTransaction: true,
+  run: ({ psql }) => [
+    {
+      name: 'users pending SCIM account takeover index',
+      query: psql`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "users_pending_scim_account_takeover"
+        ON "users" ("provisioned_by_organization_id", "id")
+        WHERE "provisioning_status" = 'pendingAdoption'
+      `,
+    },
+  ],
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2026.08.07T00-00-00.scim-pending-takeover-index.ts
+++ b/packages/migrations/src/actions/2026.08.07T00-00-00.scim-pending-takeover-index.ts
@@ -5,7 +5,7 @@ export default {
   noTransaction: true,
   run: ({ psql }) => [
     {
-      name: 'users pending SCIM account takeover index',
+      name: 'users pending SCIM provisioning conflict index',
       query: psql`
         CREATE INDEX CONCURRENTLY IF NOT EXISTS "users_pending_scim_account_takeover"
         ON "users" ("provisioned_by_organization_id", "id")

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -129,7 +129,6 @@ export const runPGMigrations = async (args: { slonik: PostgresDatabasePool; runT
       import('./actions/2026.06.01T00-00-00.scim-user-indices'),
       import('./actions/2026.06.11T00-00-00.oidc-integration-user-id-claim'),
       import('./actions/2026.08.06T00-00-00.scim-provisioning-status'),
-      import('./actions/2026.08.07T00-00-00.scim-pending-takeover-index'),
-      import('./actions/2026.08.07T01-00-00.scim-pending-confirmation'),
+      import('./actions/2026.08.07T00-00-00.scim-pending-confirmation-index'),
     ]),
   });

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -128,5 +128,6 @@ export const runPGMigrations = async (args: { slonik: PostgresDatabasePool; runT
       import('./actions/2026.06.01T00-00-00.scim-user-group-provisioning'),
       import('./actions/2026.06.01T00-00-00.scim-user-indices'),
       import('./actions/2026.06.11T00-00-00.oidc-integration-user-id-claim'),
+      import('./actions/2026.08.06T00-00-00.scim-provisioning-status'),
     ]),
   });

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -130,5 +130,6 @@ export const runPGMigrations = async (args: { slonik: PostgresDatabasePool; runT
       import('./actions/2026.06.11T00-00-00.oidc-integration-user-id-claim'),
       import('./actions/2026.08.06T00-00-00.scim-provisioning-status'),
       import('./actions/2026.08.07T00-00-00.scim-pending-takeover-index'),
+      import('./actions/2026.08.07T01-00-00.scim-pending-confirmation'),
     ]),
   });

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -129,5 +129,6 @@ export const runPGMigrations = async (args: { slonik: PostgresDatabasePool; runT
       import('./actions/2026.06.01T00-00-00.scim-user-indices'),
       import('./actions/2026.06.11T00-00-00.oidc-integration-user-id-claim'),
       import('./actions/2026.08.06T00-00-00.scim-provisioning-status'),
+      import('./actions/2026.08.07T00-00-00.scim-pending-takeover-index'),
     ]),
   });

--- a/packages/services/api/src/modules/auth/lib/supertokens-strategy.ts
+++ b/packages/services/api/src/modules/auth/lib/supertokens-strategy.ts
@@ -68,7 +68,7 @@ export class SuperTokensCookieBasedSession extends Session {
       organizationId,
     );
 
-    if (user.deactivatedAt !== null) {
+    if (user.provisioningStatus === 'active' && user.deactivatedAt !== null) {
       this.logger.debug('User is deactivated. Resolve no permissions.');
       return [];
     }
@@ -149,7 +149,7 @@ export class SuperTokensCookieBasedSession extends Session {
 
     // If the user is provisioned we use the assigned groups for permissions instead of permissions
     // assigned to the user.
-    if (user.provisionedByOrganizationId) {
+    if (user.provisioningStatus === 'active') {
       const groupPolicyStatements =
         await Groups.getAllAuthorizationPolicyStatementFromGroupMembershipsPolicyStatementsForOrganizationMembership(
           this.logger,

--- a/packages/services/api/src/modules/auth/providers/auth-manager.ts
+++ b/packages/services/api/src/modules/auth/providers/auth-manager.ts
@@ -121,7 +121,7 @@ export class AuthManager {
       throw new AccessError('Action can only be performed by user.');
     }
 
-    if (actor.user.provisionedByOrganizationId !== null) {
+    if (actor.user.provisioningStatus === 'active') {
       return {
         type: 'error' as const,
         error: {

--- a/packages/services/api/src/modules/organization/module.graphql.ts
+++ b/packages/services/api/src/modules/organization/module.graphql.ts
@@ -916,7 +916,7 @@ export default gql`
     """
     searchTerm: String
     """
-    When true, returns only members whose SCIM account takeover is awaiting approval.
+    When true, returns only members whose SCIM provisioning conflict is awaiting approval.
     """
     needsProvisioningTakeoverApproval: Boolean = false
   }
@@ -943,9 +943,9 @@ export default gql`
       filters: MembersFilter
     ): MemberConnection! @tag(name: "public")
     """
-    Whether any SCIM account takeovers are awaiting manual approval.
+    The number of SCIM provisioning conflicts awaiting manual approval.
     """
-    hasPendingProvisioningTakeoverApprovals: Boolean!
+    pendingProvisioningTakeoverApprovalsCount: Int!
     invitations(
       first: Int @tag(name: "public")
       after: String @tag(name: "public")
@@ -1726,14 +1726,14 @@ export default gql`
     """
     organization: OrganizationReferenceInput!
     """
-    The organization member whose pending SCIM account takeover should be confirmed.
+    The organization member whose pending SCIM provisioning conflict should be confirmed.
     """
     member: MemberReferenceInput!
   }
 
   type ConfirmSCIMAccountTakeoverResultOk {
     """
-    The member after the SCIM account takeover has been confirmed.
+    The member after the SCIM provisioning conflict has been confirmed.
     """
     confirmedMember: Member!
   }

--- a/packages/services/api/src/modules/organization/module.graphql.ts
+++ b/packages/services/api/src/modules/organization/module.graphql.ts
@@ -942,6 +942,10 @@ export default gql`
       after: String @tag(name: "public")
       filters: MembersFilter
     ): MemberConnection! @tag(name: "public")
+    """
+    Whether any SCIM account takeovers are awaiting manual approval.
+    """
+    hasPendingProvisioningTakeoverApprovals: Boolean!
     invitations(
       first: Int @tag(name: "public")
       after: String @tag(name: "public")

--- a/packages/services/api/src/modules/organization/module.graphql.ts
+++ b/packages/services/api/src/modules/organization/module.graphql.ts
@@ -1690,25 +1690,52 @@ export default gql`
     message: String!
   }
 
+  """
+  The lifecycle state of a SCIM-provisioned user.
+  """
+  enum ProvisioningStatus {
+    """
+    SCIM provisioning is active. The user's effective access is derived from SCIM group
+    assignments, and deactivation by the identity provider is enforced.
+    """
+    active
+    """
+    SCIM matched an existing account and the adoption is awaiting confirmation. Until confirmed,
+    the user's existing role assignments remain effective and SCIM deactivation is not enforced.
+    """
+    pendingAdoption
+  }
+
+  """
+  SCIM provisioning information for a user.
+  """
   type MemberProvisionInformation {
+    """
+    Whether the identity provider has deactivated the user. Deactivation is enforced only when
+    provisioningStatus is active.
+    """
     isDisabled: Boolean!
     """
-    The external ID of the member on the identity provider.
+    The current lifecycle state of the user's SCIM provisioning.
+    """
+    provisioningStatus: ProvisioningStatus!
+    """
+    The stable identifier assigned to the user by the identity provider.
     """
     externalId: ID!
   }
 
   extend type Member {
     """
-    The groups the member is part of.
+    The SCIM groups to which the member currently belongs.
     """
     groups: [Group!]!
   }
 
   extend type User {
     """
-    Information about the user if provisioned.
-    The fields value is null if the user is not a provisioned user.
+    SCIM provisioning information for the user, or null when the user is not provisioned through
+    SCIM.
     """
     provisionInfo: MemberProvisionInformation
   }

--- a/packages/services/api/src/modules/organization/module.graphql.ts
+++ b/packages/services/api/src/modules/organization/module.graphql.ts
@@ -48,11 +48,11 @@ export default gql`
     assignMemberRole(input: AssignMemberRoleInput! @tag(name: "public")): AssignMemberRoleResult!
       @tag(name: "public")
     """
-    Confirm the takeover of an existing account and activate SCIM-managed authorization for it.
+    Confirm that an existing member should be managed through SCIM.
     """
-    confirmSCIMAccountTakeover(
-      input: ConfirmSCIMAccountTakeoverInput!
-    ): ConfirmSCIMAccountTakeoverResult!
+    confirmSCIMManagementForMember(
+      input: ConfirmSCIMManagementForMemberInput!
+    ): ConfirmSCIMManagementForMemberResult!
     """
     Create a new access token scoped to an organization.
     """
@@ -916,9 +916,9 @@ export default gql`
     """
     searchTerm: String
     """
-    When true, returns only members whose SCIM provisioning conflict is awaiting approval.
+    When true, returns only members awaiting confirmation of SCIM management.
     """
-    needsProvisioningTakeoverApproval: Boolean = false
+    needsSCIMManagementConfirmation: Boolean = false
   }
 
   type Organization {
@@ -943,9 +943,9 @@ export default gql`
       filters: MembersFilter
     ): MemberConnection! @tag(name: "public")
     """
-    The number of SCIM provisioning conflicts awaiting manual approval.
+    The number of members awaiting confirmation of SCIM management.
     """
-    pendingProvisioningTakeoverApprovalsCount: Int!
+    pendingSCIMManagementConfirmationsCount: Int!
     invitations(
       first: Int @tag(name: "public")
       after: String @tag(name: "public")
@@ -1717,10 +1717,10 @@ export default gql`
     SCIM matched an existing account and the adoption is awaiting confirmation. Until confirmed,
     the user's existing role assignments remain effective and SCIM deactivation is not enforced.
     """
-    pendingAdoption
+    pendingConfirmation
   }
 
-  input ConfirmSCIMAccountTakeoverInput {
+  input ConfirmSCIMManagementForMemberInput {
     """
     The organization managing the user through SCIM.
     """
@@ -1731,23 +1731,23 @@ export default gql`
     member: MemberReferenceInput!
   }
 
-  type ConfirmSCIMAccountTakeoverResultOk {
+  type ConfirmSCIMManagementForMemberResultOk {
     """
     The member after the SCIM provisioning conflict has been confirmed.
     """
     confirmedMember: Member!
   }
 
-  type ConfirmSCIMAccountTakeoverResultError {
+  type ConfirmSCIMManagementForMemberResultError {
     message: String!
   }
 
   """
   @oneOf
   """
-  type ConfirmSCIMAccountTakeoverResult {
-    ok: ConfirmSCIMAccountTakeoverResultOk
-    error: ConfirmSCIMAccountTakeoverResultError
+  type ConfirmSCIMManagementForMemberResult {
+    ok: ConfirmSCIMManagementForMemberResultOk
+    error: ConfirmSCIMManagementForMemberResultError
   }
 
   """

--- a/packages/services/api/src/modules/organization/module.graphql.ts
+++ b/packages/services/api/src/modules/organization/module.graphql.ts
@@ -48,6 +48,12 @@ export default gql`
     assignMemberRole(input: AssignMemberRoleInput! @tag(name: "public")): AssignMemberRoleResult!
       @tag(name: "public")
     """
+    Confirm the takeover of an existing account and activate SCIM-managed authorization for it.
+    """
+    confirmSCIMAccountTakeover(
+      input: ConfirmSCIMAccountTakeoverInput!
+    ): ConfirmSCIMAccountTakeoverResult!
+    """
     Create a new access token scoped to an organization.
     """
     createOrganizationAccessToken(
@@ -1704,6 +1710,36 @@ export default gql`
     the user's existing role assignments remain effective and SCIM deactivation is not enforced.
     """
     pendingAdoption
+  }
+
+  input ConfirmSCIMAccountTakeoverInput {
+    """
+    The organization managing the user through SCIM.
+    """
+    organization: OrganizationReferenceInput!
+    """
+    The organization member whose pending SCIM account takeover should be confirmed.
+    """
+    member: MemberReferenceInput!
+  }
+
+  type ConfirmSCIMAccountTakeoverResultOk {
+    """
+    The member after the SCIM account takeover has been confirmed.
+    """
+    confirmedMember: Member!
+  }
+
+  type ConfirmSCIMAccountTakeoverResultError {
+    message: String!
+  }
+
+  """
+  @oneOf
+  """
+  type ConfirmSCIMAccountTakeoverResult {
+    ok: ConfirmSCIMAccountTakeoverResultOk
+    error: ConfirmSCIMAccountTakeoverResultError
   }
 
   """

--- a/packages/services/api/src/modules/organization/module.graphql.ts
+++ b/packages/services/api/src/modules/organization/module.graphql.ts
@@ -915,6 +915,10 @@ export default gql`
     members.
     """
     searchTerm: String
+    """
+    When true, returns only members whose SCIM account takeover is awaiting approval.
+    """
+    needsProvisioningTakeoverApproval: Boolean = false
   }
 
   type Organization {

--- a/packages/services/api/src/modules/organization/providers/organization-access-tokens-cache.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-access-tokens-cache.ts
@@ -86,7 +86,7 @@ export class OrganizationAccessTokensCache {
         accessToken.userId,
       );
 
-      if (provisionedUser?.deactivatedAt) {
+      if (provisionedUser?.provisioningStatus === 'active' && provisionedUser.deactivatedAt) {
         logger.debug('user is disabled');
         return null;
       }
@@ -102,7 +102,7 @@ export class OrganizationAccessTokensCache {
         return null;
       }
 
-      if (provisionedUser) {
+      if (provisionedUser?.provisioningStatus === 'active') {
         const mappings = await Groups.getAllGroupMembershipsWithRoleForOrganizationMembership(
           logger,
           this.pool,

--- a/packages/services/api/src/modules/organization/providers/organization-access-tokens.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-access-tokens.ts
@@ -386,7 +386,7 @@ export class OrganizationAccessTokens {
     let permissions: ReadonlyArray<string> | null = [];
     let assignedResources: ResourceAssignmentGroup;
 
-    if (viewer.provisionedByOrganizationId === null) {
+    if (viewer.provisioningStatus !== 'active') {
       // Handle permission assignment
       //
       // Must be intersection with the members permissions
@@ -1149,11 +1149,11 @@ export class OrganizationAccessTokens {
           accessToken.userId,
         );
 
-        if (provisionedUser?.deactivatedAt) {
+        if (provisionedUser?.provisioningStatus === 'active' && provisionedUser.deactivatedAt) {
           return [];
         }
 
-        if (!provisionedUser) {
+        if (provisionedUser?.provisioningStatus !== 'active') {
           if (
             !membership.assignedRole.role.permissions.organization.has('personalAccessToken:modify')
           ) {

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -1376,6 +1376,16 @@ export class OrganizationManager {
     );
   }
 
+  async hasPendingProvisioningTakeoverApprovals(organizationId: string) {
+    await this.session.assertPerformAction({
+      action: 'member:describe',
+      organizationId,
+      params: { organizationId },
+    });
+
+    return this.organizationMembers.hasPendingProvisioningTakeoverApprovals(organizationId);
+  }
+
   async getViewerMemberRole(selector: {
     organizationId: string;
   }): Promise<OrganizationMemberRole | null> {

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -200,7 +200,7 @@ export class OrganizationManager {
     this.logger.debug('Leaving organization (organization=%s)', organizationId);
     const user = await this.session.getViewer();
 
-    if (user.provisionedByOrganizationId !== null) {
+    if (user.provisioningStatus === 'active') {
       return {
         ok: false,
         message: 'Provisioned users can not leave organizations.',
@@ -324,18 +324,11 @@ export class OrganizationManager {
     return this.storage.getOrganizationOwner(selector);
   }
 
-  async createOrganization(input: {
-    slug: string;
-    user: {
-      id: string;
-      superTokensUserId: string | null;
-      provisionedByOrganizationId: string | null;
-    };
-  }) {
+  async createOrganization(input: { slug: string; user: User }) {
     const { slug, user } = input;
     this.logger.info('Creating an organization (input=%o)', input);
 
-    if (user.provisionedByOrganizationId !== null) {
+    if (user.provisioningStatus === 'active') {
       return {
         ok: false as const,
         message: 'Provisioned users can not create organizations.',
@@ -693,7 +686,7 @@ export class OrganizationManager {
       throw new Error('Only users can join organizations');
     }
 
-    if (actor.user.provisionedByOrganizationId !== null) {
+    if (actor.user.provisioningStatus === 'active') {
       return {
         message: 'Provisioned users can not join any other organization.',
       };
@@ -922,7 +915,7 @@ export class OrganizationManager {
       throw new Error(`Logged user is not a member of the organization`);
     }
 
-    if (member.user.provisionedByOrganizationId !== null) {
+    if (member.user.provisioningStatus === 'active') {
       throw new HiveError('Provisioned users can not be removed from organizations.');
     }
 
@@ -1133,7 +1126,7 @@ export class OrganizationManager {
         },
       };
     }
-    if (user.provisionedByOrganizationId !== null) {
+    if (user.provisioningStatus === 'active') {
       return {
         error: {
           message: 'Provisioned users can not be modified.',

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -1226,7 +1226,7 @@ export class OrganizationManager {
     if (!confirmedUser) {
       return {
         error: {
-          message: 'Pending SCIM account takeover not found.',
+          message: 'Pending SCIM provisioning conflict not found.',
         },
       };
     }
@@ -1240,7 +1240,7 @@ export class OrganizationManager {
     if (!confirmedMember) {
       return {
         error: {
-          message: 'Pending SCIM account takeover not found.',
+          message: 'Pending SCIM provisioning conflict not found.',
         },
       };
     }
@@ -1376,14 +1376,14 @@ export class OrganizationManager {
     );
   }
 
-  async hasPendingProvisioningTakeoverApprovals(organizationId: string) {
+  async getPendingProvisioningTakeoverApprovalsCount(organizationId: string) {
     await this.session.assertPerformAction({
       action: 'member:describe',
       organizationId,
       params: { organizationId },
     });
 
-    return this.organizationMembers.hasPendingProvisioningTakeoverApprovals(organizationId);
+    return this.organizationMembers.getPendingProvisioningTakeoverApprovalsCount(organizationId);
   }
 
   async getViewerMemberRole(selector: {

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -1194,7 +1194,7 @@ export class OrganizationManager {
     };
   }
 
-  async confirmSCIMAccountTakeover(args: {
+  async confirmSCIMManagementForMember(args: {
     organization: GraphQLSchema.OrganizationReferenceInput;
     userId: string;
   }) {
@@ -1211,7 +1211,7 @@ export class OrganizationManager {
       params: { organizationId },
     });
 
-    const confirmedUser = await this.provisionedUsersStore.confirmPendingAccountTakeover(
+    const confirmedUser = await this.provisionedUsersStore.confirmSCIMManagementForMember(
       organizationId,
       args.userId,
     );
@@ -1352,7 +1352,7 @@ export class OrganizationManager {
       first: number | null;
       after: string | null;
       searchTerm: string | null;
-      needsProvisioningTakeoverApproval: boolean | null;
+      needsSCIMManagementConfirmation: boolean | null;
     },
   ) {
     await this.session.assertPerformAction({
@@ -1369,14 +1369,14 @@ export class OrganizationManager {
     );
   }
 
-  async getPendingProvisioningTakeoverApprovalsCount(organizationId: string) {
+  async getPendingSCIMManagementConfirmationsCount(organizationId: string) {
     await this.session.assertPerformAction({
       action: 'member:describe',
       organizationId,
       params: { organizationId },
     });
 
-    return this.organizationMembers.getPendingProvisioningTakeoverApprovalsCount(organizationId);
+    return this.organizationMembers.getPendingSCIMManagementConfirmationsCount(organizationId);
   }
 
   async getViewerMemberRole(selector: {

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -23,6 +23,7 @@ import { CreateOrUpdateMemberRoleModel } from '../validation';
 import { reservedOrganizationSlugs } from './organization-config';
 import { OrganizationMemberRoles, type OrganizationMemberRole } from './organization-member-roles';
 import { OrganizationMembers } from './organization-members';
+import { ProvisionedUsersStore } from './provisioned-users-store';
 import { ResourceAssignments } from './resource-assignments';
 
 /**
@@ -48,6 +49,7 @@ export class OrganizationManager {
     private taskScheduler: TaskScheduler,
     private organizationMemberRoles: OrganizationMemberRoles,
     private organizationMembers: OrganizationMembers,
+    private provisionedUsersStore: ProvisionedUsersStore,
     private resourceAssignments: ResourceAssignments,
     private inMemoryRateLimiter: InMemoryRateLimiter,
     @Inject(WEB_APP_URL) private appBaseUrl: string,
@@ -1196,6 +1198,68 @@ export class OrganizationManager {
 
     return {
       ok: result,
+    };
+  }
+
+  async confirmSCIMAccountTakeover(args: {
+    organization: GraphQLSchema.OrganizationReferenceInput;
+    userId: string;
+  }) {
+    const { organizationId } = await this.idTranslator.resolveOrganizationReference({
+      reference: args.organization,
+      onError: () => {
+        this.session.raise('member:modify');
+      },
+    });
+
+    await this.session.assertPerformAction({
+      action: 'member:modify',
+      organizationId,
+      params: { organizationId },
+    });
+
+    const confirmedUser = await this.provisionedUsersStore.confirmPendingAccountTakeover(
+      organizationId,
+      args.userId,
+    );
+
+    if (!confirmedUser) {
+      return {
+        error: {
+          message: 'Pending SCIM account takeover not found.',
+        },
+      };
+    }
+
+    const organization = await this.storage.getOrganization({ organizationId });
+    const confirmedMember = await this.organizationMembers.findOrganizationMembership({
+      organization,
+      userId: confirmedUser.id,
+    });
+
+    if (!confirmedMember) {
+      return {
+        error: {
+          message: 'Pending SCIM account takeover not found.',
+        },
+      };
+    }
+
+    this.session.reset();
+
+    await this.auditLog.record({
+      eventType: 'SCIM_USER_UPDATED',
+      organizationId,
+      metadata: {
+        userId: confirmedUser.id,
+        updatedFields: 'provisioningStatus',
+      },
+    });
+
+    return {
+      ok: {
+        confirmedMember,
+      },
     };
   }
 

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -1355,7 +1355,12 @@ export class OrganizationManager {
 
   async getPaginatedOrganizationMembersForOrganization(
     organization: Organization,
-    args: { first: number | null; after: string | null; searchTerm: string | null },
+    args: {
+      first: number | null;
+      after: string | null;
+      searchTerm: string | null;
+      needsProvisioningTakeoverApproval: boolean | null;
+    },
   ) {
     await this.session.assertPerformAction({
       action: 'member:describe',

--- a/packages/services/api/src/modules/organization/providers/organization-members.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-members.ts
@@ -244,6 +244,22 @@ export class OrganizationMembers {
     };
   }
 
+  async hasPendingProvisioningTakeoverApprovals(organizationId: string) {
+    const query = psql`
+      SELECT EXISTS (
+        SELECT 1
+        FROM "organization_member" "om"
+        INNER JOIN "users" "u" ON "u"."id" = "om"."user_id"
+        WHERE
+          "om"."organization_id" = ${organizationId}
+          AND "u"."provisioned_by_organization_id" = ${organizationId}
+          AND "u"."provisioning_status" = 'pendingAdoption'
+      )
+    `;
+
+    return this.pool.oneFirst(query).then(z.boolean().parse);
+  }
+
   /**
    * Batched loader function for a organization membership.
    */

--- a/packages/services/api/src/modules/organization/providers/organization-members.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-members.ts
@@ -147,7 +147,12 @@ export class OrganizationMembers {
 
   async getPaginatedOrganizationMembersForOrganization(
     organization: Organization,
-    args: { first: number | null; after: string | null; searchTerm: string | null },
+    args: {
+      first: number | null;
+      after: string | null;
+      searchTerm: string | null;
+      needsProvisioningTakeoverApproval: boolean | null;
+    },
   ) {
     this.logger.debug(
       'Find paginated organization members for organization. (organizationId=%s)',
@@ -165,7 +170,7 @@ export class OrganizationMembers {
       FROM
         "organization_member" AS "om"
       ${
-        searching
+        searching || args.needsProvisioningTakeoverApproval
           ? psql`
             JOIN "users" as "u"
             ON "om"."user_id" = "u"."id"
@@ -188,6 +193,11 @@ export class OrganizationMembers {
             : psql``
         }
         ${searching ? psql`AND "u"."display_name" || ' ' || "u"."email" ILIKE ${'%' + searchTerm + '%'}` : psql``}
+        ${
+          args.needsProvisioningTakeoverApproval
+            ? psql`AND "u"."provisioning_status" = 'pendingAdoption'`
+            : psql``
+        }
       ORDER BY
         "om"."organization_id" DESC
         , "om"."created_at" DESC

--- a/packages/services/api/src/modules/organization/providers/organization-members.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-members.ts
@@ -151,7 +151,7 @@ export class OrganizationMembers {
       first: number | null;
       after: string | null;
       searchTerm: string | null;
-      needsProvisioningTakeoverApproval: boolean | null;
+      needsSCIMManagementConfirmation: boolean | null;
     },
   ) {
     this.logger.debug(
@@ -170,7 +170,7 @@ export class OrganizationMembers {
       FROM
         "organization_member" AS "om"
       ${
-        searching || args.needsProvisioningTakeoverApproval
+        searching || args.needsSCIMManagementConfirmation
           ? psql`
             JOIN "users" as "u"
             ON "om"."user_id" = "u"."id"
@@ -194,8 +194,8 @@ export class OrganizationMembers {
         }
         ${searching ? psql`AND "u"."display_name" || ' ' || "u"."email" ILIKE ${'%' + searchTerm + '%'}` : psql``}
         ${
-          args.needsProvisioningTakeoverApproval
-            ? psql`AND "u"."provisioning_status" = 'pendingAdoption'`
+          args.needsSCIMManagementConfirmation
+            ? psql`AND "u"."provisioning_status" = 'pendingConfirmation'`
             : psql``
         }
       ORDER BY
@@ -244,7 +244,7 @@ export class OrganizationMembers {
     };
   }
 
-  async getPendingProvisioningTakeoverApprovalsCount(organizationId: string) {
+  async getPendingSCIMManagementConfirmationsCount(organizationId: string) {
     const query = psql`
       SELECT COUNT(*)
       FROM "organization_member" "om"
@@ -252,7 +252,7 @@ export class OrganizationMembers {
       WHERE
         "om"."organization_id" = ${organizationId}
         AND "u"."provisioned_by_organization_id" = ${organizationId}
-        AND "u"."provisioning_status" = 'pendingAdoption'
+        AND "u"."provisioning_status" = 'pendingConfirmation'
     `;
 
     return this.pool.oneFirst(query).then(z.number().int().parse);

--- a/packages/services/api/src/modules/organization/providers/organization-members.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-members.ts
@@ -244,20 +244,18 @@ export class OrganizationMembers {
     };
   }
 
-  async hasPendingProvisioningTakeoverApprovals(organizationId: string) {
+  async getPendingProvisioningTakeoverApprovalsCount(organizationId: string) {
     const query = psql`
-      SELECT EXISTS (
-        SELECT 1
-        FROM "organization_member" "om"
-        INNER JOIN "users" "u" ON "u"."id" = "om"."user_id"
-        WHERE
-          "om"."organization_id" = ${organizationId}
-          AND "u"."provisioned_by_organization_id" = ${organizationId}
-          AND "u"."provisioning_status" = 'pendingAdoption'
-      )
+      SELECT COUNT(*)
+      FROM "organization_member" "om"
+      INNER JOIN "users" "u" ON "u"."id" = "om"."user_id"
+      WHERE
+        "om"."organization_id" = ${organizationId}
+        AND "u"."provisioned_by_organization_id" = ${organizationId}
+        AND "u"."provisioning_status" = 'pendingAdoption'
     `;
 
-    return this.pool.oneFirst(query).then(z.boolean().parse);
+    return this.pool.oneFirst(query).then(z.number().int().parse);
   }
 
   /**

--- a/packages/services/api/src/modules/organization/providers/provisioned-users-store.ts
+++ b/packages/services/api/src/modules/organization/providers/provisioned-users-store.ts
@@ -100,6 +100,7 @@ export class ProvisionedUsersStore {
             , "provisioned_by_organization_id"
             , "external_id"
             , "deactivated_at"
+            , "provisioning_status"
           ) VALUES (
             lower(${args.email})
             , ${args.displayName}
@@ -109,6 +110,7 @@ export class ProvisionedUsersStore {
             , ${args.provisionedByOrganizationId}
             , ${args.externalId}
             , ${args.isDisabled ? psql`NOW()` : null}
+            , 'active'
           )
           ON CONFLICT ("supertoken_user_id")
             DO UPDATE
@@ -120,6 +122,7 @@ export class ProvisionedUsersStore {
                 , "provisioned_by_organization_id" = EXCLUDED."provisioned_by_organization_id"
                 , "external_id" = EXCLUDED."external_id"
                 , "deactivated_at" = EXCLUDED."deactivated_at"
+                , "provisioning_status" = 'pendingAdoption'
           RETURNING
             ${userFields}
         `;
@@ -394,6 +397,7 @@ const ProvisionedUserModel = z.object({
   provisionedByOrganizationId: z.string().uuid(),
   externalId: z.string(),
   deactivatedAt: z.string().nullable(),
+  provisioningStatus: z.enum(['pendingAdoption', 'active']),
   supertokenUserId: z.string(),
   createdAt: z.string(),
   lastUpdatedAt: z.string().nullable(),
@@ -409,6 +413,7 @@ const userFields = psql`
   , "provisioned_by_organization_id" AS "provisionedByOrganizationId"
   , "external_id" AS "externalId"
   , to_json("deactivated_at") AS "deactivatedAt"
+  , "provisioning_status" AS "provisioningStatus"
   , "supertoken_user_id" AS "supertokenUserId"
   , to_json("created_at") AS "createdAt"
   , to_json("last_updated_at") AS "lastUpdatedAt"

--- a/packages/services/api/src/modules/organization/providers/provisioned-users-store.ts
+++ b/packages/services/api/src/modules/organization/providers/provisioned-users-store.ts
@@ -353,11 +353,29 @@ export class ProvisionedUsersStore {
     return await this.pool.oneFirst(query).then(z.number().parse);
   }
 
-  async isUserWithIdAdminOfAnyOrganization(userId: string) {
+  /** Find out whether any supertoken identity linked to the identity is allowed to access the organization. */
+  async isIdentityAdminOfOrganization(superTokensUserId: string, organizationId: string) {
     const query = psql`
       SELECT TRUE as "exists"
-      FROM "organizations"
-      WHERE "user_id" = ${userId}
+      FROM "organizations" "o"
+      WHERE
+        "o"."id" = ${organizationId}
+        AND EXISTS (
+          SELECT 1
+          FROM "users" "u"
+          WHERE
+            "u"."id" = "o"."user_id"
+            AND (
+              "u"."supertoken_user_id" = ${superTokensUserId}
+              OR EXISTS (
+                SELECT 1
+                FROM "users_linked_identities" "uli"
+                WHERE
+                  "uli"."user_id" = "u"."id"
+                  AND "uli"."identity_id" = ${superTokensUserId}
+              )
+            )
+          )
       LIMIT 1
     `;
 

--- a/packages/services/api/src/modules/organization/providers/provisioned-users-store.ts
+++ b/packages/services/api/src/modules/organization/providers/provisioned-users-store.ts
@@ -222,6 +222,21 @@ export class ProvisionedUsersStore {
     return await trx.maybeOne(query).then(ProvisionedUserModel.parse);
   }
 
+  async confirmPendingAccountTakeover(organizationId: string, userId: string) {
+    const query = psql`
+      UPDATE "users"
+      SET "provisioning_status" = 'active'
+      WHERE
+        "id" = ${userId}
+        AND "provisioned_by_organization_id" = ${organizationId}
+        AND "provisioning_status" = 'pendingAdoption'
+      RETURNING
+        ${userFields}
+    `;
+
+    return await this.pool.maybeOne(query).then(ProvisionedUserModel.nullable().parse);
+  }
+
   async updateUserEmail(
     organizationId: string,
     userId: string,

--- a/packages/services/api/src/modules/organization/providers/provisioned-users-store.ts
+++ b/packages/services/api/src/modules/organization/providers/provisioned-users-store.ts
@@ -122,7 +122,7 @@ export class ProvisionedUsersStore {
                 , "provisioned_by_organization_id" = EXCLUDED."provisioned_by_organization_id"
                 , "external_id" = EXCLUDED."external_id"
                 , "deactivated_at" = EXCLUDED."deactivated_at"
-                , "provisioning_status" = 'pendingAdoption'
+                , "provisioning_status" = 'pendingConfirmation'
           RETURNING
             ${userFields}
         `;
@@ -222,14 +222,14 @@ export class ProvisionedUsersStore {
     return await trx.maybeOne(query).then(ProvisionedUserModel.parse);
   }
 
-  async confirmPendingAccountTakeover(organizationId: string, userId: string) {
+  async confirmSCIMManagementForMember(organizationId: string, userId: string) {
     const query = psql`
       UPDATE "users"
       SET "provisioning_status" = 'active'
       WHERE
         "id" = ${userId}
         AND "provisioned_by_organization_id" = ${organizationId}
-        AND "provisioning_status" = 'pendingAdoption'
+        AND "provisioning_status" = 'pendingConfirmation'
       RETURNING
         ${userFields}
     `;
@@ -412,7 +412,7 @@ const ProvisionedUserModel = z.object({
   provisionedByOrganizationId: z.string().uuid(),
   externalId: z.string(),
   deactivatedAt: z.string().nullable(),
-  provisioningStatus: z.enum(['pendingAdoption', 'active']),
+  provisioningStatus: z.enum(['pendingConfirmation', 'active']),
   supertokenUserId: z.string(),
   createdAt: z.string(),
   lastUpdatedAt: z.string().nullable(),

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/confirmSCIMAccountTakeover.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/confirmSCIMAccountTakeover.ts
@@ -1,0 +1,11 @@
+import { OrganizationManager } from '../../providers/organization-manager';
+import type { MutationResolvers } from './../../../../__generated__/types';
+
+export const confirmSCIMAccountTakeover: NonNullable<
+  MutationResolvers['confirmSCIMAccountTakeover']
+> = async (_, { input }, { injector }) => {
+  return injector.get(OrganizationManager).confirmSCIMAccountTakeover({
+    organization: input.organization,
+    userId: input.member.byId,
+  });
+};

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/confirmSCIMManagementForMember.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/confirmSCIMManagementForMember.ts
@@ -1,10 +1,10 @@
 import { OrganizationManager } from '../../providers/organization-manager';
 import type { MutationResolvers } from './../../../../__generated__/types';
 
-export const confirmSCIMAccountTakeover: NonNullable<
-  MutationResolvers['confirmSCIMAccountTakeover']
+export const confirmSCIMManagementForMember: NonNullable<
+  MutationResolvers['confirmSCIMManagementForMember']
 > = async (_, { input }, { injector }) => {
-  return injector.get(OrganizationManager).confirmSCIMAccountTakeover({
+  return injector.get(OrganizationManager).confirmSCIMManagementForMember({
     organization: input.organization,
     userId: input.member.byId,
   });

--- a/packages/services/api/src/modules/organization/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Organization.ts
@@ -67,6 +67,7 @@ export const Organization: Pick<
         first: args.first ?? null,
         after: args.after ?? null,
         searchTerm: args.filters?.searchTerm ?? null,
+        needsProvisioningTakeoverApproval: args.filters?.needsProvisioningTakeoverApproval ?? null,
       });
   },
   invitations: async (organization, args, { injector }) => {

--- a/packages/services/api/src/modules/organization/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Organization.ts
@@ -20,7 +20,6 @@ export const Organization: Pick<
   | 'getStarted'
   | 'group'
   | 'groups'
-  | 'hasPendingProvisioningTakeoverApprovals'
   | 'id'
   | 'invitations'
   | 'me'
@@ -28,6 +27,7 @@ export const Organization: Pick<
   | 'members'
   | 'name'
   | 'owner'
+  | 'pendingProvisioningTakeoverApprovalsCount'
   | 'projectForResourceSelector'
   | 'projectsForResourceSelector'
   | 'slug'
@@ -71,10 +71,10 @@ export const Organization: Pick<
         needsProvisioningTakeoverApproval: args.filters?.needsProvisioningTakeoverApproval ?? null,
       });
   },
-  hasPendingProvisioningTakeoverApprovals: (organization, _args, { injector }) => {
+  pendingProvisioningTakeoverApprovalsCount: (organization, _args, { injector }) => {
     return injector
       .get(OrganizationManager)
-      .hasPendingProvisioningTakeoverApprovals(organization.id);
+      .getPendingProvisioningTakeoverApprovalsCount(organization.id);
   },
   invitations: async (organization, args, { injector }) => {
     const invitations = await injector.get(OrganizationManager).getInvitations(organization, {

--- a/packages/services/api/src/modules/organization/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Organization.ts
@@ -20,6 +20,7 @@ export const Organization: Pick<
   | 'getStarted'
   | 'group'
   | 'groups'
+  | 'hasPendingProvisioningTakeoverApprovals'
   | 'id'
   | 'invitations'
   | 'me'
@@ -69,6 +70,11 @@ export const Organization: Pick<
         searchTerm: args.filters?.searchTerm ?? null,
         needsProvisioningTakeoverApproval: args.filters?.needsProvisioningTakeoverApproval ?? null,
       });
+  },
+  hasPendingProvisioningTakeoverApprovals: (organization, _args, { injector }) => {
+    return injector
+      .get(OrganizationManager)
+      .hasPendingProvisioningTakeoverApprovals(organization.id);
   },
   invitations: async (organization, args, { injector }) => {
     const invitations = await injector.get(OrganizationManager).getInvitations(organization, {

--- a/packages/services/api/src/modules/organization/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Organization.ts
@@ -27,7 +27,7 @@ export const Organization: Pick<
   | 'members'
   | 'name'
   | 'owner'
-  | 'pendingProvisioningTakeoverApprovalsCount'
+  | 'pendingSCIMManagementConfirmationsCount'
   | 'projectForResourceSelector'
   | 'projectsForResourceSelector'
   | 'slug'
@@ -68,13 +68,13 @@ export const Organization: Pick<
         first: args.first ?? null,
         after: args.after ?? null,
         searchTerm: args.filters?.searchTerm ?? null,
-        needsProvisioningTakeoverApproval: args.filters?.needsProvisioningTakeoverApproval ?? null,
+        needsSCIMManagementConfirmation: args.filters?.needsSCIMManagementConfirmation ?? null,
       });
   },
-  pendingProvisioningTakeoverApprovalsCount: (organization, _args, { injector }) => {
+  pendingSCIMManagementConfirmationsCount: (organization, _args, { injector }) => {
     return injector
       .get(OrganizationManager)
-      .getPendingProvisioningTakeoverApprovalsCount(organization.id);
+      .getPendingSCIMManagementConfirmationsCount(organization.id);
   },
   invitations: async (organization, args, { injector }) => {
     const invitations = await injector.get(OrganizationManager).getInvitations(organization, {

--- a/packages/services/api/src/modules/organization/resolvers/User.ts
+++ b/packages/services/api/src/modules/organization/resolvers/User.ts
@@ -9,6 +9,7 @@ export const User: Pick<UserResolvers, 'provisionInfo'> = {
     return {
       isDisabled: user.deactivatedAt !== null,
       externalId: user.externalId,
+      provisioningStatus: user.provisioningStatus,
     };
   },
 };

--- a/packages/services/server/src/supertokens-at-home.ts
+++ b/packages/services/server/src/supertokens-at-home.ts
@@ -101,25 +101,24 @@ export async function registerSupertokensAtHome(
       };
     }
 
-    if (user) {
-      const hiveUser = await storage.getUserBySuperTokenId({ superTokensUserId: user.userId });
+    if (!user) {
+      return {
+        type: 'error' as const,
+      };
+    }
 
-      if (hiveUser) {
-        const usersStore = new ProvisionedUsersStore(storage.pool);
-        const isUserAdminOfAnyOrganization = await usersStore.isUserWithIdAdminOfAnyOrganization(
-          hiveUser.id,
-        );
+    const isUserAdminOfOrganization = await new ProvisionedUsersStore(
+      storage.pool,
+    ).isIdentityAdminOfOrganization(user.userId, oidcIntegration.linkedOrganizationId);
 
-        if (isUserAdminOfAnyOrganization) {
-          return {
-            type: 'success' as const,
-          };
-        }
-      }
+    if (!isUserAdminOfOrganization) {
+      return {
+        type: 'error' as const,
+      };
     }
 
     return {
-      type: 'error' as const,
+      type: 'success' as const,
     };
   }
 

--- a/packages/services/server/src/supertokens-at-home.ts
+++ b/packages/services/server/src/supertokens-at-home.ts
@@ -1677,7 +1677,7 @@ export async function registerSupertokensAtHome(
         });
 
         if (organization.featureFlags.scim) {
-          if (maybeHiveUser?.deactivatedAt) {
+          if (maybeHiveUser?.provisioningStatus === 'active' && maybeHiveUser.deactivatedAt) {
             req.log.debug('user is deactivated.');
             return rep.status(200).send({
               status: 'SIGN_IN_UP_NOT_ALLOWED',

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -610,6 +610,7 @@ export interface users {
   last_updated_at: Date | null;
   oidc_integration_id: string | null;
   provisioned_by_organization_id: string | null;
+  provisioning_status: string | null;
   supertoken_user_id: string | null;
   zendesk_user_id: string | null;
 }

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -4694,7 +4694,7 @@ const MemberModel = z
     ),
     deactivatedAt: z.string().nullable(),
     provisionedByOrganizationId: z.string().nullable(),
-    provisioningStatus: z.enum(['pendingAdoption', 'active']).nullable(),
+    provisioningStatus: z.enum(['pendingConfirmation', 'active']).nullable(),
     externalId: z.string().nullable(),
   })
   .transform(row => ({
@@ -4825,7 +4825,7 @@ const UserBase = z.object({
 export const UserModel = z.union([
   UserBase.extend({
     provisionedByOrganizationId: z.string().uuid(),
-    provisioningStatus: z.enum(['pendingAdoption', 'active']),
+    provisioningStatus: z.enum(['pendingConfirmation', 'active']),
     externalId: z.string(),
   }),
   UserBase.extend({

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -320,7 +320,7 @@ export async function createStorage(
             )
             .then(UserModel.nullable().parse);
 
-          if (internalUser && internalUser.provisionedByOrganizationId !== null) {
+          if (internalUser && internalUser.provisioningStatus === 'active') {
             return {
               ok: true,
               user: internalUser,

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -4395,6 +4395,7 @@ export const userFields = (user: TaggedTemplateLiteralInvocation) => psql`
   , ${user}"oidc_integration_id" AS "oidcIntegrationId"
   , ${user}"zendesk_user_id" AS "zendeskId"
   , ${user}"provisioned_by_organization_id" AS "provisionedByOrganizationId"
+  , ${user}"provisioning_status" AS "provisioningStatus"
   , ${user}"external_id" AS "externalId"
   , to_json(${user}"deactivated_at") AS "deactivatedAt"
   , (
@@ -4693,6 +4694,7 @@ const MemberModel = z
     ),
     deactivatedAt: z.string().nullable(),
     provisionedByOrganizationId: z.string().nullable(),
+    provisioningStatus: z.enum(['pendingAdoption', 'active']).nullable(),
     externalId: z.string().nullable(),
   })
   .transform(row => ({
@@ -4823,10 +4825,12 @@ const UserBase = z.object({
 export const UserModel = z.union([
   UserBase.extend({
     provisionedByOrganizationId: z.string().uuid(),
+    provisioningStatus: z.enum(['pendingAdoption', 'active']),
     externalId: z.string(),
   }),
   UserBase.extend({
     provisionedByOrganizationId: z.null(),
+    provisioningStatus: z.null(),
     externalId: z.string().nullable(),
   }),
 ]);

--- a/packages/web/app/src/components/organization/members/list.tsx
+++ b/packages/web/app/src/components/organization/members/list.tsx
@@ -154,11 +154,11 @@ const OrganizationMemberRow_DeleteMember = graphql(`
   }
 `);
 
-const OrganizationMemberRow_ConfirmSCIMAccountTakeover = graphql(`
-  mutation OrganizationMemberRow_ConfirmSCIMAccountTakeover(
-    $input: ConfirmSCIMAccountTakeoverInput!
+const OrganizationMemberRow_ConfirmSCIMManagementForMember = graphql(`
+  mutation OrganizationMemberRow_ConfirmSCIMManagementForMember(
+    $input: ConfirmSCIMManagementForMemberInput!
   ) {
-    confirmSCIMAccountTakeover(input: $input) {
+    confirmSCIMManagementForMember(input: $input) {
       ok {
         confirmedMember {
           id
@@ -211,8 +211,8 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
   const { toast } = useToast();
   const [open, setOpen] = useState(false);
   const [deleteMemberState, deleteMember] = useMutation(OrganizationMemberRow_DeleteMember);
-  const [confirmTakeoverState, confirmTakeover] = useMutation(
-    OrganizationMemberRow_ConfirmSCIMAccountTakeover,
+  const [confirmManagementState, confirmManagement] = useMutation(
+    OrganizationMemberRow_ConfirmSCIMManagementForMember,
   );
   return (
     <>
@@ -377,7 +377,7 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
             <>
               {member.viewerCanRemove &&
                 member.user.provisionInfo?.provisioningStatus ===
-                  GraphQLSchema.ProvisioningStatus.PendingAdoption && (
+                  GraphQLSchema.ProvisioningStatus.PendingConfirmation && (
                   <AlertDialog>
                     <AlertDialogTrigger asChild>
                       <Button type="button" size="xs" variant="orangeLink" className="mr-2">
@@ -414,17 +414,17 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
                         </div>
                       </AlertDialogHeader>
                       <AlertDialogFooter>
-                        <AlertDialogCancel disabled={confirmTakeoverState.fetching}>
+                        <AlertDialogCancel disabled={confirmManagementState.fetching}>
                           Cancel
                         </AlertDialogCancel>
                         <AlertDialogAction
                           variant="destructive"
-                          disabled={confirmTakeoverState.fetching}
+                          disabled={confirmManagementState.fetching}
                           onClick={async event => {
                             event.preventDefault();
 
                             try {
-                              const result = await confirmTakeover({
+                              const result = await confirmManagement({
                                 input: {
                                   organization: { byId: organization.id },
                                   member: { byId: member.user.id },
@@ -437,13 +437,14 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
                                   title: 'Could not enable SCIM management',
                                   description: result.error.message,
                                 });
-                              } else if (result.data?.confirmSCIMAccountTakeover.error) {
+                              } else if (result.data?.confirmSCIMManagementForMember.error) {
                                 toast({
                                   variant: 'destructive',
                                   title: 'Could not enable SCIM management',
-                                  description: result.data.confirmSCIMAccountTakeover.error.message,
+                                  description:
+                                    result.data.confirmSCIMManagementForMember.error.message,
                                 });
-                              } else if (result.data?.confirmSCIMAccountTakeover.ok) {
+                              } else if (result.data?.confirmSCIMManagementForMember.ok) {
                                 toast({
                                   title: 'SCIM management enabled',
                                   description: `${member.user.email} is now managed through SCIM.`,
@@ -460,7 +461,9 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
                             }
                           }}
                         >
-                          {confirmTakeoverState.fetching ? 'Applying...' : 'Allow SCIM management'}
+                          {confirmManagementState.fetching
+                            ? 'Applying...'
+                            : 'Allow SCIM management'}
                         </AlertDialogAction>
                       </AlertDialogFooter>
                     </AlertDialogContent>
@@ -586,7 +589,7 @@ const OrganizationMembers_OrganizationFragment = graphql(`
       after: $after
       filters: {
         searchTerm: $searchTerm
-        needsProvisioningTakeoverApproval: $needsProvisioningTakeoverApproval
+        needsSCIMManagementConfirmation: $needsSCIMManagementConfirmation
       }
     ) {
       edges {
@@ -677,7 +680,7 @@ export function OrganizationMembers(props: {
           )}
         </div>
       </SubPageLayoutHeader>
-      {search.showProvisioningConflicts && (
+      {search.showPendingSCIMManagementConfirmations && (
         <Callout type="warning">
           Showing members with unresolved SCIM provisioning conflicts.{' '}
           <Link
@@ -704,7 +707,7 @@ export function OrganizationMembers(props: {
           </thead>
           <tbody className="divide-neutral-10/20 divide-y">
             {members.length === 0 ? (
-              search.showProvisioningConflicts ? (
+              search.showPendingSCIMManagementConfirmations ? (
                 <tr>
                   <td colSpan={4} className="py-16">
                     <div className="flex flex-col items-center justify-center px-4">
@@ -712,7 +715,7 @@ export function OrganizationMembers(props: {
                         No members with provisioning conflict found
                       </h3>
 
-                      {search.showProvisioningConflicts && (
+                      {search.showPendingSCIMManagementConfirmations && (
                         <Link
                           to="/$organizationSlug/view/members"
                           search={{ page: 'list' }}

--- a/packages/web/app/src/components/organization/members/list.tsx
+++ b/packages/web/app/src/components/organization/members/list.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useState } from 'react';
 import {
+  AlertCircle,
   ChevronLeftIcon,
   ChevronRightIcon,
   MoreHorizontalIcon,
@@ -24,14 +25,17 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
+import { Callout } from '@/components/ui/callout';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { KeyIcon } from '@/components/ui/icon';
 import { Input } from '@/components/ui/input';
 import { SubPageLayout, SubPageLayoutHeader } from '@/components/ui/page-content-layout';
 import * as Sheet from '@/components/ui/sheet';
@@ -41,6 +45,7 @@ import { FragmentType, graphql, useFragment } from '@/gql';
 import * as GraphQLSchema from '@/gql/graphql';
 import { useSearchParamsFilter } from '@/lib/hooks/use-search-params-filters';
 import { cn } from '@/lib/utils';
+import { Link } from '@tanstack/react-router';
 import { organizationMembersRoute } from '../../../router';
 import { MemberInvitationButton } from './invitations';
 import { MemberRolePicker } from './member-role-picker';
@@ -63,7 +68,7 @@ function MemberGroups(props: { groups: Array<FragmentType<typeof MemberGroups_Gr
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger>
-            <div className="flex items-center justify-end gap-1.5">
+            <div className="flex w-fit items-center gap-1.5">
               <UsersIcon className="h-3.5 w-3.5" />
               <span className="text-xs">Groups: none</span>
             </div>
@@ -78,7 +83,7 @@ function MemberGroups(props: { groups: Array<FragmentType<typeof MemberGroups_Gr
 
   return (
     <TooltipProvider>
-      <div className="flex items-center justify-end gap-2">
+      <div className="flex w-fit items-center gap-2">
         <div className="flex items-center gap-1.5">
           <UsersIcon className="h-3.5 w-3.5" />
           <span className="text-xs">Groups:</span>
@@ -86,16 +91,9 @@ function MemberGroups(props: { groups: Array<FragmentType<typeof MemberGroups_Gr
 
         <div className="flex flex-wrap items-center gap-1.5">
           {visibleGroups.map(group => (
-            <Tooltip key={group.id}>
-              <TooltipTrigger asChild>
-                <Badge className="cursor-default text-xs">{group.name}</Badge>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>
-                  <span className="font-medium">{group.name}</span>
-                </p>
-              </TooltipContent>
-            </Tooltip>
+            <Badge className="cursor-default text-xs" key={group.id}>
+              {group.name}
+            </Badge>
           ))}
           {remainingCount > 0 && (
             <Tooltip>
@@ -156,6 +154,23 @@ const OrganizationMemberRow_DeleteMember = graphql(`
   }
 `);
 
+const OrganizationMemberRow_ConfirmSCIMAccountTakeover = graphql(`
+  mutation OrganizationMemberRow_ConfirmSCIMAccountTakeover(
+    $input: ConfirmSCIMAccountTakeoverInput!
+  ) {
+    confirmSCIMAccountTakeover(input: $input) {
+      ok {
+        confirmedMember {
+          id
+        }
+      }
+      error {
+        message
+      }
+    }
+  }
+`);
+
 const OrganizationMemberRow_MemberFragment = graphql(`
   fragment OrganizationMemberRow_MemberFragment on Member {
     id
@@ -166,6 +181,7 @@ const OrganizationMemberRow_MemberFragment = graphql(`
       provisionInfo {
         isDisabled
         externalId
+        provisioningStatus
       }
     }
     authProviders {
@@ -194,7 +210,11 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
   const member = useFragment(OrganizationMemberRow_MemberFragment, props.member);
   const { toast } = useToast();
   const [open, setOpen] = useState(false);
+  const [takeoverOpen, setTakeoverOpen] = useState(false);
   const [deleteMemberState, deleteMember] = useMutation(OrganizationMemberRow_DeleteMember);
+  const [confirmTakeoverState, confirmTakeover] = useMutation(
+    OrganizationMemberRow_ConfirmSCIMAccountTakeover,
+  );
   return (
     <>
       <AlertDialog open={open} onOpenChange={setOpen}>
@@ -325,7 +345,7 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
           </div>
           <h4 className="text-neutral-10 text-xs">{member.user.email}</h4>
         </td>
-        <td className="w-full py-3 text-right text-sm">
+        <td className="w-full py-3 text-right text-sm" align="right">
           {member.isOwner ? (
             <TooltipProvider>
               <Tooltip>
@@ -349,7 +369,9 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
                 </Tooltip>
               </TooltipProvider>
             ) : (
-              <MemberGroups groups={member.groups ?? []} />
+              <div className="ml-auto mr-0 w-fit">
+                <MemberGroups groups={member.groups ?? []} />
+              </div>
             )
           ) : (
             <MemberRole member={member} organization={organization} />
@@ -358,16 +380,102 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
         <td className="py-3 pr-2 text-right text-sm">
           {member.viewerCanRemove &&
             (member.user.provisionInfo ? (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <ShieldCheck size={16} className="text-neutral-8 ml-2 mt-1.5" />
-                  </TooltipTrigger>
-                  <TooltipContent className="text-xs">
-                    Provisioned users can only be updated via the SCIM endpoints.
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              member.user.provisionInfo.provisioningStatus ===
+              GraphQLSchema.ProvisioningStatus.PendingAdoption ? (
+                <AlertDialog open={takeoverOpen} onOpenChange={setTakeoverOpen}>
+                  <AlertDialogTrigger>
+                    <AlertCircle size={16} className="ml-2 mt-1.5 text-yellow-500" />
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Transfer User to be managed via SCIM</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This user existed in your organization before your identity provider
+                        attempted to provision it via SCIM.
+                      </AlertDialogDescription>
+                      <AlertDialogDescription>
+                        Before transfering the user to be managed via SCIM, ensure that users group
+                        membership and status is as desired to avoid an accidential lockout.
+                      </AlertDialogDescription>
+                      <div className="mt-4 space-y-2">
+                        <div className="text-sm">SCIM State</div>
+                        <div className="flex w-fit items-center gap-2">
+                          <div className="flex items-center gap-1.5">
+                            <KeyIcon className="h-3.5 w-3.5" />
+                            <span className="text-xs">
+                              Account Status:{' '}
+                              {member.user.provisionInfo.isDisabled ? 'disabled' : 'active'}
+                            </span>
+                          </div>
+                        </div>
+                        <MemberGroups groups={member.groups ?? []} />
+                      </div>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel disabled={confirmTakeoverState.fetching}>
+                        Cancel
+                      </AlertDialogCancel>
+                      <AlertDialogAction
+                        variant="destructive"
+                        disabled={confirmTakeoverState.fetching}
+                        onClick={async event => {
+                          event.preventDefault();
+
+                          try {
+                            const result = await confirmTakeover({
+                              input: {
+                                organization: { byId: organization.id },
+                                member: { byId: member.user.id },
+                              },
+                            });
+
+                            if (result.error) {
+                              toast({
+                                variant: 'destructive',
+                                title: 'Failed to confirm SCIM account takeover',
+                                description: result.error.message,
+                              });
+                            } else if (result.data?.confirmSCIMAccountTakeover.error) {
+                              toast({
+                                variant: 'destructive',
+                                title: 'Failed to confirm SCIM account takeover',
+                                description: result.data.confirmSCIMAccountTakeover.error.message,
+                              });
+                            } else if (result.data?.confirmSCIMAccountTakeover.ok) {
+                              toast({
+                                title: 'SCIM account takeover confirmed',
+                                description: `${member.user.email} is now managed via SCIM.`,
+                              });
+                              setTakeoverOpen(false);
+                              props.refetchMembers({ requestPolicy: 'network-only' });
+                            }
+                          } catch (error) {
+                            console.error(error);
+                            toast({
+                              variant: 'destructive',
+                              title: 'Failed to confirm SCIM account takeover',
+                              description: error instanceof Error ? error.message : String(error),
+                            });
+                          }
+                        }}
+                      >
+                        {confirmTakeoverState.fetching ? 'Confirming...' : 'Confirm'}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              ) : (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <ShieldCheck size={16} className="text-neutral-8 ml-2 mt-1.5" />
+                    </TooltipTrigger>
+                    <TooltipContent className="text-xs">
+                      Provisioned users can only be updated via the SCIM endpoints.
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )
             ) : (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -463,7 +571,14 @@ const OrganizationMembers_OrganizationFragment = graphql(`
     owner {
       id
     }
-    members(first: $first, after: $after, filters: { searchTerm: $searchTerm }) {
+    members(
+      first: $first
+      after: $after
+      filters: {
+        searchTerm: $searchTerm
+        needsProvisioningTakeoverApproval: $needsProvisioningTakeoverApproval
+      }
+    ) {
       edges {
         node {
           id
@@ -552,6 +667,19 @@ export function OrganizationMembers(props: {
           )}
         </div>
       </SubPageLayoutHeader>
+      {search.showProvisioningConflicts && (
+        <Callout type="warning">
+          Showing only members with provisioning conflicts.{' '}
+          <Link
+            to="/$organizationSlug/view/members"
+            search={{ page: 'list' }}
+            params={{ organizationSlug: organization.slug }}
+            className="text-neutral-1 hover:text-neutral-8"
+          >
+            Show all members
+          </Link>
+        </Callout>
+      )}
       <div className="mt-4 overflow-hidden rounded-lg border">
         <table className="divide-neutral-10/20 w-full table-auto divide-y">
           <thead className="bg-neutral-3 border-b px-4 py-3 text-sm font-medium">
@@ -566,17 +694,42 @@ export function OrganizationMembers(props: {
           </thead>
           <tbody className="divide-neutral-10/20 divide-y">
             {members.length === 0 ? (
-              <tr>
-                <td colSpan={4} className="py-16">
-                  <div className="flex flex-col items-center justify-center px-4">
-                    <h3 className="text-neutral-11 mb-2 text-lg font-semibold">No members found</h3>
+              search.showProvisioningConflicts ? (
+                <tr>
+                  <td colSpan={4} className="py-16">
+                    <div className="flex flex-col items-center justify-center px-4">
+                      <h3 className="text-neutral-11 mb-2 text-lg font-semibold">
+                        No members with provisioning conflict found
+                      </h3>
 
-                    <p className="text-neutral-10 max-w-sm text-center text-sm">
-                      {`No results for "${searchValue}". Try adjusting your search term.`}
-                    </p>
-                  </div>
-                </td>
-              </tr>
+                      {search.showProvisioningConflicts && (
+                        <Link
+                          to="/$organizationSlug/view/members"
+                          search={{ page: 'list' }}
+                          params={{ organizationSlug: organization.slug }}
+                          className="text-accent hover:text-accent/80 inline-flex items-center gap-1"
+                        >
+                          Show all members
+                        </Link>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                <tr>
+                  <td colSpan={4} className="py-16">
+                    <div className="flex flex-col items-center justify-center px-4">
+                      <h3 className="text-neutral-11 mb-2 text-lg font-semibold">
+                        No members found
+                      </h3>
+
+                      <p className="text-neutral-10 max-w-sm text-center text-sm">
+                        {`No results for "${searchValue}". Try adjusting your search term.`}
+                      </p>
+                    </div>
+                  </td>
+                </tr>
+              )
             ) : (
               members.map(node => (
                 <OrganizationMemberRow

--- a/packages/web/app/src/components/organization/members/list.tsx
+++ b/packages/web/app/src/components/organization/members/list.tsx
@@ -358,7 +358,8 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-          ) : member.user.provisionInfo ? (
+          ) : member.user.provisionInfo?.provisioningStatus ===
+            GraphQLSchema.ProvisioningStatus.Active ? (
             member.user.provisionInfo.isDisabled ? (
               <TooltipProvider>
                 <Tooltip>
@@ -383,28 +384,32 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
               member.user.provisionInfo.provisioningStatus ===
               GraphQLSchema.ProvisioningStatus.PendingAdoption ? (
                 <AlertDialog open={takeoverOpen} onOpenChange={setTakeoverOpen}>
-                  <AlertDialogTrigger>
+                  <AlertDialogTrigger title="Review SCIM provisioning conflict">
                     <AlertCircle size={16} className="ml-2 mt-1.5 text-yellow-500" />
+                    <span className="sr-only">Review SCIM provisioning conflict</span>
                   </AlertDialogTrigger>
                   <AlertDialogContent>
                     <AlertDialogHeader>
-                      <AlertDialogTitle>Transfer User to be managed via SCIM</AlertDialogTitle>
+                      <AlertDialogTitle>
+                        Allow SCIM to manage {member.user.displayName}?
+                      </AlertDialogTitle>
                       <AlertDialogDescription>
-                        This user existed in your organization before your identity provider
-                        attempted to provision it via SCIM.
+                        SCIM matched <strong>{member.user.email}</strong> to an existing
+                        organization member.
                       </AlertDialogDescription>
                       <AlertDialogDescription>
-                        Before transfering the user to be managed via SCIM, ensure that users group
-                        membership and status is as desired to avoid an accidential lockout.
+                        After confirmation, your identity provider will control this user's status
+                        and group-based access. Review the pending SCIM values below to avoid
+                        removing access unintentionally.
                       </AlertDialogDescription>
                       <div className="mt-4 space-y-2">
-                        <div className="text-sm">SCIM State</div>
+                        <div className="text-sm">Pending SCIM values</div>
                         <div className="flex w-fit items-center gap-2">
                           <div className="flex items-center gap-1.5">
                             <KeyIcon className="h-3.5 w-3.5" />
                             <span className="text-xs">
-                              Account Status:{' '}
-                              {member.user.provisionInfo.isDisabled ? 'disabled' : 'active'}
+                              User status:{' '}
+                              {member.user.provisionInfo.isDisabled ? 'Disabled' : 'Active'}
                             </span>
                           </div>
                         </div>
@@ -432,19 +437,19 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
                             if (result.error) {
                               toast({
                                 variant: 'destructive',
-                                title: 'Failed to confirm SCIM account takeover',
+                                title: 'Could not enable SCIM management',
                                 description: result.error.message,
                               });
                             } else if (result.data?.confirmSCIMAccountTakeover.error) {
                               toast({
                                 variant: 'destructive',
-                                title: 'Failed to confirm SCIM account takeover',
+                                title: 'Could not enable SCIM management',
                                 description: result.data.confirmSCIMAccountTakeover.error.message,
                               });
                             } else if (result.data?.confirmSCIMAccountTakeover.ok) {
                               toast({
-                                title: 'SCIM account takeover confirmed',
-                                description: `${member.user.email} is now managed via SCIM.`,
+                                title: 'SCIM management enabled',
+                                description: `${member.user.email} is now managed through SCIM.`,
                               });
                               setTakeoverOpen(false);
                               props.refetchMembers({ requestPolicy: 'network-only' });
@@ -453,13 +458,13 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
                             console.error(error);
                             toast({
                               variant: 'destructive',
-                              title: 'Failed to confirm SCIM account takeover',
+                              title: 'Could not enable SCIM management',
                               description: error instanceof Error ? error.message : String(error),
                             });
                           }
                         }}
                       >
-                        {confirmTakeoverState.fetching ? 'Confirming...' : 'Confirm'}
+                        {confirmTakeoverState.fetching ? 'Applying...' : 'Allow SCIM management'}
                       </AlertDialogAction>
                     </AlertDialogFooter>
                   </AlertDialogContent>
@@ -669,7 +674,7 @@ export function OrganizationMembers(props: {
       </SubPageLayoutHeader>
       {search.showProvisioningConflicts && (
         <Callout type="warning">
-          Showing only members with provisioning conflicts.{' '}
+          Showing members with unresolved SCIM provisioning conflicts.{' '}
           <Link
             to="/$organizationSlug/view/members"
             search={{ page: 'list' }}

--- a/packages/web/app/src/components/organization/members/list.tsx
+++ b/packages/web/app/src/components/organization/members/list.tsx
@@ -1,10 +1,10 @@
 import { memo, useEffect, useState } from 'react';
 import {
-  AlertCircle,
   ChevronLeftIcon,
   ChevronRightIcon,
   MoreHorizontalIcon,
   ShieldCheck,
+  TriangleAlert,
   UserLock,
   UserRound,
   UserRoundX,
@@ -210,7 +210,6 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
   const member = useFragment(OrganizationMemberRow_MemberFragment, props.member);
   const { toast } = useToast();
   const [open, setOpen] = useState(false);
-  const [takeoverOpen, setTakeoverOpen] = useState(false);
   const [deleteMemberState, deleteMember] = useMutation(OrganizationMemberRow_DeleteMember);
   const [confirmTakeoverState, confirmTakeover] = useMutation(
     OrganizationMemberRow_ConfirmSCIMAccountTakeover,
@@ -375,127 +374,133 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
               </div>
             )
           ) : (
-            <MemberRole member={member} organization={organization} />
+            <>
+              {member.viewerCanRemove &&
+                member.user.provisionInfo?.provisioningStatus ===
+                  GraphQLSchema.ProvisioningStatus.PendingAdoption && (
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button type="button" size="xs" variant="orangeLink" className="mr-2">
+                        <TriangleAlert className="mr-1 size-3" />
+                        SCIM matched this existing account
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>
+                          Allow SCIM to manage {member.user.displayName}?
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                          SCIM matched <strong>{member.user.email}</strong> to an existing
+                          organization member.
+                        </AlertDialogDescription>
+                        <AlertDialogDescription>
+                          After confirmation, your identity provider will control this user's status
+                          and group-based access. Review the pending SCIM values below to avoid
+                          removing access unintentionally.
+                        </AlertDialogDescription>
+                        <div className="mt-4 space-y-2">
+                          <div className="text-sm">Pending SCIM values</div>
+                          <div className="flex w-fit items-center gap-2">
+                            <div className="flex items-center gap-1.5">
+                              <KeyIcon className="h-3.5 w-3.5" />
+                              <span className="text-xs">
+                                User status:{' '}
+                                {member.user.provisionInfo.isDisabled ? 'Disabled' : 'Active'}
+                              </span>
+                            </div>
+                          </div>
+                          <MemberGroups groups={member.groups ?? []} />
+                        </div>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel disabled={confirmTakeoverState.fetching}>
+                          Cancel
+                        </AlertDialogCancel>
+                        <AlertDialogAction
+                          variant="destructive"
+                          disabled={confirmTakeoverState.fetching}
+                          onClick={async event => {
+                            event.preventDefault();
+
+                            try {
+                              const result = await confirmTakeover({
+                                input: {
+                                  organization: { byId: organization.id },
+                                  member: { byId: member.user.id },
+                                },
+                              });
+
+                              if (result.error) {
+                                toast({
+                                  variant: 'destructive',
+                                  title: 'Could not enable SCIM management',
+                                  description: result.error.message,
+                                });
+                              } else if (result.data?.confirmSCIMAccountTakeover.error) {
+                                toast({
+                                  variant: 'destructive',
+                                  title: 'Could not enable SCIM management',
+                                  description: result.data.confirmSCIMAccountTakeover.error.message,
+                                });
+                              } else if (result.data?.confirmSCIMAccountTakeover.ok) {
+                                toast({
+                                  title: 'SCIM management enabled',
+                                  description: `${member.user.email} is now managed through SCIM.`,
+                                });
+                                props.refetchMembers({ requestPolicy: 'network-only' });
+                              }
+                            } catch (error) {
+                              console.error(error);
+                              toast({
+                                variant: 'destructive',
+                                title: 'Could not enable SCIM management',
+                                description: error instanceof Error ? error.message : String(error),
+                              });
+                            }
+                          }}
+                        >
+                          {confirmTakeoverState.fetching ? 'Applying...' : 'Allow SCIM management'}
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                )}
+              <MemberRole member={member} organization={organization} />
+            </>
           )}
         </td>
-        <td className="py-3 pr-2 text-right text-sm">
+        <td className="py-3 pl-2 pr-3 text-right text-sm">
           {member.viewerCanRemove &&
-            (member.user.provisionInfo ? (
-              member.user.provisionInfo.provisioningStatus ===
-              GraphQLSchema.ProvisioningStatus.PendingAdoption ? (
-                <AlertDialog open={takeoverOpen} onOpenChange={setTakeoverOpen}>
-                  <AlertDialogTrigger title="Review SCIM provisioning conflict">
-                    <AlertCircle size={16} className="ml-2 mt-1.5 text-yellow-500" />
-                    <span className="sr-only">Review SCIM provisioning conflict</span>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>
-                        Allow SCIM to manage {member.user.displayName}?
-                      </AlertDialogTitle>
-                      <AlertDialogDescription>
-                        SCIM matched <strong>{member.user.email}</strong> to an existing
-                        organization member.
-                      </AlertDialogDescription>
-                      <AlertDialogDescription>
-                        After confirmation, your identity provider will control this user's status
-                        and group-based access. Review the pending SCIM values below to avoid
-                        removing access unintentionally.
-                      </AlertDialogDescription>
-                      <div className="mt-4 space-y-2">
-                        <div className="text-sm">Pending SCIM values</div>
-                        <div className="flex w-fit items-center gap-2">
-                          <div className="flex items-center gap-1.5">
-                            <KeyIcon className="h-3.5 w-3.5" />
-                            <span className="text-xs">
-                              User status:{' '}
-                              {member.user.provisionInfo.isDisabled ? 'Disabled' : 'Active'}
-                            </span>
-                          </div>
-                        </div>
-                        <MemberGroups groups={member.groups ?? []} />
-                      </div>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel disabled={confirmTakeoverState.fetching}>
-                        Cancel
-                      </AlertDialogCancel>
-                      <AlertDialogAction
-                        variant="destructive"
-                        disabled={confirmTakeoverState.fetching}
-                        onClick={async event => {
-                          event.preventDefault();
-
-                          try {
-                            const result = await confirmTakeover({
-                              input: {
-                                organization: { byId: organization.id },
-                                member: { byId: member.user.id },
-                              },
-                            });
-
-                            if (result.error) {
-                              toast({
-                                variant: 'destructive',
-                                title: 'Could not enable SCIM management',
-                                description: result.error.message,
-                              });
-                            } else if (result.data?.confirmSCIMAccountTakeover.error) {
-                              toast({
-                                variant: 'destructive',
-                                title: 'Could not enable SCIM management',
-                                description: result.data.confirmSCIMAccountTakeover.error.message,
-                              });
-                            } else if (result.data?.confirmSCIMAccountTakeover.ok) {
-                              toast({
-                                title: 'SCIM management enabled',
-                                description: `${member.user.email} is now managed through SCIM.`,
-                              });
-                              setTakeoverOpen(false);
-                              props.refetchMembers({ requestPolicy: 'network-only' });
-                            }
-                          } catch (error) {
-                            console.error(error);
-                            toast({
-                              variant: 'destructive',
-                              title: 'Could not enable SCIM management',
-                              description: error instanceof Error ? error.message : String(error),
-                            });
-                          }
-                        }}
-                      >
-                        {confirmTakeoverState.fetching ? 'Applying...' : 'Allow SCIM management'}
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              ) : (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger>
-                      <ShieldCheck size={16} className="text-neutral-8 ml-2 mt-1.5" />
-                    </TooltipTrigger>
-                    <TooltipContent className="text-xs">
-                      Provisioned users can only be updated via the SCIM endpoints.
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )
+            (member.user.provisionInfo?.provisioningStatus ===
+            GraphQLSchema.ProvisioningStatus.Active ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <ShieldCheck size={16} className="text-neutral-8 ml-2 mt-1.5" />
+                  </TooltipTrigger>
+                  <TooltipContent className="text-xs">
+                    Provisioned users can only be updated via the SCIM endpoints.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             ) : (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    className="data-[state=open]:bg-neutral-3 flex size-8 p-0"
-                  >
-                    <MoreHorizontalIcon className="size-4" />
-                    <span className="sr-only">Open menu</span>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-[160px]">
-                  <DropdownMenuItem onSelect={() => setOpen(true)}>Delete</DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              member.viewerCanRemove && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      className="data-[state=open]:bg-neutral-3 ml-auto flex p-0"
+                    >
+                      <MoreHorizontalIcon className="size-4" />
+                      <span className="sr-only">Open menu</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-[160px]">
+                    <DropdownMenuItem onSelect={() => setOpen(true)}>Delete</DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )
             ))}
         </td>
       </tr>

--- a/packages/web/app/src/components/organization/settings/single-sign-on/oidc-integration-configuration.tsx
+++ b/packages/web/app/src/components/organization/settings/single-sign-on/oidc-integration-configuration.tsx
@@ -8,9 +8,21 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/base/card/card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
+import { Callout } from '@/components/ui/callout';
 import { CopyIconButton } from '@/components/ui/copy-icon-button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader } from '@/components/ui/dialog';
 import { Heading } from '@/components/ui/heading';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
@@ -22,6 +34,7 @@ import { Tag } from '@/components/v2';
 import { env } from '@/env/frontend';
 import { FragmentType, graphql, useFragment } from '@/gql';
 import { cn } from '@/lib/utils';
+import { Link } from '@tanstack/react-router';
 import { ConnectSingleSignOnProviderSheet } from './connect-single-sign-on-provider-sheet';
 import { DebugOIDCIntegrationModal } from './debug-oidc-integration-modal';
 import { OIDCDefaultResourceSelector } from './oidc-default-resource-selector';
@@ -180,8 +193,8 @@ export function OIDCIntegrationConfiguration(props: {
               ? 'OIDC login is now required for verified domains.'
               : 'Other login methods are now allowed for verified domains.',
             userProvisioningRequired: value
-              ? 'Users must now be provisioned via SCIM before signing in with OIDC.'
-              : 'User s can now be provisioned when signing in with OIDC.',
+              ? 'Users must be provisioned via SCIM before signing in with OIDC.'
+              : 'Users are provisioned when signing in with OIDC.',
           }[name],
         });
       } else {
@@ -563,13 +576,52 @@ function OIDCDomainConfiguration(props: {
                 blocked. Organization administrators are excluded.
               </p>
             </div>
-            <Switch
-              checked={oidcIntegration.oidcForVerifiedDomainsRequired}
-              data-cy="oidc-require-verified-domain-login-toggle"
-              onCheckedChange={checked =>
-                props.onRestrictionChange('oidcForVerifiedDomainsRequired', checked)
-              }
-            />
+            <AlertDialog>
+              <AlertDialogContent>
+                {oidcIntegration.oidcForVerifiedDomainsRequired ? (
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Disable enforced OIDC login</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Users will be able to login with any method, such as email + password or
+                      social logins.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                ) : (
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Enforce OIDC login</AlertDialogTitle>{' '}
+                    <AlertDialogDescription>
+                      Users will no longer be able to login with email+password or social logins.
+                      <Callout type="warning">
+                        This action can potentially lock you out of the organization. Make sure your
+                        OIDC provider is not configured properly and you can log in using it.
+                      </Callout>
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                )}
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    variant="destructive"
+                    onClick={() =>
+                      props.onRestrictionChange(
+                        'oidcForVerifiedDomainsRequired',
+                        !oidcIntegration.oidcForVerifiedDomainsRequired,
+                      )
+                    }
+                  >
+                    {oidcIntegration.oidcForVerifiedDomainsRequired
+                      ? 'Disable enforced ODIC login'
+                      : 'Enforce OIDC login'}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+              <AlertDialogTrigger>
+                <Switch
+                  checked={oidcIntegration.oidcForVerifiedDomainsRequired}
+                  data-cy="oidc-require-verified-domain-login-toggle"
+                />
+              </AlertDialogTrigger>
+            </AlertDialog>
           </div>
         </CardContent>
       </Card>
@@ -659,50 +711,81 @@ function OIDCAccessSettings(props: {
   return (
     <div>
       <Heading>User Provisioning</Heading>
+      <p>Configure how users should be provisioned by your identity provider.</p>
       <div className="mt-2 space-y-4 rounded-lg border p-6">
-        <RadioGroup
-          value={isSCIMProvisioningEnabled ? 'scim' : 'oidc'}
-          onValueChange={value =>
-            props.onRestrictionChange('userProvisioningRequired', value === 'scim' ? true : false)
-          }
-          className="flex gap-4"
-        >
+        <RadioGroup value={isSCIMProvisioningEnabled ? 'scim' : 'oidc'} className="flex gap-4">
           <Card
             variant={!isSCIMProvisioningEnabled ? 'selected' : 'selectable'}
-            onClick={() => props.onRestrictionChange('userProvisioningRequired', false)}
+            onClick={
+              oidcIntegration.userProvisioningRequired
+                ? () => props.onRestrictionChange('userProvisioningRequired', false)
+                : undefined
+            }
           >
             <CardContent variant="selection">
               <RadioGroupItem value="oidc" id="oidc-mode" className="mt-0.5" />
               <div className="flex-1">
                 <Label htmlFor="oidc-mode" className="cursor-pointer text-base font-medium">
-                  Managed via OIDC
+                  {organization.viewerCanManageSCIM ? (
+                    <>Mixed OIDC and SCIM</>
+                  ) : (
+                    <>Managed via OIDC</>
+                  )}
                 </Label>
-                <p className="mt-1 text-sm">
-                  Provision users and control user access through OIDC authentication. Configure
-                  join and access requirements with customizable default roles.
-                </p>
+                <p className="mt-1 text-sm">Users are provisioned when signing in via OIDC.</p>
+                {organization.viewerCanManageSCIM && (
+                  <p className="mt-1 text-sm">
+                    Optionally, users and groups can be provisioned via SCIM.
+                  </p>
+                )}
               </div>
             </CardContent>
           </Card>
 
           {organization.viewerCanManageSCIM ? (
-            <Card
-              variant={isSCIMProvisioningEnabled ? 'selected' : 'selectable'}
-              onClick={() => props.onRestrictionChange('userProvisioningRequired', true)}
-            >
-              <CardContent variant="selection">
-                <RadioGroupItem value="scim" id="scim-mode" className="mt-0.5" />
-                <div className="flex-1">
-                  <Label htmlFor="scim-mode" className="cursor-pointer text-base font-medium">
-                    Managed via SCIM
-                  </Label>
-                  <p className="mt-1 text-sm">
-                    Users and groups are synced via SCIM. Roles and permissions are assigned to
-                    groups via role mappings.
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Card variant={isSCIMProvisioningEnabled ? 'selected' : 'selectable'}>
+                  <CardContent variant="selection">
+                    <RadioGroupItem value="scim" id="scim-mode" className="mt-0.5" />
+                    <div className="flex-1">
+                      <Label htmlFor="scim-mode" className="cursor-pointer text-base font-medium">
+                        <span>Managed via SCIM</span>
+                      </Label>
+                      <p className="mt-1 text-sm">
+                        Users and groups are exclusively managed by your identity provider via SCIM.
+                      </p>
+                      <p className="mt-1 text-sm">
+                        Roles and permissions are assigned to groups via role mappings.
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Enabling this method will lock out all users that were not provisioned via your
+                    identity provider using SCIM.
+                    <Callout type="warning">
+                      Users that are currently in a conflicting state are excluded. <br /> You can
+                      continue resolving the conflicts after enabling this option. Any new attempts
+                      to login via OIDC without a prior provisioning of the user via SCIM will fail.
+                    </Callout>
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    variant="destructive"
+                    onClick={() => props.onRestrictionChange('userProvisioningRequired', true)}
+                  >
+                    Exclusively manage users via SCIM
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           ) : null}
         </RadioGroup>
         {isSCIMProvisioningEnabled ? (
@@ -729,7 +812,13 @@ function OIDCAccessSettings(props: {
                     <div className="flex flex-col space-y-1 text-sm font-medium leading-none">
                       <p>Sync groups via SCIM</p>
                       <p className="text-neutral-10 max-w-[500px] text-xs font-normal leading-snug">
-                        Groups are provisioned and updated via SCIM.
+                        Groups are provisioned and updated via SCIM.{' '}
+                        <Link
+                          to="/$organizationSlug/view/members?page=groups"
+                          className="text-accent hover:text-accent/80 inline-flex items-center gap-1"
+                        >
+                          Manage Groups
+                        </Link>
                       </p>
                     </div>
                   </div>
@@ -737,7 +826,13 @@ function OIDCAccessSettings(props: {
                     <div className="flex flex-col space-y-1 text-sm font-medium leading-none">
                       <p>Sync users via SCIM</p>
                       <p className="text-neutral-10 max-w-[500px] text-xs font-normal leading-snug">
-                        Users are provisioned and updated via SCIM.
+                        Users are provisioned and updated via SCIM.{' '}
+                        <Link
+                          to="/$organizationSlug/view/members?page=list"
+                          className="text-accent hover:text-accent/80 inline-flex items-center gap-1"
+                        >
+                          Manage Users
+                        </Link>
                       </p>
                     </div>
                   </div>
@@ -745,7 +840,13 @@ function OIDCAccessSettings(props: {
                     <div className="flex flex-col space-y-1 text-sm font-medium leading-none">
                       <p>Assign permissions via groups</p>
                       <p className="text-neutral-10 max-w-[500px] text-xs font-normal leading-snug">
-                        Assign role mappings to groups to grant permissions to group members.
+                        Assign role mappings to groups to grant permissions to group members.{' '}
+                        <Link
+                          to="/$organizationSlug/view/members?page=groups"
+                          className="text-accent hover:text-accent/80 inline-flex items-center gap-1"
+                        >
+                          Manage Groups
+                        </Link>
                       </p>
                     </div>
                   </div>

--- a/packages/web/app/src/components/organization/settings/single-sign-on/oidc-integration-configuration.tsx
+++ b/packages/web/app/src/components/organization/settings/single-sign-on/oidc-integration-configuration.tsx
@@ -683,7 +683,7 @@ const OIDCAccessSettings_OrganizationFragment = graphql(`
         }
       }
     }
-    pendingProvisioningTakeoverApprovalsCount
+    pendingSCIMManagementConfirmationsCount
     viewerCanManageSCIM
     ...OIDCDefaultResourceSelector_OrganizationFragment
   }
@@ -841,15 +841,15 @@ function OIDCAccessSettings(props: {
                         </Link>
                       </p>
                     </div>
-                    {organization.pendingProvisioningTakeoverApprovalsCount > 0 && (
+                    {organization.pendingSCIMManagementConfirmationsCount > 0 && (
                       <div>
                         <TooltipProvider delayDuration={100}>
                           <Tooltip>
                             <TooltipTrigger>
                               <div className="flex text-xs text-yellow-500">
-                                {organization.pendingProvisioningTakeoverApprovalsCount} SCIM
+                                {organization.pendingSCIMManagementConfirmationsCount} SCIM
                                 provisioning conflict
-                                {organization.pendingProvisioningTakeoverApprovalsCount === 1
+                                {organization.pendingSCIMManagementConfirmationsCount === 1
                                   ? ''
                                   : 's'}
                               </div>
@@ -862,7 +862,10 @@ function OIDCAccessSettings(props: {
                               <Link
                                 to="/$organizationSlug/view/members"
                                 params={{ organizationSlug: organization.slug }}
-                                search={{ page: 'list', showProvisioningConflicts: true }}
+                                search={{
+                                  page: 'list',
+                                  showPendingSCIMManagementConfirmations: true,
+                                }}
                                 className="text-accent hover:text-accent/80 inline-flex items-center gap-1"
                               >
                                 Review conflicts

--- a/packages/web/app/src/components/organization/settings/single-sign-on/oidc-integration-configuration.tsx
+++ b/packages/web/app/src/components/organization/settings/single-sign-on/oidc-integration-configuration.tsx
@@ -22,7 +22,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Callout } from '@/components/ui/callout';
 import { CopyIconButton } from '@/components/ui/copy-icon-button';
-import { Dialog, DialogContent, DialogHeader } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Heading } from '@/components/ui/heading';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
@@ -573,7 +573,7 @@ function OIDCDomainConfiguration(props: {
               <p>Require OIDC Login</p>
               <p className="max-w-[500px] text-xs font-normal leading-snug">
                 Enforce sign in/up through OIDC for verified domains. Any other login method will be
-                blocked. Organization administrators are excluded.
+                blocked. The organization owner is excluded from this restriction.
               </p>
             </div>
             <AlertDialog>
@@ -667,6 +667,7 @@ const OIDCAccessSettings_OIDCIntegrationFragment = graphql(`
 const OIDCAccessSettings_OrganizationFragment = graphql(`
   fragment OIDCAccessSettings_OrganizationFragment on Organization {
     id
+    slug
     me {
       id
       role {
@@ -682,6 +683,7 @@ const OIDCAccessSettings_OrganizationFragment = graphql(`
         }
       }
     }
+    pendingProvisioningTakeoverApprovalsCount
     viewerCanManageSCIM
     ...OIDCDefaultResourceSelector_OrganizationFragment
   }
@@ -803,7 +805,7 @@ function OIDCAccessSettings(props: {
                         Only (active) users provisioned via SCIM can access the organization.
                         <br />
                         <span className="font-bold">
-                          Organization administrators are excluded from this restriction.
+                          The organization owner is excluded from this restriction.
                         </span>
                       </p>
                     </div>
@@ -814,7 +816,9 @@ function OIDCAccessSettings(props: {
                       <p className="text-neutral-10 max-w-[500px] text-xs font-normal leading-snug">
                         Groups are provisioned and updated via SCIM.{' '}
                         <Link
-                          to="/$organizationSlug/view/members?page=groups"
+                          to="/$organizationSlug/view/members"
+                          params={{ organizationSlug: organization.slug }}
+                          search={{ page: 'groups' }}
                           className="text-accent hover:text-accent/80 inline-flex items-center gap-1"
                         >
                           Manage Groups
@@ -828,13 +832,46 @@ function OIDCAccessSettings(props: {
                       <p className="text-neutral-10 max-w-[500px] text-xs font-normal leading-snug">
                         Users are provisioned and updated via SCIM.{' '}
                         <Link
-                          to="/$organizationSlug/view/members?page=list"
+                          to="/$organizationSlug/view/members"
+                          params={{ organizationSlug: organization.slug }}
+                          search={{ page: 'list' }}
                           className="text-accent hover:text-accent/80 inline-flex items-center gap-1"
                         >
                           Manage Users
                         </Link>
                       </p>
                     </div>
+                    {organization.pendingProvisioningTakeoverApprovalsCount > 0 && (
+                      <div>
+                        <TooltipProvider delayDuration={100}>
+                          <Tooltip>
+                            <TooltipTrigger>
+                              <div className="flex text-xs text-yellow-500">
+                                {organization.pendingProvisioningTakeoverApprovalsCount} Conflict
+                                {organization.pendingProvisioningTakeoverApprovalsCount === 1
+                                  ? ''
+                                  : 's'}{' '}
+                                Detected
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-[250px] space-y-2">
+                              <p>
+                                Some users attempted to be provisioned conflict with existing users
+                                in the system.
+                              </p>
+                              <Link
+                                to="/$organizationSlug/view/members"
+                                params={{ organizationSlug: organization.slug }}
+                                search={{ page: 'list', showProvisioningConflicts: true }}
+                                className="text-accent hover:text-accent/80 inline-flex items-center gap-1"
+                              >
+                                Show and resolve conflicts
+                              </Link>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      </div>
+                    )}
                   </div>
                   <div className="flex items-center justify-between space-x-4">
                     <div className="flex flex-col space-y-1 text-sm font-medium leading-none">
@@ -842,7 +879,9 @@ function OIDCAccessSettings(props: {
                       <p className="text-neutral-10 max-w-[500px] text-xs font-normal leading-snug">
                         Assign role mappings to groups to grant permissions to group members.{' '}
                         <Link
-                          to="/$organizationSlug/view/members?page=groups"
+                          to="/$organizationSlug/view/members"
+                          params={{ organizationSlug: organization.slug }}
+                          search={{ page: 'groups' }}
                           className="text-accent hover:text-accent/80 inline-flex items-center gap-1"
                         >
                           Manage Groups

--- a/packages/web/app/src/components/organization/settings/single-sign-on/oidc-integration-configuration.tsx
+++ b/packages/web/app/src/components/organization/settings/single-sign-on/oidc-integration-configuration.tsx
@@ -766,14 +766,14 @@ function OIDCAccessSettings(props: {
               </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
-                  <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                  <AlertDialogTitle>Require SCIM provisioning?</AlertDialogTitle>
                   <AlertDialogDescription>
-                    Enabling this method will lock out all users that were not provisioned via your
-                    identity provider using SCIM.
+                    Users who are not provisioned through SCIM will no longer be able to access this
+                    organization. The organization owner is not affected.
                     <Callout type="warning">
-                      Users that are currently in a conflicting state are excluded. <br /> You can
-                      continue resolving the conflicts after enabling this option. Any new attempts
-                      to login via OIDC without a prior provisioning of the user via SCIM will fail.
+                      Members with unresolved SCIM provisioning conflicts will keep their current
+                      access until you review them. New OIDC users must first be provisioned through
+                      SCIM.
                     </Callout>
                   </AlertDialogDescription>
                 </AlertDialogHeader>
@@ -783,7 +783,7 @@ function OIDCAccessSettings(props: {
                     variant="destructive"
                     onClick={() => props.onRestrictionChange('userProvisioningRequired', true)}
                   >
-                    Exclusively manage users via SCIM
+                    Require SCIM provisioning
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>
@@ -847,17 +847,17 @@ function OIDCAccessSettings(props: {
                           <Tooltip>
                             <TooltipTrigger>
                               <div className="flex text-xs text-yellow-500">
-                                {organization.pendingProvisioningTakeoverApprovalsCount} Conflict
+                                {organization.pendingProvisioningTakeoverApprovalsCount} SCIM
+                                provisioning conflict
                                 {organization.pendingProvisioningTakeoverApprovalsCount === 1
                                   ? ''
-                                  : 's'}{' '}
-                                Detected
+                                  : 's'}
                               </div>
                             </TooltipTrigger>
                             <TooltipContent className="max-w-[250px] space-y-2">
                               <p>
-                                Some users attempted to be provisioned conflict with existing users
-                                in the system.
+                                SCIM provisioning matched existing organization members. Review each
+                                match before allowing SCIM to manage the account.
                               </p>
                               <Link
                                 to="/$organizationSlug/view/members"
@@ -865,7 +865,7 @@ function OIDCAccessSettings(props: {
                                 search={{ page: 'list', showProvisioningConflicts: true }}
                                 className="text-accent hover:text-accent/80 inline-flex items-center gap-1"
                               >
-                                Show and resolve conflicts
+                                Review conflicts
                               </Link>
                             </TooltipContent>
                           </Tooltip>

--- a/packages/web/app/src/components/ui/callout.tsx
+++ b/packages/web/app/src/components/ui/callout.tsx
@@ -52,7 +52,7 @@ const Callout = React.forwardRef<
       >
         {emoji}
       </div>
-      <div className="w-full min-w-0 leading-7">{children}</div>
+      <div>{children}</div>
     </div>
   );
 });

--- a/packages/web/app/src/pages/organization-members.tsx
+++ b/packages/web/app/src/pages/organization-members.tsx
@@ -115,6 +115,7 @@ const OrganizationMembersPageQuery = graphql(`
     $searchTerm: String
     $first: Int
     $after: String
+    $needsProvisioningTakeoverApproval: Boolean
   ) {
     organization: organizationBySlug(organizationSlug: $organizationSlug) {
       ...OrganizationMembersPage_OrganizationFragment
@@ -141,6 +142,7 @@ function OrganizationMembersPageContent(props: {
     variables: {
       organizationSlug: props.organizationSlug,
       searchTerm: search.search || undefined,
+      needsProvisioningTakeoverApproval: search.showProvisioningConflicts,
       first: 20,
       after,
     },

--- a/packages/web/app/src/pages/organization-members.tsx
+++ b/packages/web/app/src/pages/organization-members.tsx
@@ -115,7 +115,7 @@ const OrganizationMembersPageQuery = graphql(`
     $searchTerm: String
     $first: Int
     $after: String
-    $needsProvisioningTakeoverApproval: Boolean
+    $needsSCIMManagementConfirmation: Boolean
   ) {
     organization: organizationBySlug(organizationSlug: $organizationSlug) {
       ...OrganizationMembersPage_OrganizationFragment
@@ -142,7 +142,7 @@ function OrganizationMembersPageContent(props: {
     variables: {
       organizationSlug: props.organizationSlug,
       searchTerm: search.search || undefined,
-      needsProvisioningTakeoverApproval: search.showProvisioningConflicts,
+      needsSCIMManagementConfirmation: search.showPendingSCIMManagementConfirmations,
       first: 20,
       after,
     },

--- a/packages/web/app/src/router.tsx
+++ b/packages/web/app/src/router.tsx
@@ -514,7 +514,7 @@ const organizationSettingsRoute = createRoute({
 const OrganizationMembersRouteSearch = z.object({
   page: z.enum(['list', 'roles', 'invitations', 'groups']).catch('list').default('list'),
   search: z.string().optional(),
-  showProvisioningConflicts: z.boolean().optional(),
+  showPendingSCIMManagementConfirmations: z.boolean().optional(),
 });
 
 export const organizationMembersRoute = createRoute({

--- a/packages/web/app/src/router.tsx
+++ b/packages/web/app/src/router.tsx
@@ -514,6 +514,7 @@ const organizationSettingsRoute = createRoute({
 const OrganizationMembersRouteSearch = z.object({
   page: z.enum(['list', 'roles', 'invitations', 'groups']).catch('list').default('list'),
   search: z.string().optional(),
+  showProvisioningConflicts: z.boolean().optional(),
 });
 
 export const organizationMembersRoute = createRoute({


### PR DESCRIPTION
Introduces a way of resolving scim provisioning conflicts instead of taking over the accounts immediatly.

When a scim user is provisioned, but it already exists within the organization, the `provisioning_status` of that user is set to `'pendingConfirmation'`.

[Internal run through video](https://guild-oss.slack.com/archives/C01E8ATBQGN/p1786101979552839?thread_ts=1786029275.388039&cid=C01E8ATBQGN) (UI slightly outdated; the screenshots below are more up 2 date and fix some shortcomings I mentioned before).

The provisioning conflict count is displayed within the user provisioning settings:

<img width="919" height="647" alt="image" src="https://github.com/user-attachments/assets/5c28d843-2124-48ba-9737-808ed70531ec" />

The conflict can be resolved via the members UI, which provides a list of all the conflicting users:

<img width="1462" height="674" alt="image" src="https://github.com/user-attachments/assets/01ae169c-8e88-4280-a2fb-648f4659a3ac" />

The viewer needs to confirm for each of these users that it is now managed via SCIM. Showing the groups and status of the user helps to make a sane decision and avoid accidental lockout. 

<img width="831" height="534" alt="image" src="https://github.com/user-attachments/assets/ab5cacf6-fad5-4f31-ac58-5fef942b410c" />

After confirming all users, we have a proper emtpy state 🥳 

<img width="1280" height="784" alt="image" src="https://github.com/user-attachments/assets/fb74bbce-26fd-4413-b518-d5409677d079" />

