### PR TITLE
Laboratory: add built in docs component

### DIFF
--- a/.changeset/large-seas-chew.md
+++ b/.changeset/large-seas-chew.md
@@ -4,3 +4,10 @@
 ---
 
 Lab: Add a schema documentation pane, opt-in via the new `enableDocs` prop.
+
+When enabled, a third icon appears in the left rail and opens documentation in the same slot as Collections and History: browse root types, types and fields, search across the whole type map (including input objects and enum values), and read descriptions, deprecations and argument defaults. Builder rows gain an "Open in Docs" context menu entry, and the GraphQL editor hover gains an "Open in Docs" link. `renderLaboratory` enables the pane by default, so standalone embedders of the UMD bundle get it without passing `enableDocs`.
+
+`enableDocs` also decides whether introspection asks for descriptions, so a host that supplies `defaultSchemaIntrospection` must build it with descriptions itself. Building it with `introspectionFromSchema` does that by default.
+
+**Removed:** the `introspection.schemaDescription` setting and its toggle in the settings dialog. It was wired to graphql-js's `descriptions` option rather than `schemaDescription`, and defaulted to `false` where graphql-js defaults to `true`, so nothing rendered descriptions and the toggle had no discoverable effect. Descriptions now follow `enableDocs`. `render-laboratory` no longer maps Yoga's `schemaDescription` option.
+

--- a/.changeset/large-seas-chew.md
+++ b/.changeset/large-seas-chew.md
@@ -1,0 +1,6 @@
+---
+'@graphql-hive/render-laboratory': patch
+'@graphql-hive/laboratory': patch
+---
+
+Lab: Add a schema documentation pane, opt-in via the new `enableDocs` prop.

--- a/packages/libraries/laboratory/README.md
+++ b/packages/libraries/laboratory/README.md
@@ -16,6 +16,7 @@ Hive Console and can be embedded into any page that talks to a GraphQL endpoint.
 - Query builder: click schema fields/arguments to build the operation
 - Schema explorer with search (list and tree modes)
 - Collections (saved operations) and request history
+- Schema documentation pane (opt-in via `enableDocs`), reachable from Builder rows and editor hovers
 - Preflight scripts: run JavaScript before a request in a sandboxed Web Worker
 - Environment variables with `{{variable}}` interpolation
 - Renders a federation query plan when a server includes one in the response `extensions`
@@ -101,6 +102,18 @@ Pass a `permissions` object to gate actions per resource (`preflight`, `collecti
 `collectionsOperations`) with `read`/`create`/`update`/`delete` flags. Gating is applied in the UI
 (controls are hidden/disabled) with a backstop in the operations logic; anything unspecified
 defaults to allowed.
+
+### Documentation pane
+
+`enableDocs` adds a documentation icon to the left rail, opening a schema browser in the same slot
+as Collections and History. It is off unless you pass it. Builder rows get an "Open in Docs" context
+menu entry, and the GraphQL editor hover gets an "Open in Docs" link (the Lab serves that hover
+itself when docs are on, instead of monaco-graphql).
+
+The prop also decides whether introspection requests descriptions, since nothing else renders them.
+That only reaches introspection the Lab performs itself: if you pass `defaultSchemaIntrospection`,
+build it with descriptions or the pane will have nothing to show. `introspectionFromSchema` includes
+them by default, so the usual `introspectionFromSchema(buildSchema(sdl))` needs no extra options.
 
 ### Styling and rendering
 

--- a/packages/libraries/laboratory/package.json
+++ b/packages/libraries/laboratory/package.json
@@ -45,6 +45,7 @@
     "@base-ui/react": "^1.1.0",
     "@graphql-tools/url-loader": "^9.1.0",
     "dompurify": "3.4.12",
+    "graphql-language-service": "^5.5.0",
     "radix-ui": "^1.4.3",
     "react-zoom-pan-pinch": "^3.7.0",
     "snarkdown": "2.0.0",

--- a/packages/libraries/laboratory/package.json
+++ b/packages/libraries/laboratory/package.json
@@ -44,8 +44,10 @@
   "dependencies": {
     "@base-ui/react": "^1.1.0",
     "@graphql-tools/url-loader": "^9.1.0",
+    "dompurify": "3.4.12",
     "radix-ui": "^1.4.3",
     "react-zoom-pan-pinch": "^3.7.0",
+    "snarkdown": "2.0.0",
     "uuid": "^14.0.0"
   },
   "devDependencies": {
@@ -106,6 +108,7 @@
     "graphql": "^16.14.0",
     "graphql-yoga": "5.21.1",
     "happy-dom": "^20.10.6",
+    "jsdom": "^30.0.1",
     "lodash": "^4.18.1",
     "lucide-react": "^0.548.0",
     "lz-string": "^1.5.0",

--- a/packages/libraries/laboratory/src/components/laboratory/builder-docs-context-menu.spec.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/builder-docs-context-menu.spec.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { buildSchema, type GraphQLObjectType } from 'graphql';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BuilderObjectField, BuilderScalarField } from './builder';
+
+const laboratory = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
+
+vi.mock('./context', () => ({
+  useLaboratory: () => laboratory.current,
+}));
+
+const schema = buildSchema(`
+  type Profile { city: String }
+  type User { id: ID!, profile: Profile }
+  type Query { me: User }
+`);
+
+const idField = (schema.getType('User') as GraphQLObjectType).getFields().id;
+const meField = schema.getQueryType()!.getFields().me;
+
+const openDocs = vi.fn();
+
+const mount = (node: React.ReactElement, enableDocs: boolean) => {
+  laboratory.current = {
+    schema,
+    enableDocs,
+    openDocs,
+    activeOperation: null,
+    activeTab: { type: 'operation' },
+    addPathToActiveOperation: vi.fn(),
+    deletePathFromActiveOperation: vi.fn(),
+    addArgToActiveOperation: vi.fn(),
+    deleteArgFromActiveOperation: vi.fn(),
+  };
+
+  return render(node);
+};
+
+const scalarRow = (disableChildren: boolean) => (
+  <BuilderScalarField
+    field={idField}
+    path={['query', 'me', 'id']}
+    openPaths={[]}
+    setOpenPaths={vi.fn()}
+    disableChildren={disableChildren}
+  />
+);
+
+describe('Builder row docs context menu', () => {
+  beforeEach(() => {
+    openDocs.mockReset();
+  });
+
+  it('offers Open in Docs on a plain row', () => {
+    const { container } = mount(scalarRow(false), true);
+
+    fireEvent.contextMenu(container.firstElementChild!);
+
+    expect(screen.getByText('Open in Docs')).toBeDefined();
+  });
+
+  it('opens the field the row represents, not its return type', () => {
+    const { container } = mount(scalarRow(false), true);
+
+    fireEvent.contextMenu(container.firstElementChild!);
+    fireEvent.click(screen.getByText('Open in Docs'));
+
+    expect(openDocs).toHaveBeenCalledWith({ kind: 'field', typeName: 'User', fieldName: 'id' });
+  });
+
+  it('offers nothing when docs are disabled', () => {
+    const { container } = mount(scalarRow(false), false);
+
+    fireEvent.contextMenu(container.firstElementChild!);
+
+    expect(screen.queryByText('Open in Docs')).toBeNull();
+  });
+
+  it('still renders the sticky row variant', () => {
+    const { container } = mount(scalarRow(true), true);
+
+    expect(container.firstElementChild).not.toBeNull();
+  });
+
+  // The collapsible variant nests ContextMenuTrigger asChild around
+  // CollapsibleTrigger asChild, so both slots have to resolve onto the Button.
+  it('renders the collapsible row without breaking the asChild chain', () => {
+    const { container } = mount(
+      <BuilderObjectField
+        field={meField}
+        path={['query', 'me']}
+        openPaths={[]}
+        setOpenPaths={vi.fn()}
+      />,
+      true,
+    );
+
+    const button = container.querySelector('button');
+    expect(button).not.toBeNull();
+
+    fireEvent.contextMenu(button!);
+
+    expect(screen.getByText('Open in Docs')).toBeDefined();
+  });
+});

--- a/packages/libraries/laboratory/src/components/laboratory/builder.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/builder.tsx
@@ -30,6 +30,7 @@ import {
   SettingsIcon,
   TextAlignStartIcon,
 } from 'lucide-react';
+import { docsTargetFromPath } from '../../lib/docs';
 import type { LaboratoryOperation } from '../../lib/operations';
 import {
   getFieldByPath,
@@ -45,6 +46,12 @@ import { GraphQLIcon } from '../icons';
 import { Button, buttonVariants } from '../ui/button';
 import { Checkbox } from '../ui/checkbox';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '../ui/context-menu';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../ui/empty';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '../ui/input-group';
 import { ScrollArea, ScrollBar } from '../ui/scroll-area';
@@ -52,6 +59,36 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { useLaboratory } from './context';
+
+/**
+ * Rows are already buttons (and the collapsible ones wrap the checkbox's own
+ * button), so there is no room to nest an inline docs control. A context menu
+ * keeps the row untouched and works the same on every row variant.
+ *
+ * Must sit outside `CollapsibleTrigger` so both `asChild` slots resolve onto the
+ * same underlying element.
+ */
+const BuilderRowContextMenu = (props: { path: string[]; children: React.ReactNode }) => {
+  const { schema, enableDocs, openDocs } = useLaboratory();
+
+  const target = useMemo(
+    () => docsTargetFromPath(props.path, schema ?? null),
+    [props.path, schema],
+  );
+
+  if (!enableDocs || !target) {
+    return <>{props.children}</>;
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{props.children}</ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onClick={() => openDocs(target)}>Open in Docs</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+};
 
 export const BuilderArgument = (props: {
   field: GraphQLArgument;
@@ -192,99 +229,103 @@ export const BuilderScalarField = (props: {
     return (
       // A div, not a Button: the row is a styled container, and a button here would
       // nest the checkbox's own button inside it.
-      <div
-        className={cn(
-          buttonVariants({ variant: 'ghost', size: 'sm' }),
-          'text-muted-foreground bg-card p-1! group sticky top-0 z-10 w-full justify-start overflow-hidden text-xs',
-          {
-            'text-foreground-primary': isInQuery,
-          },
-        )}
-        style={{
-          top: `${(props.path.length - 2) * 32}px`,
-        }}
-      >
-        <div className="bg-card absolute left-0 top-0 -z-20 size-full" />
-        <div className="group-hover:bg-accent/50 absolute left-0 top-0 -z-10 size-full transition-colors" />
-        <Checkbox
-          onClick={e => e.stopPropagation()}
-          checked={isInQuery}
-          disabled={activeTab?.type !== 'operation' || props.isReadOnly}
-          onCheckedChange={checked => {
-            if (checked) {
-              setIsOpen(true);
-              addPathToActiveOperation(path, props.operationName);
-            } else {
-              deletePathFromActiveOperation(path, props.operationName);
-            }
+      <BuilderRowContextMenu path={props.path}>
+        <div
+          className={cn(
+            buttonVariants({ variant: 'ghost', size: 'sm' }),
+            'text-muted-foreground bg-card p-1! group sticky top-0 z-10 w-full justify-start overflow-hidden text-xs',
+            {
+              'text-foreground-primary': isInQuery,
+            },
+          )}
+          style={{
+            top: `${(props.path.length - 2) * 32}px`,
           }}
-        />
-        <BoxIcon className="size-4 text-rose-400" />
-        {props.label ?? (
-          <span
-            className={cn({
-              'text-primary-foreground bg-primary -mx-0.5 rounded-sm px-0.5': shouldHighlight,
-            })}
-          >
-            {props.field.name}
-          </span>
-        )}
-        : <GraphQLType type={props.field.type} />
-      </div>
+        >
+          <div className="bg-card absolute left-0 top-0 -z-20 size-full" />
+          <div className="group-hover:bg-accent/50 absolute left-0 top-0 -z-10 size-full transition-colors" />
+          <Checkbox
+            onClick={e => e.stopPropagation()}
+            checked={isInQuery}
+            disabled={activeTab?.type !== 'operation' || props.isReadOnly}
+            onCheckedChange={checked => {
+              if (checked) {
+                setIsOpen(true);
+                addPathToActiveOperation(path, props.operationName);
+              } else {
+                deletePathFromActiveOperation(path, props.operationName);
+              }
+            }}
+          />
+          <BoxIcon className="size-4 text-rose-400" />
+          {props.label ?? (
+            <span
+              className={cn({
+                'text-primary-foreground bg-primary -mx-0.5 rounded-sm px-0.5': shouldHighlight,
+              })}
+            >
+              {props.field.name}
+            </span>
+          )}
+          : <GraphQLType type={props.field.type} />
+        </div>
+      </BuilderRowContextMenu>
     );
   }
 
   if (args.length > 0) {
     return (
       <Collapsible key={props.field.name} open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger asChild>
-          <Button
-            variant="ghost"
-            className={cn(
-              'text-muted-foreground bg-card p-1! group sticky top-0 z-10 w-full justify-start overflow-hidden text-xs',
-              {
-                'text-foreground-primary': isInQuery,
-              },
-            )}
-            style={{
-              top: `${(props.path.length - 2) * 32}px`,
-            }}
-            size="sm"
-          >
-            <div className="bg-card absolute left-0 top-0 -z-20 size-full" />
-            <div className="group-hover:bg-accent/50 absolute left-0 top-0 -z-10 size-full transition-colors" />
-            <ChevronDownIcon
-              className={cn('text-muted-foreground size-4 transition-all', {
-                '-rotate-90': !isOpen,
-              })}
-            />
-            <Checkbox
-              asSpan
-              onClick={e => e.stopPropagation()}
-              checked={isInQuery}
-              disabled={activeTab?.type !== 'operation' || props.isReadOnly}
-              onCheckedChange={checked => {
-                if (checked) {
-                  setIsOpen(true);
-                  addPathToActiveOperation(path, props.operationName);
-                } else {
-                  deletePathFromActiveOperation(path, props.operationName);
-                }
+        <BuilderRowContextMenu path={props.path}>
+          <CollapsibleTrigger asChild>
+            <Button
+              variant="ghost"
+              className={cn(
+                'text-muted-foreground bg-card p-1! group sticky top-0 z-10 w-full justify-start overflow-hidden text-xs',
+                {
+                  'text-foreground-primary': isInQuery,
+                },
+              )}
+              style={{
+                top: `${(props.path.length - 2) * 32}px`,
               }}
-            />
-            <BoxIcon className="size-4 text-rose-400" />
-            {props.label ?? (
-              <span
-                className={cn({
-                  'text-primary-foreground bg-primary -mx-0.5 rounded-sm px-0.5': shouldHighlight,
+              size="sm"
+            >
+              <div className="bg-card absolute left-0 top-0 -z-20 size-full" />
+              <div className="group-hover:bg-accent/50 absolute left-0 top-0 -z-10 size-full transition-colors" />
+              <ChevronDownIcon
+                className={cn('text-muted-foreground size-4 transition-all', {
+                  '-rotate-90': !isOpen,
                 })}
-              >
-                {props.field.name}
-              </span>
-            )}
-            : <GraphQLType type={props.field.type} />
-          </Button>
-        </CollapsibleTrigger>
+              />
+              <Checkbox
+                asSpan
+                onClick={e => e.stopPropagation()}
+                checked={isInQuery}
+                disabled={activeTab?.type !== 'operation' || props.isReadOnly}
+                onCheckedChange={checked => {
+                  if (checked) {
+                    setIsOpen(true);
+                    addPathToActiveOperation(path, props.operationName);
+                  } else {
+                    deletePathFromActiveOperation(path, props.operationName);
+                  }
+                }}
+              />
+              <BoxIcon className="size-4 text-rose-400" />
+              {props.label ?? (
+                <span
+                  className={cn({
+                    'text-primary-foreground bg-primary -mx-0.5 rounded-sm px-0.5': shouldHighlight,
+                  })}
+                >
+                  {props.field.name}
+                </span>
+              )}
+              : <GraphQLType type={props.field.type} />
+            </Button>
+          </CollapsibleTrigger>
+        </BuilderRowContextMenu>
         <CollapsibleContent className="border-border relative z-0 ml-3 flex flex-col border-l pl-2">
           {isOpen && (
             <div>
@@ -342,41 +383,43 @@ export const BuilderScalarField = (props: {
   return (
     // A div, not a Button: the row is a styled container, and a button here would
     // nest the checkbox's own button inside it.
-    <div
-      key={props.field.name}
-      className={cn(
-        buttonVariants({ variant: 'ghost', size: 'sm' }),
-        'text-muted-foreground p-1! w-full justify-start text-xs',
-        {
-          'text-foreground-primary': isInQuery,
-        },
-      )}
-    >
-      <div className="size-4" />
-      <Checkbox
-        onClick={e => e.stopPropagation()}
-        checked={isInQuery}
-        disabled={activeTab?.type !== 'operation'}
-        onCheckedChange={checked => {
-          if (checked) {
-            addPathToActiveOperation(props.path.join('.'), props.operationName);
-          } else {
-            deletePathFromActiveOperation(props.path.join('.'), props.operationName);
-          }
-        }}
-      />
-      <BoxIcon className="size-4 text-rose-400" />
-      {props.label ?? (
-        <span
-          className={cn({
-            'text-primary-foreground bg-primary -mx-0.5 rounded-sm px-0.5': shouldHighlight,
-          })}
-        >
-          {props.field.name}
-        </span>
-      )}
-      : <GraphQLType type={props.field.type} />
-    </div>
+    <BuilderRowContextMenu path={props.path}>
+      <div
+        key={props.field.name}
+        className={cn(
+          buttonVariants({ variant: 'ghost', size: 'sm' }),
+          'text-muted-foreground p-1! w-full justify-start text-xs',
+          {
+            'text-foreground-primary': isInQuery,
+          },
+        )}
+      >
+        <div className="size-4" />
+        <Checkbox
+          onClick={e => e.stopPropagation()}
+          checked={isInQuery}
+          disabled={activeTab?.type !== 'operation'}
+          onCheckedChange={checked => {
+            if (checked) {
+              addPathToActiveOperation(props.path.join('.'), props.operationName);
+            } else {
+              deletePathFromActiveOperation(props.path.join('.'), props.operationName);
+            }
+          }}
+        />
+        <BoxIcon className="size-4 text-rose-400" />
+        {props.label ?? (
+          <span
+            className={cn({
+              'text-primary-foreground bg-primary -mx-0.5 rounded-sm px-0.5': shouldHighlight,
+            })}
+          >
+            {props.field.name}
+          </span>
+        )}
+        : <GraphQLType type={props.field.type} />
+      </div>
+    </BuilderRowContextMenu>
   );
 };
 
@@ -460,54 +503,10 @@ export const BuilderObjectField = (props: {
     return (
       // A div, not a Button: the row is a styled container, and a button here would
       // nest the checkbox's own button inside it.
-      <div
-        className={cn(
-          buttonVariants({ variant: 'ghost', size: 'sm' }),
-          'text-muted-foreground bg-card p-1! group sticky top-0 z-10 w-full justify-start overflow-hidden text-xs',
-          {
-            'text-foreground-primary': isInQuery,
-          },
-        )}
-        style={{
-          top: `${(props.path.length - 2) * 32}px`,
-        }}
-      >
-        <div className="bg-card absolute left-0 top-0 -z-20 size-full" />
-        <div className="group-hover:bg-accent/50 absolute left-0 top-0 -z-10 size-full transition-colors" />
-        <Checkbox
-          onClick={e => e.stopPropagation()}
-          checked={isInQuery}
-          disabled={activeTab?.type !== 'operation' || props.isReadOnly}
-          onCheckedChange={checked => {
-            if (checked) {
-              setIsOpen(true);
-              addPathToActiveOperation(path, props.operationName);
-            } else {
-              deletePathFromActiveOperation(path, props.operationName);
-            }
-          }}
-        />
-        <BoxIcon className="size-4 text-rose-400" />
-        {props.label ?? (
-          <span
-            className={cn({
-              'text-primary-foreground bg-primary -mx-0.5 rounded-sm px-0.5': shouldHighlight,
-            })}
-          >
-            {props.field.name}
-          </span>
-        )}
-        : <GraphQLType type={props.field.type} />
-      </div>
-    );
-  }
-
-  return (
-    <Collapsible key={props.field.name} open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger asChild>
-        <Button
-          variant="ghost"
+      <BuilderRowContextMenu path={props.path}>
+        <div
           className={cn(
+            buttonVariants({ variant: 'ghost', size: 'sm' }),
             'text-muted-foreground bg-card p-1! group sticky top-0 z-10 w-full justify-start overflow-hidden text-xs',
             {
               'text-foreground-primary': isInQuery,
@@ -516,17 +515,10 @@ export const BuilderObjectField = (props: {
           style={{
             top: `${(props.path.length - 2) * 32}px`,
           }}
-          size="sm"
         >
           <div className="bg-card absolute left-0 top-0 -z-20 size-full" />
           <div className="group-hover:bg-accent/50 absolute left-0 top-0 -z-10 size-full transition-colors" />
-          <ChevronDownIcon
-            className={cn('text-muted-foreground size-4 transition-all', {
-              '-rotate-90': !isOpen,
-            })}
-          />
           <Checkbox
-            asSpan
             onClick={e => e.stopPropagation()}
             checked={isInQuery}
             disabled={activeTab?.type !== 'operation' || props.isReadOnly}
@@ -550,8 +542,63 @@ export const BuilderObjectField = (props: {
             </span>
           )}
           : <GraphQLType type={props.field.type} />
-        </Button>
-      </CollapsibleTrigger>
+        </div>
+      </BuilderRowContextMenu>
+    );
+  }
+
+  return (
+    <Collapsible key={props.field.name} open={isOpen} onOpenChange={setIsOpen}>
+      <BuilderRowContextMenu path={props.path}>
+        <CollapsibleTrigger asChild>
+          <Button
+            variant="ghost"
+            className={cn(
+              'text-muted-foreground bg-card p-1! group sticky top-0 z-10 w-full justify-start overflow-hidden text-xs',
+              {
+                'text-foreground-primary': isInQuery,
+              },
+            )}
+            style={{
+              top: `${(props.path.length - 2) * 32}px`,
+            }}
+            size="sm"
+          >
+            <div className="bg-card absolute left-0 top-0 -z-20 size-full" />
+            <div className="group-hover:bg-accent/50 absolute left-0 top-0 -z-10 size-full transition-colors" />
+            <ChevronDownIcon
+              className={cn('text-muted-foreground size-4 transition-all', {
+                '-rotate-90': !isOpen,
+              })}
+            />
+            <Checkbox
+              asSpan
+              onClick={e => e.stopPropagation()}
+              checked={isInQuery}
+              disabled={activeTab?.type !== 'operation' || props.isReadOnly}
+              onCheckedChange={checked => {
+                if (checked) {
+                  setIsOpen(true);
+                  addPathToActiveOperation(path, props.operationName);
+                } else {
+                  deletePathFromActiveOperation(path, props.operationName);
+                }
+              }}
+            />
+            <BoxIcon className="size-4 text-rose-400" />
+            {props.label ?? (
+              <span
+                className={cn({
+                  'text-primary-foreground bg-primary -mx-0.5 rounded-sm px-0.5': shouldHighlight,
+                })}
+              >
+                {props.field.name}
+              </span>
+            )}
+            : <GraphQLType type={props.field.type} />
+          </Button>
+        </CollapsibleTrigger>
+      </BuilderRowContextMenu>
       <CollapsibleContent className="border-border relative z-0 ml-4 flex flex-col border-l pl-1">
         {isOpen && (
           <div>

--- a/packages/libraries/laboratory/src/components/laboratory/context.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/context.tsx
@@ -48,6 +48,7 @@ type LaboratoryContextState = LaboratoryCollectionsState &
   LaboratoryTestState & {
     isFullScreen?: boolean;
     enableFullScreen?: boolean;
+    enableDocs?: boolean;
     theme?: 'light' | 'dark';
   };
 type LaboratoryContextActions = LaboratoryCollectionsActions &
@@ -144,6 +145,12 @@ export interface LaboratoryApi {
   isFullScreen?: boolean;
   /** Show the full screen control. Off for hosts that already fill the viewport. */
   enableFullScreen?: boolean;
+  /**
+   * Show the schema documentation pane. Off unless explicitly enabled. Also decides
+   * whether introspection asks for descriptions, so a host passing
+   * `defaultSchemaIntrospection` must build that with descriptions itself.
+   */
+  enableDocs?: boolean;
   goToFullScreen?: () => void;
   exitFullScreen?: () => void;
   defaultPreflight?: LaboratoryPreflight | null;

--- a/packages/libraries/laboratory/src/components/laboratory/context.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/context.tsx
@@ -6,6 +6,7 @@ import {
   type LaboratoryCollectionsActions,
   type LaboratoryCollectionsState,
 } from '../../lib/collections';
+import type { LaboratoryDocsActions, LaboratoryDocsState } from '../../lib/docs';
 import { type LaboratoryEndpointActions, type LaboratoryEndpointState } from '../../lib/endpoint';
 import type { LaboratoryEnv, LaboratoryEnvActions, LaboratoryEnvState } from '../../lib/env';
 import type {
@@ -45,6 +46,7 @@ type LaboratoryContextState = LaboratoryCollectionsState &
   LaboratoryEnvState &
   LaboratorySettingsState &
   LaboratoryPluginsState &
+  LaboratoryDocsState &
   LaboratoryTestState & {
     isFullScreen?: boolean;
     enableFullScreen?: boolean;
@@ -60,6 +62,7 @@ type LaboratoryContextActions = LaboratoryCollectionsActions &
   LaboratoryEnvActions &
   LaboratorySettingsActions &
   LaboratoryPluginsActions &
+  LaboratoryDocsActions &
   LaboratoryTestActions & {
     openAddCollectionDialog?: () => void;
     openUpdateEndpointDialog?: () => void;

--- a/packages/libraries/laboratory/src/components/laboratory/docs.spec.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/docs.spec.tsx
@@ -15,7 +15,11 @@ const schema = buildSchema(`
     id: ID!
     displayName: String
   }
-  type Query { me: User }
+  type Query {
+    "The currently authenticated user."
+    me: User
+    anonymous: String
+  }
 `);
 
 const mount = (state: Record<string, unknown>) => {
@@ -35,7 +39,23 @@ describe('Docs', () => {
   it('lists the root operation types when the stack is empty', () => {
     mount({});
 
-    expect(screen.getByText('Query')).toBeDefined();
+    expect(screen.getByText('query')).toBeDefined();
+    expect(screen.getByText('Root types')).toBeDefined();
+  });
+
+  // Without this the type view is a bare list of names, which reads as "descriptions
+  // are broken" even when the schema has them.
+  it('shows field descriptions inline in the type view, without clicking through', () => {
+    mount({ docsNavStack: [{ kind: 'type', name: 'Query' }] });
+
+    expect(screen.getByText('The currently authenticated user.')).toBeDefined();
+  });
+
+  it('omits the inline description for fields that have none', () => {
+    mount({ docsNavStack: [{ kind: 'type', name: 'Query' }] });
+
+    expect(screen.getByText('anonymous')).toBeDefined();
+    expect(screen.queryByText('undefined')).toBeNull();
   });
 
   it('renders a description when the field has one', () => {

--- a/packages/libraries/laboratory/src/components/laboratory/docs.spec.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/docs.spec.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { buildSchema } from 'graphql';
+import { render, screen } from '@testing-library/react';
+import { Docs } from './docs';
+
+const laboratory = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
+
+vi.mock('./context', () => ({
+  useLaboratory: () => laboratory.current,
+}));
+
+const schema = buildSchema(`
+  type User {
+    "The user's unique identifier."
+    id: ID!
+    displayName: String
+  }
+  type Query { me: User }
+`);
+
+const mount = (state: Record<string, unknown>) => {
+  laboratory.current = {
+    schema,
+    docsNavStack: [],
+    pushDocs: vi.fn(),
+    popDocs: vi.fn(),
+    resetDocs: vi.fn(),
+    ...state,
+  };
+
+  return render(<Docs />);
+};
+
+describe('Docs', () => {
+  it('lists the root operation types when the stack is empty', () => {
+    mount({});
+
+    expect(screen.getByText('Query')).toBeDefined();
+  });
+
+  it('renders a description when the field has one', () => {
+    const { container } = mount({
+      docsNavStack: [{ kind: 'field', typeName: 'User', fieldName: 'id' }],
+    });
+
+    expect(container.querySelector('[data-slot="markdown"]')).not.toBeNull();
+  });
+
+  // Most schemas carry no docstrings, so an empty container would be the common case.
+  it('renders no description block when the field has none', () => {
+    const { container } = mount({
+      docsNavStack: [{ kind: 'field', typeName: 'User', fieldName: 'displayName' }],
+    });
+
+    expect(container.querySelector('[data-slot="markdown"]')).toBeNull();
+    expect(screen.getByText('Type')).toBeDefined();
+  });
+
+  it('falls back to the root view when the target type is gone', () => {
+    mount({ docsNavStack: [{ kind: 'type', name: 'Removed' }] });
+
+    expect(screen.getByText('Root types')).toBeDefined();
+  });
+
+  it('falls back to the root view when the target field is gone', () => {
+    mount({ docsNavStack: [{ kind: 'field', typeName: 'User', fieldName: 'gone' }] });
+
+    expect(screen.getByText('Root types')).toBeDefined();
+  });
+
+  it('shows an empty state before a schema is available', () => {
+    mount({ schema: null });
+
+    expect(screen.getByText('No schema yet')).toBeDefined();
+  });
+});

--- a/packages/libraries/laboratory/src/components/laboratory/docs.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/docs.tsx
@@ -1,0 +1,423 @@
+import { useDeferredValue, useMemo, useState } from 'react';
+import {
+  isEnumType,
+  isInputObjectType,
+  isInterfaceType,
+  isObjectType,
+  isUnionType,
+  type GraphQLArgument,
+  type GraphQLEnumValue,
+  type GraphQLField,
+  type GraphQLInputField,
+  type GraphQLNamedType,
+} from 'graphql';
+import { BookOpenIcon, ChevronLeftIcon, SearchIcon } from 'lucide-react';
+import { searchSchemaDocs } from '../../lib/docs-search';
+import { cn } from '../../lib/utils';
+import { GraphQLType } from '../graphql-type';
+import { Markdown } from '../markdown';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../ui/empty';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group';
+import { ScrollArea, ScrollBar } from '../ui/scroll-area';
+import { useLaboratory } from './context';
+
+const namedTypeOf = (type: unknown): GraphQLNamedType | null => {
+  let current = type as { ofType?: unknown; name?: string } | null;
+
+  while (current && 'ofType' in current && current.ofType) {
+    current = current.ofType as { ofType?: unknown; name?: string };
+  }
+
+  return (current as GraphQLNamedType | null) ?? null;
+};
+
+const Section = (props: { title: string; children: React.ReactNode }) => (
+  <div className="flex flex-col gap-1">
+    <div className="text-muted-foreground px-2 pt-2 text-[11px] font-medium uppercase tracking-wide">
+      {props.title}
+    </div>
+    {props.children}
+  </div>
+);
+
+const Description = (props: { description?: string | null }) =>
+  props.description ? <Markdown className="px-2 py-1" content={props.description} /> : null;
+
+const DeprecationBadge = (props: { reason?: string | null }) => (
+  <div className="flex flex-col gap-1 px-2 py-1">
+    <Badge variant="outline" className="text-muted-foreground w-fit">
+      Deprecated
+    </Badge>
+    {props.reason ? <Markdown content={props.reason} /> : null}
+  </div>
+);
+
+const Row = (props: { onClick?: () => void; children: React.ReactNode; className?: string }) => (
+  <Button
+    variant="ghost"
+    size="sm"
+    onClick={props.onClick}
+    className={cn('w-full justify-start px-2 text-xs font-normal', props.className)}
+  >
+    {props.children}
+  </Button>
+);
+
+const TypeRow = (props: { type: unknown; onNavigate: (name: string) => void }) => {
+  const named = namedTypeOf(props.type);
+
+  return (
+    <button
+      type="button"
+      className="cursor-pointer"
+      onClick={() => named && props.onNavigate(named.name)}
+    >
+      <GraphQLType type={props.type as never} />
+    </button>
+  );
+};
+
+const ArgumentRow = (props: { arg: GraphQLArgument; onNavigate: (name: string) => void }) => (
+  <div className="flex flex-col gap-0.5 px-2 py-1 text-xs">
+    <div className="flex flex-wrap items-center gap-1">
+      <span className="text-rose-400">{props.arg.name}</span>
+      <span className="text-muted-foreground">:</span>
+      <TypeRow type={props.arg.type} onNavigate={props.onNavigate} />
+      {props.arg.defaultValue === undefined ? null : (
+        <span className="text-muted-foreground">= {JSON.stringify(props.arg.defaultValue)}</span>
+      )}
+    </div>
+    <Description description={props.arg.description} />
+    {props.arg.deprecationReason ? (
+      <DeprecationBadge reason={props.arg.deprecationReason} />
+    ) : null}
+  </div>
+);
+
+const EnumValueRow = (props: { value: GraphQLEnumValue }) => (
+  <div className="flex flex-col gap-0.5 px-2 py-1 text-xs">
+    <span className="text-teal-400">{props.value.name}</span>
+    <Description description={props.value.description} />
+    {props.value.deprecationReason ? (
+      <DeprecationBadge reason={props.value.deprecationReason} />
+    ) : null}
+  </div>
+);
+
+export const Docs = () => {
+  const { schema, docsNavStack, pushDocs, popDocs, resetDocs } = useLaboratory();
+  const [searchValue, setSearchValue] = useState('');
+  const deferredSearch = useDeferredValue(searchValue);
+  const isSearchActive = deferredSearch.trim().length > 0;
+
+  const searchResult = useMemo(
+    () => searchSchemaDocs(schema ?? null, deferredSearch),
+    [schema, deferredSearch],
+  );
+
+  const goToType = (name: string) => pushDocs({ kind: 'type', name });
+  const goToField = (typeName: string, fieldName: string) =>
+    pushDocs({ kind: 'field', typeName, fieldName });
+
+  const target = docsNavStack.at(-1) ?? null;
+
+  // A target names a type that an endpoint switch or a poll may have removed, so
+  // resolution can fail; falling back to the root beats a blank pane.
+  const resolved = useMemo(() => {
+    if (!schema || !target) {
+      return null;
+    }
+
+    const type = schema.getType(target.kind === 'type' ? target.name : target.typeName);
+
+    if (!type) {
+      return null;
+    }
+
+    if (target.kind === 'type') {
+      return { kind: 'type' as const, type };
+    }
+
+    if (!isObjectType(type) && !isInterfaceType(type) && !isInputObjectType(type)) {
+      return null;
+    }
+
+    const field = type.getFields()[target.fieldName];
+
+    return field ? { kind: 'field' as const, type, field } : null;
+  }, [schema, target]);
+
+  const title = useMemo(() => {
+    if (!resolved) {
+      return 'Documentation';
+    }
+
+    return resolved.kind === 'type' ? resolved.type.name : resolved.field.name;
+  }, [resolved]);
+
+  const renderRoot = () => {
+    if (!schema) {
+      return null;
+    }
+
+    const roots = [
+      { label: 'Query', type: schema.getQueryType() },
+      { label: 'Mutation', type: schema.getMutationType() },
+      { label: 'Subscription', type: schema.getSubscriptionType() },
+    ].filter(root => root.type);
+
+    return (
+      <Section title="Root types">
+        {roots.map(root => (
+          <Row key={root.label} onClick={() => goToType(root.type!.name)}>
+            <span className="text-muted-foreground">{root.label}:</span>
+            <span className="text-amber-400">{root.type!.name}</span>
+          </Row>
+        ))}
+      </Section>
+    );
+  };
+
+  const renderType = (type: GraphQLNamedType) => {
+    const sections: React.ReactNode[] = [];
+
+    if (isObjectType(type) || isInterfaceType(type) || isInputObjectType(type)) {
+      const fields = Object.values(type.getFields());
+
+      if (fields.length > 0) {
+        sections.push(
+          <Section key="fields" title="Fields">
+            {fields.map(field => (
+              <Row key={field.name} onClick={() => goToField(type.name, field.name)}>
+                <span className="text-rose-400">{field.name}</span>
+                <span className="text-muted-foreground">:</span>
+                <GraphQLType type={field.type} />
+                {'deprecationReason' in field && field.deprecationReason ? (
+                  <Badge variant="outline" className="text-muted-foreground ml-auto">
+                    Deprecated
+                  </Badge>
+                ) : null}
+              </Row>
+            ))}
+          </Section>,
+        );
+      }
+    }
+
+    if (isObjectType(type) || isInterfaceType(type)) {
+      const interfaces = type.getInterfaces();
+
+      if (interfaces.length > 0) {
+        sections.push(
+          <Section key="implements" title="Implements">
+            {interfaces.map(iface => (
+              <Row key={iface.name} onClick={() => goToType(iface.name)}>
+                <span className="text-amber-400">{iface.name}</span>
+              </Row>
+            ))}
+          </Section>,
+        );
+      }
+    }
+
+    if (isUnionType(type) || isInterfaceType(type)) {
+      const possible = isUnionType(type) ? type.getTypes() : schema?.getPossibleTypes(type) ?? [];
+
+      if (possible.length > 0) {
+        sections.push(
+          <Section key="possible" title={isUnionType(type) ? 'Possible types' : 'Implementations'}>
+            {possible.map(possibleType => (
+              <Row key={possibleType.name} onClick={() => goToType(possibleType.name)}>
+                <span className="text-amber-400">{possibleType.name}</span>
+              </Row>
+            ))}
+          </Section>,
+        );
+      }
+    }
+
+    if (isEnumType(type)) {
+      sections.push(
+        <Section key="values" title="Enum values">
+          {type.getValues().map(value => (
+            <EnumValueRow key={value.name} value={value} />
+          ))}
+        </Section>,
+      );
+    }
+
+    return (
+      <>
+        <Description description={type.description} />
+        {sections}
+      </>
+    );
+  };
+
+  const renderField = (
+    type: GraphQLNamedType,
+    field: GraphQLField<unknown, unknown> | GraphQLInputField,
+  ) => {
+    const args = 'args' in field ? field.args : [];
+
+    return (
+      <>
+        <div className="text-muted-foreground px-2 pt-2 text-xs">
+          on <span className="text-amber-400">{type.name}</span>
+        </div>
+        <Description description={field.description} />
+        {field.deprecationReason ? <DeprecationBadge reason={field.deprecationReason} /> : null}
+        <Section title="Type">
+          <div className="px-2 py-1 text-xs">
+            <TypeRow type={field.type} onNavigate={goToType} />
+          </div>
+        </Section>
+        {args.length > 0 ? (
+          <Section title="Arguments">
+            {args.map(arg => (
+              <ArgumentRow key={arg.name} arg={arg} onNavigate={goToType} />
+            ))}
+          </Section>
+        ) : null}
+      </>
+    );
+  };
+
+  const renderSearch = () => {
+    const isEmpty =
+      searchResult.types.length === 0 &&
+      searchResult.fields.length === 0 &&
+      searchResult.enumValues.length === 0;
+
+    if (isEmpty) {
+      return (
+        <Empty className="px-0! w-full">
+          <EmptyHeader>
+            <EmptyTitle className="text-base">No matches</EmptyTitle>
+            <EmptyDescription className="text-xs">
+              Nothing in this schema matches "{deferredSearch}".
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      );
+    }
+
+    return (
+      <>
+        {searchResult.types.length > 0 ? (
+          <Section title="Types">
+            {searchResult.types.map(type => (
+              <Row key={type.name} onClick={() => goToType(type.name)}>
+                <span className="text-amber-400">{type.name}</span>
+              </Row>
+            ))}
+          </Section>
+        ) : null}
+        {searchResult.fields.length > 0 ? (
+          <Section title="Fields">
+            {searchResult.fields.map(field => (
+              <Row
+                key={`${field.typeName}.${field.fieldName}`}
+                onClick={() => goToField(field.typeName, field.fieldName)}
+              >
+                <span className="text-muted-foreground">{field.typeName}.</span>
+                <span className="text-rose-400">{field.fieldName}</span>
+              </Row>
+            ))}
+          </Section>
+        ) : null}
+        {searchResult.enumValues.length > 0 ? (
+          <Section title="Enum values">
+            {searchResult.enumValues.map(value => (
+              <Row
+                key={`${value.typeName}.${value.valueName}`}
+                onClick={() => goToType(value.typeName)}
+              >
+                <span className="text-muted-foreground">{value.typeName}.</span>
+                <span className="text-teal-400">{value.valueName}</span>
+              </Row>
+            ))}
+          </Section>
+        ) : null}
+      </>
+    );
+  };
+
+  const renderBody = () => {
+    if (!schema) {
+      return (
+        <Empty className="px-0! w-full">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <BookOpenIcon className="text-muted-foreground size-6" />
+            </EmptyMedia>
+            <EmptyTitle className="text-base">No schema yet</EmptyTitle>
+            <EmptyDescription className="text-xs">
+              Documentation appears once the Laboratory has introspected your endpoint.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      );
+    }
+
+    if (isSearchActive) {
+      return renderSearch();
+    }
+
+    if (!resolved) {
+      return renderRoot();
+    }
+
+    return resolved.kind === 'type'
+      ? renderType(resolved.type)
+      : renderField(resolved.type, resolved.field);
+  };
+
+  return (
+    <div className="grid size-full grid-rows-[auto_auto_1fr] pb-0">
+      <div className="border-border flex h-12 items-center gap-2 border-b p-3">
+        {docsNavStack.length > 0 && !isSearchActive ? (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="text-muted-foreground hover:text-foreground p-1! size-6 rounded-sm"
+            onClick={popDocs}
+          >
+            <ChevronLeftIcon className="size-4" />
+          </Button>
+        ) : null}
+        <span className="truncate text-base font-medium">{title}</span>
+        {docsNavStack.length > 0 && !isSearchActive ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-foreground ml-auto h-6 px-2 text-xs"
+            onClick={resetDocs}
+          >
+            Root
+          </Button>
+        ) : null}
+      </div>
+      <div className="border-border border-b p-3">
+        <InputGroup>
+          <InputGroupInput
+            placeholder="Search the schema"
+            value={searchValue}
+            onChange={e => setSearchValue(e.currentTarget.value)}
+          />
+          <InputGroupAddon>
+            <SearchIcon className="text-muted-foreground size-4" />
+          </InputGroupAddon>
+        </InputGroup>
+      </div>
+      <div className="size-full overflow-hidden">
+        <ScrollArea className="size-full">
+          <div className="flex flex-col gap-1 p-3">{renderBody()}</div>
+          <ScrollBar />
+        </ScrollArea>
+      </div>
+    </div>
+  );
+};

--- a/packages/libraries/laboratory/src/components/laboratory/docs.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/docs.tsx
@@ -65,6 +65,42 @@ const Row = (props: { onClick?: () => void; children: React.ReactNode; className
   </Button>
 );
 
+/**
+ * Descriptions are plain text here rather than markdown: the row is a button, and
+ * a rendered link inside one is both invalid and unclickable. The field view shows
+ * the full markdown.
+ */
+const FieldRow = (props: {
+  name: string;
+  type: unknown;
+  description?: string | null;
+  isDeprecated?: boolean;
+  onClick: () => void;
+}) => (
+  <Button
+    variant="ghost"
+    size="sm"
+    onClick={props.onClick}
+    className="h-auto w-full flex-col items-start gap-0.5 px-2 py-1.5 text-xs font-normal"
+  >
+    <div className="flex w-full items-center gap-1">
+      <span className="text-rose-400">{props.name}</span>
+      <span className="text-muted-foreground">:</span>
+      <GraphQLType type={props.type as never} />
+      {props.isDeprecated ? (
+        <Badge variant="outline" className="text-muted-foreground ml-auto">
+          Deprecated
+        </Badge>
+      ) : null}
+    </div>
+    {props.description ? (
+      <span className="text-muted-foreground line-clamp-2 whitespace-normal text-left">
+        {props.description}
+      </span>
+    ) : null}
+  </Button>
+);
+
 const TypeRow = (props: { type: unknown; onNavigate: (name: string) => void }) => {
   const named = namedTypeOf(props.type);
 
@@ -90,9 +126,7 @@ const ArgumentRow = (props: { arg: GraphQLArgument; onNavigate: (name: string) =
       )}
     </div>
     <Description description={props.arg.description} />
-    {props.arg.deprecationReason ? (
-      <DeprecationBadge reason={props.arg.deprecationReason} />
-    ) : null}
+    {props.arg.deprecationReason ? <DeprecationBadge reason={props.arg.deprecationReason} /> : null}
   </div>
 );
 
@@ -163,18 +197,21 @@ export const Docs = () => {
     }
 
     const roots = [
-      { label: 'Query', type: schema.getQueryType() },
-      { label: 'Mutation', type: schema.getMutationType() },
-      { label: 'Subscription', type: schema.getSubscriptionType() },
+      { label: 'query', type: schema.getQueryType() },
+      { label: 'mutation', type: schema.getMutationType() },
+      { label: 'subscription', type: schema.getSubscriptionType() },
     ].filter(root => root.type);
 
     return (
       <Section title="Root types">
         {roots.map(root => (
-          <Row key={root.label} onClick={() => goToType(root.type!.name)}>
-            <span className="text-muted-foreground">{root.label}:</span>
-            <span className="text-amber-400">{root.type!.name}</span>
-          </Row>
+          <FieldRow
+            key={root.label}
+            name={root.label}
+            type={root.type!}
+            description={root.type!.description}
+            onClick={() => goToType(root.type!.name)}
+          />
         ))}
       </Section>
     );
@@ -190,16 +227,14 @@ export const Docs = () => {
         sections.push(
           <Section key="fields" title="Fields">
             {fields.map(field => (
-              <Row key={field.name} onClick={() => goToField(type.name, field.name)}>
-                <span className="text-rose-400">{field.name}</span>
-                <span className="text-muted-foreground">:</span>
-                <GraphQLType type={field.type} />
-                {'deprecationReason' in field && field.deprecationReason ? (
-                  <Badge variant="outline" className="text-muted-foreground ml-auto">
-                    Deprecated
-                  </Badge>
-                ) : null}
-              </Row>
+              <FieldRow
+                key={field.name}
+                name={field.name}
+                type={field.type}
+                description={field.description}
+                isDeprecated={!!field.deprecationReason}
+                onClick={() => goToField(type.name, field.name)}
+              />
             ))}
           </Section>,
         );
@@ -223,7 +258,7 @@ export const Docs = () => {
     }
 
     if (isUnionType(type) || isInterfaceType(type)) {
-      const possible = isUnionType(type) ? type.getTypes() : schema?.getPossibleTypes(type) ?? [];
+      const possible = isUnionType(type) ? type.getTypes() : (schema?.getPossibleTypes(type) ?? []);
 
       if (possible.length > 0) {
         sections.push(

--- a/packages/libraries/laboratory/src/components/laboratory/editor.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/editor.tsx
@@ -139,7 +139,7 @@ export type EditorProps = React.ComponentProps<typeof MonacoEditor> & {
 const EditorInner = forwardRef<EditorHandle, EditorProps>((props, ref) => {
   const id = useId();
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
-  const { introspection, endpoint, theme } = useLaboratory();
+  const { introspection, endpoint, theme, enableDocs } = useLaboratory();
   const wantsJson = props.language === 'json' || props.defaultLanguage === 'json';
   const [typescriptReady, setTypescriptReady] = useState(!!monaco.languages.typescript);
   const [jsonReady, setJsonReady] = useState(
@@ -155,8 +155,9 @@ const EditorInner = forwardRef<EditorHandle, EditorProps>((props, ref) => {
       schemaUri: `schema_${endpoint}.graphql`,
       operationUri: props.uri?.toString(),
       variablesUri: props.variablesUri?.toString(),
+      enableDocs,
     });
-  }, [endpoint, introspection, props.uri?.toString(), props.variablesUri?.toString()]);
+  }, [endpoint, introspection, enableDocs, props.uri?.toString(), props.variablesUri?.toString()]);
 
   useEffect(() => {
     void (async function () {

--- a/packages/libraries/laboratory/src/components/laboratory/laboratory.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/laboratory.tsx
@@ -9,11 +9,12 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import laboratoryStyles from '../../index.css?inline';
-import { FileIcon, FoldersIcon, HistoryIcon, SettingsIcon } from 'lucide-react';
+import { BookOpenIcon, FileIcon, FoldersIcon, HistoryIcon, SettingsIcon } from 'lucide-react';
 import monacoStyles from 'monaco-editor/min/vs/editor/editor.main.css?inline';
 import * as z from 'zod';
 import { useForm } from '@tanstack/react-form';
 import { useCollections } from '../../lib/collections';
+import { useDocs } from '../../lib/docs';
 import { ensureDocumentFontFaces } from '../../lib/document-styles';
 import { useEndpoint } from '../../lib/endpoint';
 import { useEnv } from '../../lib/env';
@@ -59,6 +60,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '../ui/resi
 import { Toaster } from '../ui/sonner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { Collections } from './collections';
+import { Docs } from './docs';
 import { Command } from './command';
 import {
   LaboratoryPermission,
@@ -215,7 +217,6 @@ const LaboratoryContent = () => {
   const {
     activeTab,
     addOperation,
-    collections,
     addTab,
     setActiveTab,
     preflight,
@@ -224,11 +225,11 @@ const LaboratoryContent = () => {
     plugins,
     pluginsState,
     setPluginsState,
+    activePanel,
+    setActivePanel,
+    enableDocs,
   } = useLaboratory();
   const laboratory = useLaboratory();
-  const [activePanel, setActivePanel] = useState<
-    'collections' | 'history' | 'tests' | 'settings' | null
-  >(collections.length > 0 ? 'collections' : null);
   const [commandOpen, setCommandOpen] = useState(false);
 
   const contentNode = useMemo(() => {
@@ -360,6 +361,32 @@ const LaboratoryContent = () => {
           </TooltipTrigger>
           <TooltipContent side="right">History</TooltipContent>
         </Tooltip>
+        {enableDocs ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={cn(
+                  'relative z-10 flex aspect-square h-12 w-full items-center justify-center border-l-2 border-transparent',
+                  {
+                    'border-primary': activePanel === 'docs',
+                  },
+                )}
+              >
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setActivePanel(activePanel === 'docs' ? null : 'docs')}
+                  className={cn('text-muted-foreground hover:text-foreground', {
+                    'text-foreground': activePanel === 'docs',
+                  })}
+                >
+                  <BookOpenIcon className="size-5" />
+                </Button>
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="right">Documentation</TooltipContent>
+          </Tooltip>
+        ) : null}
         <div
           className={cn(
             'z-100 relative mt-auto flex aspect-square h-12 w-full items-center justify-center border-l-2 border-transparent',
@@ -445,6 +472,7 @@ const LaboratoryContent = () => {
         <ResizablePanel minSize={10} defaultSize={17} hidden={!activePanel} className="border-l">
           {activePanel === 'collections' && <Collections />}
           {activePanel === 'history' && <History />}
+          {activePanel === 'docs' && <Docs />}
         </ResizablePanel>
         <ResizableHandle />
         <ResizablePanel minSize={10} defaultSize={83} className="flex flex-col">
@@ -537,6 +565,9 @@ export const Laboratory = (
   const collectionsApi = useCollections({
     ...props,
     tabsApi,
+  });
+  const docsApi = useDocs({
+    defaultActivePanel: collectionsApi.collections.length > 0 ? 'collections' : null,
   });
   const operationsApi = useOperations({
     ...props,
@@ -688,6 +719,7 @@ export const Laboratory = (
           {...collectionsApi}
           {...operationsApi}
           {...historyApi}
+          {...docsApi}
           container={container}
           openAddCollectionDialog={openAddCollectionDialog}
           openUpdateEndpointDialog={openUpdateEndpointDialog}

--- a/packages/libraries/laboratory/src/components/laboratory/laboratory.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/laboratory.tsx
@@ -505,6 +505,7 @@ export const Laboratory = (
       | 'theme'
       | 'defaultSchemaIntrospection'
       | 'enableFullScreen'
+      | 'enableDocs'
     >
   >,
 ) => {
@@ -696,6 +697,7 @@ export const Laboratory = (
           exitFullScreen={exitFullScreen}
           isFullScreen={isFullScreen}
           enableFullScreen={props.enableFullScreen !== false}
+          enableDocs={props.enableDocs === true}
           checkPermissions={checkPermissions}
         >
           <Dialog open={isUpdateEndpointDialogOpen} onOpenChange={setIsUpdateEndpointDialogOpen}>

--- a/packages/libraries/laboratory/src/components/laboratory/laboratory.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/laboratory.tsx
@@ -1,6 +1,7 @@
 import {
   ReactNode,
   useCallback,
+  useEffect,
   useInsertionEffect,
   useLayoutEffect,
   useMemo,
@@ -15,6 +16,7 @@ import * as z from 'zod';
 import { useForm } from '@tanstack/react-form';
 import { useCollections } from '../../lib/collections';
 import { useDocs } from '../../lib/docs';
+import { registerDocsHover } from '../../lib/docs-hover';
 import { ensureDocumentFontFaces } from '../../lib/document-styles';
 import { useEndpoint } from '../../lib/endpoint';
 import { useEnv } from '../../lib/env';
@@ -60,7 +62,6 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '../ui/resi
 import { Toaster } from '../ui/sonner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { Collections } from './collections';
-import { Docs } from './docs';
 import { Command } from './command';
 import {
   LaboratoryPermission,
@@ -69,6 +70,7 @@ import {
   useLaboratory,
   type LaboratoryApi,
 } from './context';
+import { Docs } from './docs';
 import { Env } from './env';
 import { History } from './history';
 import { HistoryItem } from './history-item';
@@ -228,9 +230,27 @@ const LaboratoryContent = () => {
     activePanel,
     setActivePanel,
     enableDocs,
+    openDocs,
+    schema,
   } = useLaboratory();
   const laboratory = useLaboratory();
   const [commandOpen, setCommandOpen] = useState(false);
+
+  // Read through a ref so a schema poll does not tear down and re-register the
+  // provider, which would drop an open hover.
+  const schemaRef = useRef(schema);
+  schemaRef.current = schema;
+
+  useEffect(() => {
+    if (!enableDocs) {
+      return;
+    }
+
+    return registerDocsHover({
+      getSchema: () => schemaRef.current ?? null,
+      openDocs,
+    });
+  }, [enableDocs, openDocs]);
 
   const contentNode = useMemo(() => {
     switch (activeTab?.type) {

--- a/packages/libraries/laboratory/src/components/laboratory/settings.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/settings.tsx
@@ -20,7 +20,6 @@ const settingsFormSchema = z.object({
   }),
   introspection: z.object({
     method: z.enum(['GET', 'POST']).optional(),
-    schemaDescription: z.boolean().optional(),
     headers: z.string().optional(),
     includeActiveOperationHeaders: z.boolean().optional(),
   }),
@@ -184,20 +183,6 @@ export const Settings = () => {
                           <SelectItem value="POST">POST</SelectItem>
                         </SelectContent>
                       </Select>
-                    </Field>
-                  );
-                }}
-              </form.Field>
-              <form.Field name="introspection.schemaDescription">
-                {field => {
-                  return (
-                    <Field className="flex-row items-center">
-                      <Switch
-                        className="!w-8"
-                        checked={field.state.value ?? false}
-                        onCheckedChange={field.handleChange}
-                      />
-                      <FieldLabel htmlFor={field.name}>Schema description</FieldLabel>
                     </Field>
                   );
                 }}

--- a/packages/libraries/laboratory/src/components/markdown.spec.tsx
+++ b/packages/libraries/laboratory/src/components/markdown.spec.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+// happy-dom's parser drops elements DOMPurify would have kept (`<strong>`, `<a>`),
+// which makes the "was it stripped?" assertions below pass for the wrong reason.
+import { render } from '@testing-library/react';
+import { Markdown } from './markdown';
+
+// Descriptions come from whatever endpoint the Lab is pointed at, so these are the
+// cases that matter: the GraphiQL CVE-2021-41248 class of attack.
+describe('Markdown', () => {
+  const html = (content: string) => render(<Markdown content={content} />).container.innerHTML;
+
+  it('renders ordinary markdown', () => {
+    expect(html('**bold** and `code`')).toContain('<strong>bold</strong>');
+    expect(html('**bold** and `code`')).toContain('<code>code</code>');
+  });
+
+  it('strips script tags', () => {
+    const output = html('before <script>alert(1)</script> after');
+
+    expect(output).not.toContain('<script');
+    expect(output).not.toContain('alert(1)');
+  });
+
+  it('strips event handlers on injected elements', () => {
+    const output = html('<img src=x onerror=alert(1)>');
+
+    expect(output).not.toContain('onerror');
+    expect(output).not.toContain('<img');
+  });
+
+  it('drops javascript: hrefs', () => {
+    const output = html('[click](javascript:alert(1))');
+
+    expect(output).not.toContain('javascript:');
+  });
+
+  it('keeps ordinary links and hardens them', () => {
+    const output = html('[docs](https://example.com)');
+
+    expect(output).toContain('href="https://example.com"');
+    expect(output).toContain('rel="noopener noreferrer"');
+    expect(output).toContain('target="_blank"');
+  });
+
+  it('strips iframes', () => {
+    expect(html('<iframe src="https://evil.test"></iframe>')).not.toContain('<iframe');
+  });
+});

--- a/packages/libraries/laboratory/src/components/markdown.tsx
+++ b/packages/libraries/laboratory/src/components/markdown.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from 'react';
+import dompurify from 'dompurify';
+import snarkdown from 'snarkdown';
+import { cn } from '../lib/utils';
+
+/**
+ * Schema descriptions come from whatever endpoint the user points the Lab at, so
+ * they are untrusted input. snarkdown passes raw HTML straight through, so the
+ * sanitize step is what makes this safe, and it has to run on the rendered HTML
+ * rather than the markdown.
+ */
+const ALLOWED_TAGS = [
+  'p',
+  'a',
+  'code',
+  'pre',
+  'strong',
+  'em',
+  'ul',
+  'ol',
+  'li',
+  'blockquote',
+  'br',
+];
+
+let hooked = false;
+
+const addLinkHardeningHook = () => {
+  if (hooked) {
+    return;
+  }
+
+  hooked = true;
+  dompurify.addHook('afterSanitizeAttributes', node => {
+    if (node.tagName === 'A') {
+      node.setAttribute('rel', 'noopener noreferrer');
+      node.setAttribute('target', '_blank');
+    }
+  });
+};
+
+export const Markdown = (props: { content: string; className?: string }) => {
+  const html = useMemo(() => {
+    addLinkHardeningHook();
+
+    return dompurify.sanitize(snarkdown(props.content), {
+      ALLOWED_TAGS,
+      ALLOWED_ATTR: ['href', 'title'],
+    });
+  }, [props.content]);
+
+  return (
+    <div
+      data-slot="markdown"
+      className={cn(
+        'text-muted-foreground [&_a]:text-primary text-xs leading-relaxed [&_a]:underline [&_code]:rounded [&_code]:bg-black/20 [&_code]:px-1 [&_code]:py-0.5',
+        props.className,
+      )}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+};

--- a/packages/libraries/laboratory/src/index.spec.tsx
+++ b/packages/libraries/laboratory/src/index.spec.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { act } from '@testing-library/react';
+import { renderLaboratory } from './index';
+
+const Laboratory = vi.hoisted(() => vi.fn((_props: Record<string, unknown>) => null));
+
+vi.mock('./components/laboratory/laboratory', () => ({ Laboratory }));
+
+// `index.tsx` re-exports the whole package, which drags in Monaco and its workers.
+vi.mock('monaco-editor', () => ({ editor: {}, languages: {}, Uri: {} }));
+vi.mock('@monaco-editor/react', () => ({ default: () => null, loader: { config: () => {} } }));
+vi.mock('./components/laboratory/editor', () => ({ Editor: () => null }));
+vi.mock('./components/ui/dialog', () => ({}));
+vi.mock('./components/ui/tabs', () => ({}));
+
+describe('renderLaboratory', () => {
+  beforeEach(() => {
+    Laboratory.mockClear();
+    localStorage.clear();
+  });
+
+  const mount = (props = {}) => {
+    const el = document.createElement('div');
+    document.body.append(el);
+
+    // createRoot().render() is async, so the props are not readable until flushed.
+    act(() => {
+      renderLaboratory(el, props);
+    });
+
+    return Laboratory.mock.lastCall?.[0];
+  };
+
+  // Standalone embedders (Hive Router) call this global directly and pass no props.
+  it('enables the docs pane by default', () => {
+    expect(mount()?.enableDocs).toBe(true);
+  });
+
+  it('lets the host turn it back off', () => {
+    expect(mount({ enableDocs: false })?.enableDocs).toBe(false);
+  });
+});

--- a/packages/libraries/laboratory/src/index.tsx
+++ b/packages/libraries/laboratory/src/index.tsx
@@ -6,6 +6,7 @@ export * from './components/laboratory/context';
 export * from './components/laboratory/editor';
 export * from './components/ui/dialog';
 export * from './components/ui/tabs';
+export * from './lib/docs';
 export * from './lib/endpoint';
 export * from './lib/collections';
 export * from './lib/env';

--- a/packages/libraries/laboratory/src/index.tsx
+++ b/packages/libraries/laboratory/src/index.tsx
@@ -37,6 +37,9 @@ export const renderLaboratory = (el: HTMLElement, props: LaboratoryProps) => {
   return ReactDOM.createRoot(el).render(
     <Laboratory
       theme="dark"
+      // Standalone embedders have no other schema reference, so docs are on by
+      // default here. Spread last, `props` still wins.
+      enableDocs
       defaultEndpoint={
         getLocalStorage('endpoint') ?? window.location.origin + window.location.pathname
       }

--- a/packages/libraries/laboratory/src/lib/docs-hover.ts
+++ b/packages/libraries/laboratory/src/lib/docs-hover.ts
@@ -1,0 +1,96 @@
+import { getNamedType, type GraphQLSchema } from 'graphql';
+import { getContextAtPosition, getHoverInformation, Position } from 'graphql-language-service';
+import * as monaco from 'monaco-editor';
+import type { LaboratoryDocsTarget } from './docs';
+
+export const OPEN_DOCS_COMMAND_ID = 'hive-laboratory.openDocs';
+
+/** graphql-language-service positions are 0-based, Monaco's are 1-based. */
+const toLanguageServicePosition = (position: monaco.IPosition) =>
+  new Position(position.lineNumber - 1, position.column - 1);
+
+export const docsTargetAtPosition = (
+  schema: GraphQLSchema,
+  text: string,
+  position: monaco.IPosition,
+): LaboratoryDocsTarget | null => {
+  const context = getContextAtPosition(text, toLanguageServicePosition(position), schema);
+
+  if (!context) {
+    return null;
+  }
+
+  const { typeInfo } = context;
+
+  if (typeInfo.fieldDef && typeInfo.parentType) {
+    return {
+      kind: 'field',
+      typeName: getNamedType(typeInfo.parentType).name,
+      fieldName: typeInfo.fieldDef.name,
+    };
+  }
+
+  const type = typeInfo.type ?? typeInfo.inputType;
+
+  return type ? { kind: 'type', name: getNamedType(type).name } : null;
+};
+
+/**
+ * monaco-graphql owns the GraphQL hover, and its content is produced in a worker
+ * we cannot reach into. Rather than stack a second hover card next to it, the mode
+ * config turns theirs off (see `syncMonacoGraphQL`) and this provider rebuilds it
+ * from the same `getHoverInformation` call, with the docs link appended.
+ */
+export const registerDocsHover = (options: {
+  getSchema: () => GraphQLSchema | null;
+  openDocs: (target?: LaboratoryDocsTarget) => void;
+}) => {
+  const command = monaco.editor.registerCommand(OPEN_DOCS_COMMAND_ID, (_accessor, ...args) => {
+    options.openDocs(args[0] as LaboratoryDocsTarget | undefined);
+  });
+
+  const provider = monaco.languages.registerHoverProvider('graphql', {
+    provideHover(model, position) {
+      const schema = options.getSchema();
+
+      if (!schema) {
+        return null;
+      }
+
+      const text = model.getValue();
+      const info = getHoverInformation(
+        schema,
+        text,
+        toLanguageServicePosition(position),
+        undefined,
+        {
+          useMarkdown: true,
+        },
+      );
+
+      if (!info || typeof info !== 'string') {
+        return null;
+      }
+
+      const contents: monaco.IMarkdownString[] = [{ value: info }];
+      const target = docsTargetAtPosition(schema, text, position);
+
+      if (target) {
+        contents.push({
+          // Command links only run from trusted markdown.
+          isTrusted: true,
+          value: `[Open in Docs](command:${OPEN_DOCS_COMMAND_ID}?${encodeURIComponent(
+            JSON.stringify([target]),
+          )})`,
+        });
+      }
+
+      return { contents };
+    },
+  });
+
+  return () => {
+    provider.dispose();
+    command.dispose();
+  };
+};

--- a/packages/libraries/laboratory/src/lib/docs-search.spec.ts
+++ b/packages/libraries/laboratory/src/lib/docs-search.spec.ts
@@ -1,0 +1,66 @@
+import { buildSchema } from 'graphql';
+import { searchSchemaDocs } from './docs-search';
+
+const schema = buildSchema(`
+  input UserFilter { nameContains: String }
+  enum UserRole { ADMIN VIEWER }
+  type User { id: ID!, displayName: String, role: UserRole }
+  type Query { users(filter: UserFilter): [User!]! }
+`);
+
+describe('searchSchemaDocs', () => {
+  it('returns nothing for an empty search', () => {
+    expect(searchSchemaDocs(schema, '  ')).toEqual({
+      types: [],
+      fields: [],
+      enumValues: [],
+      hasMore: false,
+    });
+  });
+
+  it('returns nothing without a schema', () => {
+    expect(searchSchemaDocs(null, 'user').types).toEqual([]);
+  });
+
+  it('matches type names case-insensitively', () => {
+    const result = searchSchemaDocs(schema, 'user');
+
+    expect(result.types.map(type => type.name)).toEqual(
+      expect.arrayContaining(['User', 'UserFilter', 'UserRole']),
+    );
+  });
+
+  it('matches fields', () => {
+    const result = searchSchemaDocs(schema, 'displayname');
+
+    expect(result.fields).toEqual([{ typeName: 'User', fieldName: 'displayName' }]);
+  });
+
+  // The Builder's path search walks out from the root operation types, so it never
+  // reaches an input object only referenced as an argument.
+  it('finds input object types and their fields', () => {
+    const result = searchSchemaDocs(schema, 'namecontains');
+
+    expect(result.fields).toEqual([{ typeName: 'UserFilter', fieldName: 'nameContains' }]);
+  });
+
+  it('finds enum values', () => {
+    const result = searchSchemaDocs(schema, 'admin');
+
+    expect(result.enumValues).toEqual([{ typeName: 'UserRole', valueName: 'ADMIN' }]);
+  });
+
+  it('excludes introspection types', () => {
+    const result = searchSchemaDocs(schema, 'type');
+
+    expect(result.types.every(type => !type.name.startsWith('__'))).toBe(true);
+    expect(result.fields.every(field => !field.typeName.startsWith('__'))).toBe(true);
+  });
+
+  it('caps results and reports that it truncated', () => {
+    const result = searchSchemaDocs(schema, 'e', { maxResults: 2 });
+
+    expect(result.hasMore).toBe(true);
+    expect(result.types.length + result.fields.length + result.enumValues.length).toBe(2);
+  });
+});

--- a/packages/libraries/laboratory/src/lib/docs-search.ts
+++ b/packages/libraries/laboratory/src/lib/docs-search.ts
@@ -1,0 +1,86 @@
+import {
+  isEnumType,
+  isInputObjectType,
+  isInterfaceType,
+  isObjectType,
+  type GraphQLNamedType,
+  type GraphQLSchema,
+} from 'graphql';
+
+export interface DocsSearchResult {
+  types: GraphQLNamedType[];
+  fields: { typeName: string; fieldName: string }[];
+  enumValues: { typeName: string; valueName: string }[];
+  hasMore: boolean;
+}
+
+const EMPTY: DocsSearchResult = { types: [], fields: [], enumValues: [], hasMore: false };
+
+/**
+ * Walks the type map rather than reusing the Builder's `searchSchemaPaths`, which
+ * only follows field paths out from the root operation types and stops at depth 8.
+ * Docs has to reach input objects, argument types and enum values, none of which
+ * that traversal can see.
+ */
+export const searchSchemaDocs = (
+  schema: GraphQLSchema | null,
+  search: string,
+  options?: { maxResults?: number },
+): DocsSearchResult => {
+  const normalized = search.trim().toLowerCase();
+
+  if (!schema || !normalized) {
+    return EMPTY;
+  }
+
+  const maxResults = options?.maxResults ?? 100;
+  const result: DocsSearchResult = { types: [], fields: [], enumValues: [], hasMore: false };
+
+  let count = 0;
+  const room = () => {
+    if (count >= maxResults) {
+      result.hasMore = true;
+      return false;
+    }
+    count++;
+    return true;
+  };
+
+  for (const type of Object.values(schema.getTypeMap())) {
+    if (type.name.startsWith('__')) {
+      continue;
+    }
+
+    if (type.name.toLowerCase().includes(normalized)) {
+      if (!room()) {
+        return result;
+      }
+      result.types.push(type);
+    }
+
+    if (isObjectType(type) || isInterfaceType(type) || isInputObjectType(type)) {
+      for (const field of Object.values(type.getFields())) {
+        if (field.name.toLowerCase().includes(normalized)) {
+          if (!room()) {
+            return result;
+          }
+          result.fields.push({ typeName: type.name, fieldName: field.name });
+        }
+      }
+      continue;
+    }
+
+    if (isEnumType(type)) {
+      for (const value of type.getValues()) {
+        if (value.name.toLowerCase().includes(normalized)) {
+          if (!room()) {
+            return result;
+          }
+          result.enumValues.push({ typeName: type.name, valueName: value.name });
+        }
+      }
+    }
+  }
+
+  return result;
+};

--- a/packages/libraries/laboratory/src/lib/docs.spec.ts
+++ b/packages/libraries/laboratory/src/lib/docs.spec.ts
@@ -1,6 +1,63 @@
 // @vitest-environment happy-dom
+import { buildSchema } from 'graphql';
 import { act, renderHook } from '@testing-library/react';
-import { useDocs } from './docs';
+import { docsTargetFromPath, useDocs } from './docs';
+
+const schema = buildSchema(`
+  interface Node { id: ID! }
+  type Address { city: String }
+  type Profile implements Node { id: ID!, address: Address }
+  type User implements Node { id: ID!, profile: Profile }
+  type Query { me: User }
+  type Mutation { signIn: User }
+`);
+
+describe('docsTargetFromPath', () => {
+  it('resolves a root field to its operation type', () => {
+    expect(docsTargetFromPath(['query', 'me'], schema)).toEqual({
+      kind: 'field',
+      typeName: 'Query',
+      fieldName: 'me',
+    });
+  });
+
+  it('resolves a nested field to its immediate parent type', () => {
+    expect(docsTargetFromPath(['query', 'me', 'profile', 'address'], schema)).toEqual({
+      kind: 'field',
+      typeName: 'Profile',
+      fieldName: 'address',
+    });
+  });
+
+  it('walks through interfaces', () => {
+    expect(docsTargetFromPath(['query', 'me', 'profile', 'id'], schema)).toEqual({
+      kind: 'field',
+      typeName: 'Profile',
+      fieldName: 'id',
+    });
+  });
+
+  it('resolves mutation roots', () => {
+    expect(docsTargetFromPath(['mutation', 'signIn'], schema)).toEqual({
+      kind: 'field',
+      typeName: 'Mutation',
+      fieldName: 'signIn',
+    });
+  });
+
+  it('returns null for an unknown field', () => {
+    expect(docsTargetFromPath(['query', 'nope'], schema)).toBeNull();
+  });
+
+  it('returns null for an operation the schema does not define', () => {
+    expect(docsTargetFromPath(['subscription', 'anything'], schema)).toBeNull();
+  });
+
+  it('returns null without a schema or a field segment', () => {
+    expect(docsTargetFromPath(['query', 'me'], null)).toBeNull();
+    expect(docsTargetFromPath(['query'], schema)).toBeNull();
+  });
+});
 
 describe('useDocs', () => {
   it('starts on the root view', () => {

--- a/packages/libraries/laboratory/src/lib/docs.spec.ts
+++ b/packages/libraries/laboratory/src/lib/docs.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react';
+import { useDocs } from './docs';
+
+describe('useDocs', () => {
+  it('starts on the root view', () => {
+    const { result } = renderHook(() => useDocs({}));
+
+    expect(result.current.docsNavStack).toEqual([]);
+    expect(result.current.activePanel).toBeNull();
+  });
+
+  it('honours the default active panel', () => {
+    const { result } = renderHook(() => useDocs({ defaultActivePanel: 'collections' }));
+
+    expect(result.current.activePanel).toBe('collections');
+  });
+
+  it('opens the pane and pushes the target in one step', () => {
+    const { result } = renderHook(() => useDocs({}));
+
+    act(() => {
+      result.current.openDocs({ kind: 'type', name: 'User' });
+    });
+
+    expect(result.current.activePanel).toBe('docs');
+    expect(result.current.docsNavStack).toEqual([{ kind: 'type', name: 'User' }]);
+  });
+
+  it('opens the pane without a target, leaving the stack alone', () => {
+    const { result } = renderHook(() => useDocs({}));
+
+    act(() => {
+      result.current.openDocs();
+    });
+
+    expect(result.current.activePanel).toBe('docs');
+    expect(result.current.docsNavStack).toEqual([]);
+  });
+
+  it('pops back one level at a time', () => {
+    const { result } = renderHook(() => useDocs({}));
+
+    act(() => {
+      result.current.pushDocs({ kind: 'type', name: 'User' });
+    });
+    act(() => {
+      result.current.pushDocs({ kind: 'field', typeName: 'User', fieldName: 'id' });
+    });
+    act(() => {
+      result.current.popDocs();
+    });
+
+    expect(result.current.docsNavStack).toEqual([{ kind: 'type', name: 'User' }]);
+  });
+
+  it('resets all the way to the root', () => {
+    const { result } = renderHook(() => useDocs({}));
+
+    act(() => {
+      result.current.pushDocs({ kind: 'type', name: 'User' });
+    });
+    act(() => {
+      result.current.resetDocs();
+    });
+
+    expect(result.current.docsNavStack).toEqual([]);
+  });
+
+  it('holds targets by name so a schema swap cannot strand the stack', () => {
+    const { result } = renderHook(() => useDocs({}));
+
+    act(() => {
+      result.current.pushDocs({ kind: 'field', typeName: 'User', fieldName: 'id' });
+    });
+
+    // Nothing in the stack references a GraphQLSchema object, so a new schema
+    // instance leaves it re-resolvable rather than pointing at a detached type.
+    expect(result.current.docsNavStack).toEqual([
+      { kind: 'field', typeName: 'User', fieldName: 'id' },
+    ]);
+  });
+});

--- a/packages/libraries/laboratory/src/lib/docs.ts
+++ b/packages/libraries/laboratory/src/lib/docs.ts
@@ -1,0 +1,65 @@
+import { useCallback, useState } from 'react';
+
+export type LaboratoryActivePanel = 'collections' | 'history' | 'docs' | 'tests' | 'settings' | null;
+
+/**
+ * Targets are held by name rather than by schema object: a poll or an endpoint
+ * switch replaces every type instance, and a stack of stale references would
+ * keep rendering a schema the user is no longer looking at.
+ */
+export type LaboratoryDocsTarget =
+  | { kind: 'type'; name: string }
+  | { kind: 'field'; typeName: string; fieldName: string };
+
+export interface LaboratoryDocsState {
+  activePanel: LaboratoryActivePanel;
+  /** Empty means the root view listing the operation types. */
+  docsNavStack: LaboratoryDocsTarget[];
+}
+
+export interface LaboratoryDocsActions {
+  setActivePanel: (panel: LaboratoryActivePanel) => void;
+  openDocs: (target?: LaboratoryDocsTarget) => void;
+  pushDocs: (target: LaboratoryDocsTarget) => void;
+  popDocs: () => void;
+  resetDocs: () => void;
+}
+
+export const useDocs = (props: {
+  defaultActivePanel?: LaboratoryActivePanel;
+}): LaboratoryDocsState & LaboratoryDocsActions => {
+  const [activePanel, setActivePanel] = useState<LaboratoryActivePanel>(
+    props.defaultActivePanel ?? null,
+  );
+  const [docsNavStack, setDocsNavStack] = useState<LaboratoryDocsTarget[]>([]);
+
+  const pushDocs = useCallback((target: LaboratoryDocsTarget) => {
+    setDocsNavStack(current => [...current, target]);
+  }, []);
+
+  const popDocs = useCallback(() => {
+    setDocsNavStack(current => current.slice(0, -1));
+  }, []);
+
+  const resetDocs = useCallback(() => {
+    setDocsNavStack([]);
+  }, []);
+
+  const openDocs = useCallback((target?: LaboratoryDocsTarget) => {
+    setActivePanel('docs');
+
+    if (target) {
+      setDocsNavStack(current => [...current, target]);
+    }
+  }, []);
+
+  return {
+    activePanel,
+    docsNavStack,
+    setActivePanel,
+    openDocs,
+    pushDocs,
+    popDocs,
+    resetDocs,
+  };
+};

--- a/packages/libraries/laboratory/src/lib/docs.ts
+++ b/packages/libraries/laboratory/src/lib/docs.ts
@@ -1,6 +1,20 @@
 import { useCallback, useState } from 'react';
+import {
+  getNamedType,
+  isInterfaceType,
+  isObjectType,
+  type GraphQLField,
+  type GraphQLNamedType,
+  type GraphQLSchema,
+} from 'graphql';
 
-export type LaboratoryActivePanel = 'collections' | 'history' | 'docs' | 'tests' | 'settings' | null;
+export type LaboratoryActivePanel =
+  | 'collections'
+  | 'history'
+  | 'docs'
+  | 'tests'
+  | 'settings'
+  | null;
 
 /**
  * Targets are held by name rather than by schema object: a poll or an endpoint
@@ -10,6 +24,52 @@ export type LaboratoryActivePanel = 'collections' | 'history' | 'docs' | 'tests'
 export type LaboratoryDocsTarget =
   | { kind: 'type'; name: string }
   | { kind: 'field'; typeName: string; fieldName: string };
+
+/**
+ * Builder rows identify a field by its dotted path from an operation root
+ * (`query.me.id`), which carries no parent type. Walking it back to one is what
+ * lets a row open the field it actually represents rather than its return type.
+ */
+export const docsTargetFromPath = (
+  path: string[],
+  schema: GraphQLSchema | null,
+): LaboratoryDocsTarget | null => {
+  const [operation, ...segments] = path;
+
+  if (!schema || segments.length === 0) {
+    return null;
+  }
+
+  let type: GraphQLNamedType | null | undefined =
+    operation === 'query'
+      ? schema.getQueryType()
+      : operation === 'mutation'
+        ? schema.getMutationType()
+        : operation === 'subscription'
+          ? schema.getSubscriptionType()
+          : null;
+
+  for (let i = 0; i < segments.length; i++) {
+    if (!type || (!isObjectType(type) && !isInterfaceType(type))) {
+      return null;
+    }
+
+    const parentName = type.name;
+    const field: GraphQLField<unknown, unknown> | undefined = type.getFields()[segments[i]];
+
+    if (!field) {
+      return null;
+    }
+
+    if (i === segments.length - 1) {
+      return { kind: 'field', typeName: parentName, fieldName: field.name };
+    }
+
+    type = getNamedType(field.type);
+  }
+
+  return null;
+};
 
 export interface LaboratoryDocsState {
   activePanel: LaboratoryActivePanel;

--- a/packages/libraries/laboratory/src/lib/endpoint.spec.ts
+++ b/packages/libraries/laboratory/src/lib/endpoint.spec.ts
@@ -141,6 +141,24 @@ describe('useEndpoint', () => {
     });
   });
 
+  describe('descriptions', () => {
+    it('requests them when the docs pane is enabled', async () => {
+      renderHook(() => useEndpoint({ defaultEndpoint: ENDPOINT, enableDocs: true }));
+
+      await advance(600);
+
+      expect(load).toHaveBeenCalledWith(ENDPOINT, expect.objectContaining({ descriptions: true }));
+    });
+
+    it('leaves them out of the payload when the docs pane is disabled', async () => {
+      renderHook(() => useEndpoint({ defaultEndpoint: ENDPOINT }));
+
+      await advance(600);
+
+      expect(load).toHaveBeenCalledWith(ENDPOINT, expect.objectContaining({ descriptions: false }));
+    });
+  });
+
   describe('schema polling', () => {
     const settingsApiWithPolling = (pollSchema: boolean) =>
       ({

--- a/packages/libraries/laboratory/src/lib/endpoint.ts
+++ b/packages/libraries/laboratory/src/lib/endpoint.ts
@@ -50,6 +50,7 @@ export const useEndpoint = (props: {
   defaultEndpoint?: string | null;
   onEndpointChange?: (endpoint: string | null) => void;
   defaultSchemaIntrospection?: IntrospectionQuery | null;
+  enableDocs?: boolean;
   settingsApi?: LaboratorySettingsState & LaboratorySettingsActions;
   operationsApi?: LaboratoryOperationsState & LaboratoryOperationsActions;
   envApi?: LaboratoryEnvState & LaboratoryEnvActions;
@@ -201,7 +202,8 @@ export const useEndpoint = (props: {
             timeout: props.settingsApi?.settings.fetch.timeout,
             useGETForQueries: props.settingsApi?.settings.fetch.useGETForQueries,
             exposeHTTPDetailsInExtensions: true,
-            descriptions: props.settingsApi?.settings.introspection.schemaDescription ?? false,
+            // Only worth the payload when the docs pane can render them.
+            descriptions: props.enableDocs === true,
             method: props.settingsApi?.settings.introspection.method ?? 'POST',
             fetch: (input: string | URL | Request, init?: RequestInit) =>
               fetch(input, {
@@ -247,9 +249,9 @@ export const useEndpoint = (props: {
       endpoint,
       props.defaultEndpoint,
       props.defaultSchemaIntrospection,
+      props.enableDocs,
       props.settingsApi?.settings.fetch.timeout,
       props.settingsApi?.settings.introspection.method,
-      props.settingsApi?.settings.introspection.schemaDescription,
       props.settingsApi?.settings.introspection.headers,
       props.settingsApi?.settings.introspection.includeActiveOperationHeaders,
     ],

--- a/packages/libraries/laboratory/src/lib/monaco-graphql.spec.ts
+++ b/packages/libraries/laboratory/src/lib/monaco-graphql.spec.ts
@@ -4,10 +4,13 @@ import { resetMonacoGraphQLForTests, syncMonacoGraphQL } from './monaco-graphql'
 const setSchemaConfig = vi.fn();
 const setDiagnosticSettings = vi.fn();
 const setCompletionSettings = vi.fn();
+const setModeConfiguration = vi.fn();
 const initializeMode = vi.fn(() => ({
   setSchemaConfig,
   setDiagnosticSettings,
   setCompletionSettings,
+  setModeConfiguration,
+  modeConfiguration: { hovers: true, completionItems: true },
 }));
 
 vi.mock('monaco-graphql/initializeMode', () => ({
@@ -83,5 +86,35 @@ describe('syncMonacoGraphQL', () => {
         },
       }),
     );
+  });
+
+  // Our own provider serves the hover when docs are on, so leaving monaco-graphql's
+  // enabled too would stack two cards.
+  describe('hovers', () => {
+    it('leaves them with monaco-graphql when docs are off', () => {
+      syncMonacoGraphQL({ introspection, schemaUri: 'schema.graphql' });
+
+      expect(initializeMode).toHaveBeenCalledWith(
+        expect.objectContaining({ modeConfiguration: { hovers: true } }),
+      );
+    });
+
+    it('hands them over when docs are on', () => {
+      syncMonacoGraphQL({ introspection, schemaUri: 'schema.graphql', enableDocs: true });
+
+      expect(initializeMode).toHaveBeenCalledWith(
+        expect.objectContaining({ modeConfiguration: { hovers: false } }),
+      );
+    });
+
+    it('updates the handover after the mode is already initialized', () => {
+      syncMonacoGraphQL({ introspection, schemaUri: 'schema.graphql' });
+      syncMonacoGraphQL({ introspection, schemaUri: 'schema.graphql', enableDocs: true });
+
+      // Merged onto the existing config so the other mode features stay on.
+      expect(setModeConfiguration).toHaveBeenLastCalledWith(
+        expect.objectContaining({ hovers: false, completionItems: true }),
+      );
+    });
   });
 });

--- a/packages/libraries/laboratory/src/lib/monaco-graphql.ts
+++ b/packages/libraries/laboratory/src/lib/monaco-graphql.ts
@@ -19,6 +19,11 @@ export type SyncMonacoGraphQLInput = {
   schemaUri: string;
   operationUri?: string;
   variablesUri?: string;
+  /**
+   * Hand the hover to our own provider, which rebuilds the same content and adds
+   * the docs link. Without it monaco-graphql keeps serving hovers as before.
+   */
+  enableDocs?: boolean;
 };
 
 export function syncMonacoGraphQL(input: SyncMonacoGraphQLInput): MonacoGraphQLAPI {
@@ -39,8 +44,10 @@ export function syncMonacoGraphQL(input: SyncMonacoGraphQLInput): MonacoGraphQLA
     jsonDiagnosticSettings: { allowComments: true },
   };
 
+  const hovers = !input.enableDocs;
+
   if (!api) {
-    api = initializeMode({ schemas, diagnosticSettings });
+    api = initializeMode({ schemas, diagnosticSettings, modeConfiguration: { hovers } });
     api.setCompletionSettings({ __experimental__fillLeafsOnComplete: true });
 
     return api;
@@ -48,6 +55,7 @@ export function syncMonacoGraphQL(input: SyncMonacoGraphQLInput): MonacoGraphQLA
 
   api.setSchemaConfig(schemas);
   api.setDiagnosticSettings(diagnosticSettings);
+  api.setModeConfiguration({ ...api.modeConfiguration, hovers });
 
   return api;
 }

--- a/packages/libraries/laboratory/src/lib/settings.ts
+++ b/packages/libraries/laboratory/src/lib/settings.ts
@@ -11,7 +11,6 @@ export type LaboratorySettings = {
   };
   introspection: {
     method?: 'GET' | 'POST';
-    schemaDescription?: boolean;
     headers?: string;
     includeActiveOperationHeaders?: boolean;
     pollSchema?: boolean;
@@ -29,7 +28,6 @@ export const defaultLaboratorySettings: LaboratorySettings = {
   },
   introspection: {
     method: 'POST',
-    schemaDescription: false,
     headers: '',
     includeActiveOperationHeaders: false,
     pollSchema: true,
@@ -50,9 +48,6 @@ export const normalizeLaboratorySettings = (
   },
   introspection: {
     method: settings?.introspection?.method ?? defaultLaboratorySettings.introspection.method,
-    schemaDescription:
-      settings?.introspection?.schemaDescription ??
-      defaultLaboratorySettings.introspection.schemaDescription,
     headers: settings?.introspection?.headers ?? defaultLaboratorySettings.introspection.headers,
     includeActiveOperationHeaders:
       settings?.introspection?.includeActiveOperationHeaders ??

--- a/packages/libraries/laboratory/src/main.tsx
+++ b/packages/libraries/laboratory/src/main.tsx
@@ -10,6 +10,7 @@ import { Laboratory } from './components/laboratory/laboratory';
  */
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <Laboratory
+    enableDocs
     theme="dark"
     defaultEndpoint={`${window.location.origin}/graphql`}
     defaultCollections={devCollections}

--- a/packages/libraries/render-laboratory/src/index.ts
+++ b/packages/libraries/render-laboratory/src/index.ts
@@ -27,7 +27,6 @@ const mapGraphiQLOptionsToLaboratoryProps = (opts?: GraphiQLOptions): Laboratory
       },
       introspection: {
         method: opts.method,
-        schemaDescription: opts.schemaDescription,
       },
     },
   } satisfies LaboratoryProps;

--- a/packages/libraries/render-laboratory/src/index.ts
+++ b/packages/libraries/render-laboratory/src/index.ts
@@ -12,10 +12,11 @@ import {
 
 const mapGraphiQLOptionsToLaboratoryProps = (opts?: GraphiQLOptions): LaboratoryProps => {
   if (!opts) {
-    return {};
+    return { enableDocs: true };
   }
 
   return {
+    enableDocs: true,
     defaultSettings: {
       fetch: {
         credentials: opts.credentials ?? 'same-origin',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,7 +248,7 @@ importers:
         version: 5.1.4(typescript@5.7.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
       vitest:
         specifier: 4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.10.6)(msw@2.12.7(@types/node@24.13.3)(typescript@5.7.3))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@24.13.3)(typescript@5.7.3))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
 
   deployment:
     dependencies:
@@ -420,7 +420,7 @@ importers:
         version: 2.8.1
       vitest:
         specifier: 4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -456,7 +456,7 @@ importers:
         version: link:../../services/service-common
       vitest:
         specifier: 4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
 
   packages/libraries/apollo:
     dependencies:
@@ -496,7 +496,7 @@ importers:
         version: 14.0.10
       vitest:
         specifier: 4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
       ws:
         specifier: '>=8.21.0 || >=7.5.10 || >=6.2.3 || >=5.2.4'
         version: 8.21.0
@@ -637,7 +637,7 @@ importers:
         version: 14.0.10
       vitest:
         specifier: 4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
     publishDirectory: dist
 
   packages/libraries/envelop:
@@ -704,12 +704,18 @@ importers:
       '@graphql-tools/url-loader':
         specifier: ^9.1.0
         version: 9.1.0(@types/node@24.13.3)(graphql@16.14.2)
+      dompurify:
+        specifier: 3.4.12
+        version: 3.4.12
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-zoom-pan-pinch:
         specifier: ^3.7.0
         version: 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      snarkdown:
+        specifier: 2.0.0
+        version: 2.0.0
       uuid:
         specifier: ^14.0.0
         version: 14.0.0
@@ -885,6 +891,9 @@ importers:
       happy-dom:
         specifier: ^20.10.6
         version: 20.10.6
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1(@noble/hashes@2.2.0)
       lodash:
         specifier: ^4.17.23
         version: 4.18.1
@@ -996,7 +1005,7 @@ importers:
         version: 2.8.1
       vitest:
         specifier: 4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
 
   packages/libraries/render-laboratory:
     dependencies:
@@ -1050,7 +1059,7 @@ importers:
         version: 5.13.3(graphql@16.9.0)
       vitest:
         specifier: 4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
       ws:
         specifier: '>=8.21.0 || >=7.5.10 || >=6.2.3 || >=5.2.4'
         version: 8.21.0
@@ -1298,7 +1307,7 @@ importers:
         version: 17.5.0
       vitest:
         specifier: 4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -1334,7 +1343,7 @@ importers:
         version: 7.29.0
       vitest:
         specifier: 4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
       workers-loki-logger:
         specifier: 0.1.15
         version: 0.1.15
@@ -1485,7 +1494,7 @@ importers:
     devDependencies:
       '@graphql-eslint/eslint-plugin':
         specifier: 3.20.1
-        version: 3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
+        version: 3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@24.13.3)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
       '@hive/service-common':
         specifier: workspace:*
         version: link:../service-common
@@ -1807,7 +1816,7 @@ importers:
         version: 15.1.3
       vitest:
         specifier: 4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -2743,6 +2752,14 @@ packages:
       '@apollo/server': ^4.0.0 || ^5.0.0
       express: ^4.0.0
 
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
     engines: {node: '>=16.0.0'}
@@ -3329,6 +3346,10 @@ packages:
       ioredis:
         optional: true
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
 
@@ -3457,6 +3478,42 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dagrejs/dagre@2.0.4':
     resolution: {integrity: sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==}
@@ -3945,6 +4002,15 @@ packages:
   '@esm2cjs/strip-final-newline@3.0.1-cjs.0':
     resolution: {integrity: sha512-o41riCGPiOEStayoikBCAqwa6igbv9L9rP+k5UCfQ24EJD/wGrdDs/KTNwkHG5JzDK3T60D5dMkWkLKEPy8gjA==}
     engines: {node: '>=12'}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@faker-js/faker@9.9.0':
     resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
@@ -11836,6 +11902,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   big-integer@1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
     engines: {node: '>=0.6'}
@@ -12466,6 +12535,10 @@ packages:
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
@@ -12563,6 +12636,10 @@ packages:
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -12667,6 +12744,9 @@ packages:
 
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -12838,6 +12918,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+
   dompurify@3.4.13:
     resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
@@ -12941,6 +13024,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-ci@7.3.0:
     resolution: {integrity: sha512-L8vK54CSjKB4pwlwx0YaqeBdUSGufaLHl/pEgD+EqnMrYCVUA8HzMjURALSyvOlC57e953yN7KyXS63qDoc3Rg==}
@@ -14149,6 +14236,10 @@ packages:
     resolution: {integrity: sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -14572,6 +14663,9 @@ packages:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-primitive@3.0.1:
     resolution: {integrity: sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==}
     engines: {node: '>=0.10.0'}
@@ -14793,6 +14887,15 @@ packages:
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
@@ -15354,6 +15457,10 @@ packages:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
@@ -15457,6 +15564,9 @@ packages:
 
   mdn-data@2.23.0:
     resolution: {integrity: sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -16408,6 +16518,9 @@ packages:
   parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -16982,6 +17095,10 @@ packages:
 
   punycode@2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
+    engines: {node: '>=6'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   pvtsutils@1.3.2:
@@ -17581,6 +17698,10 @@ packages:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -18151,6 +18272,9 @@ packages:
     resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
     engines: {node: '>=0.10.0'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   sync-fetch@0.6.0:
     resolution: {integrity: sha512-IELLEvzHuCfc1uTsshPK58ViSdNqXxlml1U+fmwJIKLYKOr/rAtBrorE2RYm5IHaMpDNlmC0fr1LAvdXvyheEQ==}
     engines: {node: '>=18'}
@@ -18356,11 +18480,19 @@ packages:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -18619,6 +18751,10 @@ packages:
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.14:
     resolution: {integrity: sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==}
@@ -19075,6 +19211,10 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walk-up-path@3.0.1:
     resolution: {integrity: sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==}
 
@@ -19095,6 +19235,10 @@ packages:
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
@@ -19105,6 +19249,18 @@ packages:
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -19213,9 +19369,16 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -19721,6 +19884,21 @@ snapshots:
     dependencies:
       '@apollo/server': 5.5.0(graphql@16.9.0)
       express: 4.21.2
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -21067,6 +21245,10 @@ snapshots:
     optionalDependencies:
       ioredis: 5.10.1
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
       '@changesets/config': 3.1.4
@@ -21282,6 +21464,30 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dagrejs/dagre@2.0.4':
     dependencies:
@@ -21844,6 +22050,10 @@ snapshots:
 
   '@esm2cjs/strip-final-newline@3.0.1-cjs.0': {}
 
+  '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
+
   '@faker-js/faker@9.9.0': {}
 
   '@fastify/accept-negotiator@2.0.1': {}
@@ -22253,29 +22463,6 @@ snapshots:
       fast-glob: 3.3.3
       graphql: 16.9.0
       graphql-config: 4.5.0(@types/node@24.13.3)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
-      graphql-depth-limit: 1.1.0(graphql@16.9.0)
-      lodash.lowercase: 4.3.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/node'
-      - bufferutil
-      - cosmiconfig-toml-loader
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@graphql-eslint/eslint-plugin@3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.29.7)(graphql@16.9.0)
-      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.7)(graphql@16.9.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.9.0)
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      fast-glob: 3.3.3
-      graphql: 16.9.0
-      graphql-config: 4.5.0(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
       graphql-depth-limit: 1.1.0(graphql@16.9.0)
       lodash.lowercase: 4.3.0
       tslib: 2.8.1
@@ -32834,6 +33021,10 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   big-integer@1.6.51: {}
 
   bignumber.js@9.3.1: {}
@@ -33570,6 +33761,11 @@ snapshots:
       domutils: 3.1.0
       nth-check: 2.1.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css-what@6.1.0: {}
 
   cssesc@3.0.0: {}
@@ -33652,6 +33848,13 @@ snapshots:
 
   data-uri-to-buffer@6.0.2: {}
 
+  data-urls@7.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -33723,6 +33926,8 @@ snapshots:
       supports-color: 8.1.1
 
   decimal.js-light@2.5.1: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.0.2:
     dependencies:
@@ -33893,6 +34098,10 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -33998,6 +34207,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   env-ci@7.3.0:
     dependencies:
@@ -35777,6 +35988,12 @@ snapshots:
     dependencies:
       lru-cache: 10.2.0
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-void-elements@3.0.0: {}
 
   htmlparser2@4.1.0:
@@ -36223,6 +36440,8 @@ snapshots:
     dependencies:
       isobject: 3.0.1
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-primitive@3.0.1: {}
 
   is-property@1.0.2: {}
@@ -36406,6 +36625,32 @@ snapshots:
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@30.0.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0(@noble/hashes@2.2.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@0.5.0: {}
 
@@ -36902,6 +37147,8 @@ snapshots:
 
   lru-cache@11.2.6: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@4.1.5:
     dependencies:
       pseudomap: 1.0.2
@@ -37119,6 +37366,8 @@ snapshots:
       '@types/mdast': 4.0.1
 
   mdn-data@2.23.0: {}
+
+  mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
 
@@ -38482,6 +38731,10 @@ snapshots:
     dependencies:
       entities: 4.5.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   pascal-case@3.1.2:
@@ -38950,6 +39203,8 @@ snapshots:
   punycode@1.4.1: {}
 
   punycode@2.1.1: {}
+
+  punycode@2.3.1: {}
 
   pvtsutils@1.3.2:
     dependencies:
@@ -39716,6 +39971,10 @@ snapshots:
   sax@1.4.4:
     optional: true
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -40382,6 +40641,8 @@ snapshots:
 
   symbol-observable@1.2.0: {}
 
+  symbol-tree@3.2.4: {}
+
   sync-fetch@0.6.0:
     dependencies:
       node-fetch: 3.3.2
@@ -40562,13 +40823,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  tldts-core@7.0.19:
-    optional: true
+  tldts-core@7.0.19: {}
 
   tldts@7.0.19:
     dependencies:
       tldts-core: 7.0.19
-    optional: true
 
   tmp@0.2.7: {}
 
@@ -40601,11 +40860,19 @@ snapshots:
       tldts: 7.0.19
     optional: true
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.0.19
+
   tr46@0.0.3: {}
 
   tr46@1.0.1:
     dependencies:
       punycode: 2.1.1
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -40886,6 +41153,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici@7.29.0: {}
+
+  undici@8.10.0: {}
 
   unenv@2.0.0-rc.14:
     dependencies:
@@ -41334,7 +41603,7 @@ snapshots:
       tsx: 4.19.2
       yaml: 2.8.3
 
-  vitest@4.1.3(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.10.6)(msw@2.12.7(@types/node@24.13.3)(typescript@5.7.3))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)):
+  vitest@4.1.3(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@24.13.3)(typescript@5.7.3))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.3
       '@vitest/mocker': 4.1.3(msw@2.12.7(@types/node@24.13.3)(typescript@5.7.3))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
@@ -41360,10 +41629,11 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.13.3
       happy-dom: 20.10.6
+      jsdom: 30.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)):
+  vitest@4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.3
       '@vitest/mocker': 4.1.3(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
@@ -41389,6 +41659,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.5.0
       happy-dom: 20.10.6
+      jsdom: 30.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -41397,6 +41668,10 @@ snapshots:
   vscode-uri@3.0.8: {}
 
   w3c-keyname@2.2.8: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   walk-up-path@3.0.1: {}
 
@@ -41425,11 +41700,31 @@ snapshots:
 
   webidl-conversions@4.0.2: {}
 
+  webidl-conversions@8.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
 
   whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -41575,7 +41870,11 @@ snapshots:
 
   ws@8.21.0: {}
 
+  xml-name-validator@5.0.0: {}
+
   xml-naming@0.1.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,6 +707,9 @@ importers:
       dompurify:
         specifier: 3.4.12
         version: 3.4.12
+      graphql-language-service:
+        specifier: ^5.5.0
+        version: 5.5.0(graphql@16.14.2)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -18476,10 +18479,6 @@ packages:
   toucan-js@4.1.0:
     resolution: {integrity: sha512-KaD6yfjFuOiFfKccvJ95EICwxus+g2mfPUHyxfPCq7yzsEg5Qi2wpym0cxsZI7oS4t3S7/HwL1v+2TW5/pGAUA==}
 
-  tough-cookie@6.0.0:
-    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
-    engines: {node: '>=16'}
-
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
@@ -22216,7 +22215,7 @@ snapshots:
       framer-motion: 10.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       get-value: 3.0.1
       graphql: 16.9.0
-      graphql-language-service: 5.3.0(graphql@16.9.0)
+      graphql-language-service: 5.5.0(graphql@16.9.0)
       markdown-it: 14.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -38119,7 +38118,7 @@ snapshots:
       rettime: 0.7.0
       statuses: 2.0.2
       strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.0
+      tough-cookie: 6.0.2
       type-fest: 5.4.2
       until-async: 3.0.2
       yargs: 17.7.2
@@ -38145,7 +38144,7 @@ snapshots:
       rettime: 0.7.0
       statuses: 2.0.2
       strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.0
+      tough-cookie: 6.0.2
       type-fest: 5.4.2
       until-async: 3.0.2
       yargs: 17.7.2
@@ -40854,11 +40853,6 @@ snapshots:
       '@sentry/core': 8.9.2
       '@sentry/types': 8.9.2
       '@sentry/utils': 8.9.2
-
-  tough-cookie@6.0.0:
-    dependencies:
-      tldts: 7.0.19
-    optional: true
 
   tough-cookie@6.0.2:
     dependencies:


### PR DESCRIPTION
This PR adds a GraphiQL-style schema documentation pane to the Laboratory, opt-in via a new `enableDocs` prop.

A third rail icon opens docs in the same slot as Collections and History: browse root types, types and fields, search the whole type map, and read descriptions, deprecations and argument defaults. Builder rows get an "Open in Docs" context menu entry, and the editor hover gets an "Open in Docs" link (the Lab now serves that hover itself, rebuilt from the same `getHoverInformation` monaco-graphql uses, so the link sits in the existing card instead of a second one).

`renderLaboratory` enables the pane by default, so UMD embedders like Router need only a version bump.

**Removed:** the `introspection.schemaDescription` setting and its toggle. It was wired to graphql-js's `descriptions` option rather than `schemaDescription` and defaulted to `false` where graphql-js defaults to `true`, so nothing rendered descriptions and the toggle had no discoverable effect. Descriptions now follow `enableDocs`.


https://github.com/user-attachments/assets/00c4a3ab-c060-431b-aa27-40c9a485c31e

