### PR TITLE
chore(deployment): disable otel traces for usage service

### DIFF
--- a/deployment/services/observability.ts
+++ b/deployment/services/observability.ts
@@ -6,7 +6,7 @@ import { deployGrafana } from './grafana';
 import { deployGrafanaAlerts } from './grafana-alerts';
 
 // Change this to control OTEL tracing for usage service
-const enableTracingForUsageService = true;
+const enableTracingForUsageService = false;
 
 export function deployObservability(config: { environment: Environment }) {
   const observabilityConfig = new pulumi.Config('observability');

--- a/deployment/utils/observability.ts
+++ b/deployment/utils/observability.ts
@@ -211,18 +211,16 @@ export class Observability {
                         span: [
                           // Ignore HEAD/OPTIONS
                           'attributes["component"] == "proxy" and (attributes["http.method"] == "HEAD" or attributes["http.method"] == "OPTIONS")',
-                          //Ignore health checks
+                          // Ignore health checks
                           'attributes["component"] == "proxy" and attributes["http.method"] == "GET" and (attributes["http.url"] == "/_readiness" or attributes["http.url"] == "/_health" or IsMatch(attributes["http.url"], ".*/_health"))',
-                          //Ignore /usage requests (200 or 429)
-                          'attributes["component"] == "proxy" and attributes["http.method"] == "POST" and (attributes["http.url"] == "/usage" or IsMatch(attributes["http.url"], "/usage/.*")) and (attributes["http.status_code"] == "200" or attributes["http.status_code"] == "429")',
+                          // Ignore /usage requests (200 or 429)
+                          'attributes["component"] == "proxy" and attributes["http.method"] == "POST" and (attributes["http.url"] == "/usage" or IsMatch(attributes["http.url"], "/usage/.*"))',
                           // Ignore metrics scraping
                           'attributes["component"] == "proxy" and attributes["http.method"] == "GET" and attributes["http.url"] == "/metrics"',
                           // Ignore webapp HTTP calls via upstream cluster name
                           'attributes["component"] == "proxy" and (attributes["http.method"] == "POST" or attributes["http.method"] == "GET") and IsMatch(attributes["upstream_cluster.name"], "default_app-.*")',
                           // Hive Tracing is using these endpoints and they don't have any added value for us when monitored
                           'attributes["component"] == "proxy" and attributes["http.method"] == "POST" and attributes["http.url"] == "/otel/v1/traces"',
-                          // Internal /usage calls can also be filtered out
-                          'resource.attributes["service.name"] == "usage" and attributes["http.status_code"] == 200 and IsRootSpan() == true',
                         ],
                       },
                     },


### PR DESCRIPTION
@n1ru4l and I find it wasteful and it doesn't have any added value. the envoy access logs + grafana alerts on http errors + logs gives us everything we need in terms of usage service monitoring. 
