### PR TITLE
fix: SCIM UI tweaks

### DIFF
--- a/packages/web/app/src/components/organization/members/list.tsx
+++ b/packages/web/app/src/components/organization/members/list.tsx
@@ -276,7 +276,8 @@ const OrganizationMemberRow = memo(function OrganizationMemberRow(props: {
       <tr key={member.id} className={cn(member.user.provisionInfo?.isDisabled && 'bg-red-800/5')}>
         <td className="w-12 pl-2">
           <div>
-            {member.user.provisionInfo?.isDisabled ? (
+            {member.user.provisionInfo?.provisioningStatus ===
+              GraphQLSchema.ProvisioningStatus.Active && member.user.provisionInfo?.isDisabled ? (
               <div className="flex h-9 w-9 items-center justify-center rounded-full bg-red-800/10">
                 <UserRoundX className="mx-auto size-5 text-red-800" />
               </div>

--- a/packages/web/app/src/components/organization/settings/single-sign-on/oidc-integration-configuration.tsx
+++ b/packages/web/app/src/components/organization/settings/single-sign-on/oidc-integration-configuration.tsx
@@ -747,7 +747,14 @@ function OIDCAccessSettings(props: {
           {organization.viewerCanManageSCIM ? (
             <AlertDialog>
               <AlertDialogTrigger asChild>
-                <Card variant={isSCIMProvisioningEnabled ? 'selected' : 'selectable'}>
+                <Card
+                  variant={isSCIMProvisioningEnabled ? 'selected' : 'selectable'}
+                  onClick={ev => {
+                    if (isSCIMProvisioningEnabled) {
+                      ev.preventDefault();
+                    }
+                  }}
+                >
                   <CardContent variant="selection">
                     <RadioGroupItem value="scim" id="scim-mode" className="mt-0.5" />
                     <div className="flex-1">


### PR DESCRIPTION
some small UI tweaks that reduce confusion
- only show user as inactive if provisioning status is active
- do not show the enable oidc provisioning alert if already enabled