### PR TITLE
Fix alert detail chart clipped to eval window

### DIFF
--- a/packages/web/app/src/components/target/alerts/alert-form.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-form.tsx
@@ -935,8 +935,9 @@ export function AlertForm(props: AlertFormProps) {
                                       {field.value || '0'}
                                     </span>{' '}
                                     minutes before firing. Helps prevent false alarms from brief
-                                    spikes. Leave at 0 to fire immediately (recommended for alert
-                                    ranges greater than 1 day).
+                                    spikes. Leave at 0 to fire as soon as the condition holds for
+                                    two consecutive evaluations (recommended for alert ranges
+                                    greater than 1 day).
                                   </>
                                 }
                               />

--- a/packages/web/app/src/components/target/alerts/alert-form.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-form.tsx
@@ -873,6 +873,7 @@ export function AlertForm(props: AlertFormProps) {
                   direction={watchedValues.direction}
                   thresholdType={watchedValues.thresholdType}
                   timeWindowMinutes={parseInt(watchedValues.timeWindowMinutes, 10) || 0}
+                  clipToCurrentWindow
                 />
 
                 <Accordion defaultValue={expandAdvanced ? [0] : undefined}>

--- a/packages/web/app/src/components/target/alerts/alert-metric-chart.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-metric-chart.tsx
@@ -9,7 +9,7 @@ import { formatDuration } from '@/lib/hooks/use-formatted-duration';
 import { formatNumber } from '@/lib/hooks/use-formatted-number';
 import { useChartStyles } from '@/lib/utils';
 import { ALERT_CHART_INSET_LEFT, ALERT_CHART_INSET_RIGHT } from './alert-chart-layout';
-import { applyThresholdSign, windowAggregates } from './alert-threshold';
+import { applyThresholdSign, visibleSeries, windowAggregates } from './alert-threshold';
 
 export const AlertMetricChart_OperationsStatsFragment = graphql(`
   fragment AlertMetricChart_OperationsStatsFragment on OperationsStats {
@@ -59,6 +59,9 @@ type AlertMetricChartProps = {
    * (~2 windows) into the previous | current windows the evaluator compares.
    */
   timeWindowMinutes: number;
+  /** Clip the series to the trailing window. Only for callers that fetch ~2
+   * windows; a caller fetching a user-chosen range would crop it to the window. */
+  clipToCurrentWindow?: boolean;
 };
 
 // Maps the GraphQL enum to the lowercase field names on DurationValues
@@ -100,6 +103,7 @@ export function AlertMetricChart({
   direction,
   thresholdType,
   timeWindowMinutes,
+  clipToCurrentWindow = false,
 }: AlertMetricChartProps) {
   const { colors } = useChartStyles();
 
@@ -218,10 +222,12 @@ export function AlertMetricChart({
       : false;
 
   const showWindowSplit = isPercentageChange && hasPreviousWindow;
-  const displayData =
-    isPercentageChange || timeWindowMinutes <= 0 || boundaryMs <= firstMs
-      ? data
-      : data.filter(([date]) => new Date(date).getTime() >= boundaryMs);
+  const displayData = visibleSeries(data, {
+    clipToCurrentWindow,
+    isPercentageChange,
+    timeWindowMinutes,
+    boundaryMs,
+  });
 
   const markLineData: NonNullable<MarkLineComponentOption['data']> = [];
 

--- a/packages/web/app/src/components/target/alerts/alert-metric-chart.tsx
+++ b/packages/web/app/src/components/target/alerts/alert-metric-chart.tsx
@@ -9,7 +9,12 @@ import { formatDuration } from '@/lib/hooks/use-formatted-duration';
 import { formatNumber } from '@/lib/hooks/use-formatted-number';
 import { useChartStyles } from '@/lib/utils';
 import { ALERT_CHART_INSET_LEFT, ALERT_CHART_INSET_RIGHT } from './alert-chart-layout';
-import { applyThresholdSign, visibleSeries, windowAggregates } from './alert-threshold';
+import {
+  applyThresholdSign,
+  scoredWindow,
+  visibleSeries,
+  windowAggregates,
+} from './alert-threshold';
 
 export const AlertMetricChart_OperationsStatsFragment = graphql(`
   fragment AlertMetricChart_OperationsStatsFragment on OperationsStats {
@@ -62,6 +67,8 @@ type AlertMetricChartProps = {
   /** Clip the series to the trailing window. Only for callers that fetch ~2
    * windows; a caller fetching a user-chosen range would crop it to the window. */
   clipToCurrentWindow?: boolean;
+  /** Anchors `current` to the window the rule scored. Omitted by the preview. */
+  evaluatedAt?: string | null;
 };
 
 // Maps the GraphQL enum to the lowercase field names on DurationValues
@@ -91,8 +98,6 @@ const SEVERITY_COLOR_KEY: Record<string, 'critical' | 'warning' | 'info'> = {
 // backstop against a larger `timeWindowMinutes` reaching the chart.
 const PREVIEW_SPAN_CAP_MINUTES = 20_160;
 
-const MS_PER_MINUTE = 60_000;
-
 export function AlertMetricChart({
   stats,
   loading,
@@ -104,6 +109,7 @@ export function AlertMetricChart({
   thresholdType,
   timeWindowMinutes,
   clipToCurrentWindow = false,
+  evaluatedAt,
 }: AlertMetricChartProps) {
   const { colors } = useChartStyles();
 
@@ -174,10 +180,11 @@ export function AlertMetricChart({
 
   const firstMs = new Date(data[0][0]).getTime();
   const lastMs = new Date(data[data.length - 1][0]).getTime();
-  // The current window is the most recent `timeWindowMinutes` of the fetched
-  // span; the previous window is the slice before it. Mirrors the evaluator's
-  // split (its 1-minute offset is immaterial for an illustrative preview).
-  const boundaryMs = lastMs - timeWindowMinutes * MS_PER_MINUTE;
+  const { boundaryMs, scoredEndMs, isEvaluated } = scoredWindow({
+    evaluatedAt,
+    lastMs,
+    timeWindowMinutes,
+  });
   // The previous window is only present when the fetched span covers two full
   // windows (the form caps it at 30 days) and the boundary lands in the data.
   const hasPreviousWindow =
@@ -185,12 +192,18 @@ export function AlertMetricChart({
     timeWindowMinutes * 2 <= PREVIEW_SPAN_CAP_MINUTES &&
     boundaryMs > firstMs;
 
+  // Trimming all three keeps them index-aligned, which `windowAggregates` needs.
+  // Skipped for the preview, whose cutoff is the newest bucket: trimming would
+  // drop that bucket rather than exclude an in-flight one.
+  const beforeCutoff = <T extends { date: string }>(nodes: readonly T[]) =>
+    isEvaluated ? nodes.filter(node => new Date(node.date).getTime() < scoredEndMs) : nodes;
+
   const { current: currentAgg, previous: previousAgg } = windowAggregates(
     type,
     latencyPercentile,
-    requestsOverTime,
-    failuresOverTime,
-    durationOverTime,
+    beforeCutoff(requestsOverTime),
+    beforeCutoff(failuresOverTime),
+    beforeCutoff(durationOverTime),
     boundaryMs,
   );
 
@@ -240,11 +253,18 @@ export function AlertMetricChart({
       label: { show: false },
     });
   }
-  const markArea: MarkAreaComponentOption | undefined = showWindowSplit
+  // % change shades the previous window; a fixed-value rule has none, so it
+  // shades the scored window to give `current` a visible span.
+  const shadeRange: [number, number] | null = showWindowSplit
+    ? [firstMs, boundaryMs]
+    : isEvaluated && !isPercentageChange && boundaryMs < scoredEndMs
+      ? [boundaryMs, scoredEndMs]
+      : null;
+  const markArea: MarkAreaComponentOption | undefined = shadeRange
     ? {
         silent: true,
         itemStyle: { color: colors.gridSubtle, opacity: 0.18 },
-        data: [[{ xAxis: firstMs }, { xAxis: boundaryMs }]],
+        data: [[{ xAxis: shadeRange[0] }, { xAxis: shadeRange[1] }]],
       }
     : undefined;
 
@@ -289,7 +309,7 @@ export function AlertMetricChart({
       ],
       [
         { coord: [boundaryMs, currentAgg], symbol: 'none', lineStyle: segLine },
-        { coord: [lastMs, currentAgg], symbol: 'none' },
+        { coord: [scoredEndMs, currentAgg], symbol: 'none' },
       ],
     );
   }

--- a/packages/web/app/src/components/target/alerts/alert-threshold.spec.ts
+++ b/packages/web/app/src/components/target/alerts/alert-threshold.spec.ts
@@ -1,4 +1,9 @@
-import { applyThresholdSign, thresholdUnit, windowAggregates } from './alert-threshold';
+import {
+  applyThresholdSign,
+  thresholdUnit,
+  visibleSeries,
+  windowAggregates,
+} from './alert-threshold';
 
 describe('thresholdUnit', () => {
   it('is always % for a percentage change, regardless of metric', () => {
@@ -92,5 +97,58 @@ describe('windowAggregates', () => {
     const { current, previous } = windowAggregates('LATENCY', 'p95', [], [], durations, boundaryMs);
     expect(previous).toBe(200); // mean(100, 300)
     expect(current).toBe(800); // mean(800)
+  });
+});
+
+describe('visibleSeries', () => {
+  // An hour of one-minute buckets, with a boundary one minute from the end.
+  const hourOfBuckets = Array.from(
+    { length: 60 },
+    (_, i) => [new Date(Date.UTC(2026, 5, 15, 1, i)).toISOString(), i] as const,
+  );
+  const boundaryMs = new Date(Date.UTC(2026, 5, 15, 1, 59)).getTime();
+
+  it('keeps the whole fetched span when the caller does not opt in', () => {
+    expect(
+      visibleSeries(hourOfBuckets, {
+        clipToCurrentWindow: false,
+        isPercentageChange: false,
+        timeWindowMinutes: 1,
+        boundaryMs,
+      }),
+    ).toHaveLength(60);
+  });
+
+  it('clips to the trailing window when the caller opts in', () => {
+    expect(
+      visibleSeries(hourOfBuckets, {
+        clipToCurrentWindow: true,
+        isPercentageChange: false,
+        timeWindowMinutes: 1,
+        boundaryMs,
+      }),
+    ).toHaveLength(1);
+  });
+
+  it('keeps both windows for a percentage change, even when opted in', () => {
+    expect(
+      visibleSeries(hourOfBuckets, {
+        clipToCurrentWindow: true,
+        isPercentageChange: true,
+        timeWindowMinutes: 1,
+        boundaryMs,
+      }),
+    ).toHaveLength(60);
+  });
+
+  it('keeps the whole span when there is no window to clip to', () => {
+    expect(
+      visibleSeries(hourOfBuckets, {
+        clipToCurrentWindow: true,
+        isPercentageChange: false,
+        timeWindowMinutes: 0,
+        boundaryMs,
+      }),
+    ).toHaveLength(60);
   });
 });

--- a/packages/web/app/src/components/target/alerts/alert-threshold.spec.ts
+++ b/packages/web/app/src/components/target/alerts/alert-threshold.spec.ts
@@ -1,5 +1,7 @@
 import {
   applyThresholdSign,
+  EVALUATOR_LAG_MS,
+  scoredWindow,
   thresholdUnit,
   visibleSeries,
   windowAggregates,
@@ -127,7 +129,7 @@ describe('visibleSeries', () => {
         timeWindowMinutes: 1,
         boundaryMs,
       }),
-    ).toHaveLength(1);
+    ).toEqual([hourOfBuckets[59]]);
   });
 
   it('keeps both windows for a percentage change, even when opted in', () => {
@@ -150,5 +152,70 @@ describe('visibleSeries', () => {
         boundaryMs,
       }),
     ).toHaveLength(60);
+  });
+});
+
+describe('scoredWindow', () => {
+  const evaluatedAt = '2026-06-15T01:40:00.000Z';
+  const evaluatedMs = new Date(evaluatedAt).getTime();
+  // Well past the evaluation, so a fallback to it would be obvious.
+  const lastMs = new Date('2026-06-15T01:45:00.000Z').getTime();
+
+  it('reproduces the evaluator window: [anchor - lag - window, anchor - lag)', () => {
+    const { boundaryMs, scoredEndMs, isEvaluated } = scoredWindow({
+      evaluatedAt,
+      lastMs,
+      timeWindowMinutes: 5,
+    });
+    expect(isEvaluated).toBe(true);
+    expect(scoredEndMs).toBe(evaluatedMs - EVALUATOR_LAG_MS);
+    expect(boundaryMs).toBe(evaluatedMs - EVALUATOR_LAG_MS - 5 * 60_000);
+  });
+
+  it('ignores the newest bucket, which follows the viewer clock', () => {
+    const viewedLater = scoredWindow({
+      evaluatedAt,
+      lastMs: lastMs + 60 * 60_000,
+      timeWindowMinutes: 5,
+    });
+    const viewedNow = scoredWindow({ evaluatedAt, lastMs, timeWindowMinutes: 5 });
+    expect(viewedLater).toEqual(viewedNow);
+  });
+
+  it('excludes a bucket at the cutoff and includes the one before it', () => {
+    const { boundaryMs, scoredEndMs } = scoredWindow({
+      evaluatedAt,
+      lastMs,
+      timeWindowMinutes: 1,
+    });
+    const inWindow = (ms: number) => ms >= boundaryMs && ms < scoredEndMs;
+    expect(inWindow(scoredEndMs)).toBe(false);
+    expect(inWindow(scoredEndMs - 1)).toBe(true);
+    expect(inWindow(boundaryMs)).toBe(true);
+    expect(inWindow(boundaryMs - 1)).toBe(false);
+  });
+
+  it('falls back to the newest bucket when the rule has never been evaluated', () => {
+    for (const missing of [null, undefined, '']) {
+      const { boundaryMs, scoredEndMs, isEvaluated } = scoredWindow({
+        evaluatedAt: missing,
+        lastMs,
+        timeWindowMinutes: 5,
+      });
+      expect(isEvaluated).toBe(false);
+      expect(scoredEndMs).toBe(lastMs);
+      expect(boundaryMs).toBe(lastMs - 5 * 60_000);
+    }
+  });
+
+  it('falls back rather than producing NaN on an unparseable timestamp', () => {
+    const { boundaryMs, scoredEndMs, isEvaluated } = scoredWindow({
+      evaluatedAt: 'not a date',
+      lastMs,
+      timeWindowMinutes: 5,
+    });
+    expect(isEvaluated).toBe(false);
+    expect(scoredEndMs).toBe(lastMs);
+    expect(boundaryMs).toBe(lastMs - 5 * 60_000);
   });
 });

--- a/packages/web/app/src/components/target/alerts/alert-threshold.ts
+++ b/packages/web/app/src/components/target/alerts/alert-threshold.ts
@@ -96,3 +96,23 @@ export function windowAggregates(
   };
   return { current: reduce(true), previous: reduce(false) };
 }
+
+/**
+ * The buckets a chart plots. Defaults to the whole fetched span; only a caller
+ * that fetched ~2 windows opts into clipping to the trailing one. A % change
+ * chart always keeps both windows, since the comparison is the point.
+ */
+export function visibleSeries<T extends readonly [string, number]>(
+  data: readonly T[],
+  args: {
+    clipToCurrentWindow: boolean;
+    isPercentageChange: boolean;
+    timeWindowMinutes: number;
+    boundaryMs: number;
+  },
+): readonly T[] {
+  if (!args.clipToCurrentWindow || args.isPercentageChange || args.timeWindowMinutes <= 0) {
+    return data;
+  }
+  return data.filter(([date]) => new Date(date).getTime() >= args.boundaryMs);
+}

--- a/packages/web/app/src/components/target/alerts/alert-threshold.ts
+++ b/packages/web/app/src/components/target/alerts/alert-threshold.ts
@@ -116,3 +116,29 @@ export function visibleSeries<T extends readonly [string, number]>(
   }
   return data.filter(([date]) => new Date(date).getTime() >= args.boundaryMs);
 }
+
+/** Mirrors `offsetMs` in packages/services/workflows/src/lib/metric-alert-evaluator.ts. */
+export const EVALUATOR_LAG_MS = 60_000;
+
+const MS_PER_MINUTE = 60_000;
+
+/**
+ * The window a rule scored, as `[boundaryMs, scoredEndMs)`. Anchors on the
+ * evaluation, not the newest bucket: the newest bucket follows the viewer's
+ * clock and would pick a different bucket than the rule did. Falls back to it
+ * only for the preview, which has no rule to be consistent with.
+ */
+export function scoredWindow(args: {
+  evaluatedAt: string | null | undefined;
+  lastMs: number;
+  timeWindowMinutes: number;
+}): { boundaryMs: number; scoredEndMs: number; isEvaluated: boolean } {
+  const evaluatedMs = args.evaluatedAt ? new Date(args.evaluatedAt).getTime() : NaN;
+  const isEvaluated = Number.isFinite(evaluatedMs);
+  const scoredEndMs = isEvaluated ? evaluatedMs - EVALUATOR_LAG_MS : args.lastMs;
+  return {
+    boundaryMs: scoredEndMs - args.timeWindowMinutes * MS_PER_MINUTE,
+    scoredEndMs,
+    isEvaluated,
+  };
+}

--- a/packages/web/app/src/pages/target-alerts-detail.tsx
+++ b/packages/web/app/src/pages/target-alerts-detail.tsx
@@ -62,6 +62,7 @@ const TargetAlertsDetailPage_RuleConfigQuery = graphql(`
         thresholdValue
         direction
         confirmationMinutes
+        lastEvaluatedAt
         channels {
           id
           name
@@ -299,6 +300,7 @@ function RuleStateLogSection(props: {
     createdAt: string;
     metric?: MetricAlertRuleMetric | null;
     severity: MetricAlertRuleSeverity;
+    lastEvaluatedAt?: string | null;
   };
 }) {
   const { organizationSlug, projectSlug, targetSlug, ruleId, viewRangeMinutes, rule } = props;
@@ -369,6 +371,7 @@ function RuleStateLogSection(props: {
           direction={rule.direction}
           thresholdType={rule.thresholdType}
           timeWindowMinutes={rule.timeWindowMinutes}
+          evaluatedAt={rule.lastEvaluatedAt}
         />
       </section>
 

--- a/packages/web/app/src/pages/target-alerts-detail.tsx
+++ b/packages/web/app/src/pages/target-alerts-detail.tsx
@@ -62,7 +62,6 @@ const TargetAlertsDetailPage_RuleConfigQuery = graphql(`
         thresholdValue
         direction
         confirmationMinutes
-        lastEvaluatedAt
         channels {
           id
           name
@@ -122,6 +121,7 @@ const TargetAlertsDetailPage_StateLogQuery = graphql(`
       id
       metricAlertRule(id: $ruleId) {
         id
+        lastEvaluatedAt
         stateAt(timestamp: $from)
         stateLog(from: $from, to: $to) {
           id
@@ -300,7 +300,6 @@ function RuleStateLogSection(props: {
     createdAt: string;
     metric?: MetricAlertRuleMetric | null;
     severity: MetricAlertRuleSeverity;
-    lastEvaluatedAt?: string | null;
   };
 }) {
   const { organizationSlug, projectSlug, targetSlug, ruleId, viewRangeMinutes, rule } = props;
@@ -325,6 +324,9 @@ function RuleStateLogSection(props: {
   const data = useKeepPreviousData(result.data, result.fetching || result.stale);
   const stateLog = data?.target?.metricAlertRule?.stateLog ?? [];
   const stateAtWindowStart = data?.target?.metricAlertRule?.stateAt;
+  // Read from the polling query, not the rule config: the chart's scored window
+  // has to advance with each evaluation, and the config query never refetches.
+  const lastEvaluatedAt = data?.target?.metricAlertRule?.lastEvaluatedAt;
   const operationsStats = data?.target?.operationsStats ?? null;
   const hasNoData = !data;
   const stateLogStatus =
@@ -371,7 +373,7 @@ function RuleStateLogSection(props: {
           direction={rule.direction}
           thresholdType={rule.thresholdType}
           timeWindowMinutes={rule.timeWindowMinutes}
-          evaluatedAt={rule.lastEvaluatedAt}
+          evaluatedAt={lastEvaluatedAt}
         />
       </section>
 


### PR DESCRIPTION
This PR fixes two ways the metric alert detail chart misrepresented what a rule was actually evaluating, plus a piece of help text that set the wrong expectation.

**The chart ignored its range selector.** It clipped the series to the rule's evaluation window, which is right for the create/edit preview (it fetches ~2 windows on purpose) but wrong for the detail page, where a 1-minute rule collapsed a full hour into 60 seconds. Clipping is now opt-in.

**`current` scored the wrong minute.** It used the newest bucket, which is in-flight and partial. The evaluator ends its window 60s earlier to avoid exactly that, so on a short rule the two covered non-overlapping minutes and the chart could read `current 0` while the rule correctly read 7. It now anchors on `lastEvaluatedAt` and shades the scored window.

**Hold minutes said "fire immediately" at 0.** Reaching FIRING always takes two consecutive breached checks, so 0 and 1 behave identically. Copy now matches behavior.

No evaluator changes: the state machine was correct throughout.
