### PR TITLE
fix: refetch fragment to auto-close dialog

### DIFF
--- a/packages/services/api/src/modules/oidc-integrations/providers/oidc-integrations.provider.ts
+++ b/packages/services/api/src/modules/oidc-integrations/providers/oidc-integrations.provider.ts
@@ -427,7 +427,7 @@ export class OIDCIntegrationsProvider {
         organizationId: oidcIntegration.linkedOrganizationId,
       });
 
-      if (!organization.featureFlags.scim) {
+      if (!organization.featureFlags.scim && !this.oidcIntegrationConfig.isSCIMEnabled) {
         return {
           type: 'error',
           message: 'SCIM provisioning is disabled.',

--- a/packages/services/api/src/modules/organization/providers/organization-access-tokens.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-access-tokens.ts
@@ -24,6 +24,7 @@ import {
   resourceLevelToHumanReadableName,
   resourceLevelToResourceLevelType,
 } from '../../auth/resolvers/Permission';
+import { OIDCIntegrationConfig } from '../../oidc-integrations/providers/oidc-integration-config';
 import { OTEL_TRACING_ENABLED } from '../../operations/providers/traces';
 import { SCHEMA_PROPOSALS_ENABLED } from '../../proposals/providers/schema-proposals-enabled-token';
 import { IdTranslator } from '../../shared/providers/id-translator';
@@ -193,6 +194,7 @@ export class OrganizationAccessTokens {
     @Inject(OTEL_TRACING_ENABLED) private otelTracingEnabled: boolean,
     @Inject(APP_DEPLOYMENTS_ENABLED) private appDeploymentsEnabled: boolean,
     @Inject(SCHEMA_PROPOSALS_ENABLED) private schemaProposalsEnabled: boolean,
+    private oidcConfig: OIDCIntegrationConfig,
   ) {
     this.logger = logger.child({
       source: 'OrganizationAccessTokens',
@@ -996,12 +998,14 @@ export class OrganizationAccessTokens {
     const isOTELTracingEnabled = organization.featureFlags.otelTracing || this.otelTracingEnabled;
     const isSchemaProposalsEnabled =
       organization.featureFlags.schemaProposals || this.schemaProposalsEnabled;
+    const isSCIMProvisioningEnabled =
+      organization.featureFlags.scim || this.oidcConfig.isSCIMEnabled;
 
     return (id: Permission) =>
       (!isAppDeploymentsEnabled && id.startsWith('appDeployment:')) ||
       (!isOTELTracingEnabled && id.startsWith('traces:')) ||
       (!isSchemaProposalsEnabled && id.startsWith('schemaProposal:')) ||
-      (!organization.featureFlags.scim && id.startsWith('scim:provision'))
+      (!isSCIMProvisioningEnabled && id.startsWith('scim:provision'))
         ? false
         : true;
   }

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -570,6 +570,7 @@ export async function main() {
       broadcastLog,
       env.supertokens.secrets,
       workloadIdentityFederation,
+      env.organizationSCIM,
     );
 
     if (env.cdn.providers.api !== null) {

--- a/packages/services/server/src/supertokens-at-home.ts
+++ b/packages/services/server/src/supertokens-at-home.ts
@@ -49,6 +49,7 @@ export async function registerSupertokensAtHome(
     accessTokenKey: string;
   },
   workloadIdentityFederation: WorkloadIdentityFederationProvider | null,
+  isSCIMEnabled: boolean,
 ) {
   const supertokensStore = new SuperTokensStore(storage.pool, server.log);
 
@@ -1656,7 +1657,10 @@ export async function registerSupertokensAtHome(
         if (!supertokenUser) {
           req.log.debug('no existing user found.');
 
-          if (organization.featureFlags.scim && oidcIntegration.userProvisioningRequired) {
+          if (
+            (organization.featureFlags.scim || isSCIMEnabled) &&
+            oidcIntegration.userProvisioningRequired
+          ) {
             req.log.debug('oidc integration settings requires user being provisioned.');
             return rep.status(200).send({
               status: 'SIGN_IN_UP_NOT_ALLOWED',
@@ -1676,7 +1680,7 @@ export async function registerSupertokensAtHome(
           superTokensUserId: supertokenUser.userId,
         });
 
-        if (organization.featureFlags.scim) {
+        if (organization.featureFlags.scim || isSCIMEnabled) {
           if (maybeHiveUser?.provisioningStatus === 'active' && maybeHiveUser.deactivatedAt) {
             req.log.debug('user is deactivated.');
             return rep.status(200).send({
@@ -1702,7 +1706,10 @@ export async function registerSupertokensAtHome(
 
         // only perform these updates if the user is not provisioned
         // if the user is provisioned the SCIM provider is the source of truth for all attributes
-        if (!organization.featureFlags.scim || !maybeHiveUser?.provisionedByOrganizationId) {
+        if (
+          (!organization.featureFlags.scim && !isSCIMEnabled) ||
+          !maybeHiveUser?.provisionedByOrganizationId
+        ) {
           if (supertokenUser.email !== email.data) {
             req.log.debug('providers email has changed. Update record.');
             supertokenUser = await supertokensStore.updateOIDCUserEmail({

--- a/packages/web/app/src/components/organization/members/list.tsx
+++ b/packages/web/app/src/components/organization/members/list.tsx
@@ -162,6 +162,7 @@ const OrganizationMemberRow_ConfirmSCIMManagementForMember = graphql(`
       ok {
         confirmedMember {
           id
+          ...OrganizationMemberRow_MemberFragment
         }
       }
       error {


### PR DESCRIPTION
refetch fragment as part of mutation for quicker ui feedback when confirming scim account takeover