### PR TITLE
Add schema check composed SDL fields to public API

### DIFF
--- a/.changeset/tough-lands-rule.md
+++ b/.changeset/tough-lands-rule.md
@@ -1,0 +1,16 @@
+---
+'hive': patch
+---
+
+Add schema check composed SDL fields to public API
+
+```graphql
+query CheckComposedSchemas($targetRef: TargetReferenceInput!, $checkId: ID!) {
+  target(reference:  $targetRef) {
+    schemaCheck(id: $checkId) {
+      compositeSchemaSDL # newly added
+      supergraphSDL  # newly added
+    }
+  }
+}
+```

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -1639,8 +1639,8 @@ export default gql`
     """
     schemaPolicyErrors: SchemaPolicyWarningConnection
 
-    compositeSchemaSDL: String
-    supergraphSDL: String
+    compositeSchemaSDL: String @tag(name: "public")
+    supergraphSDL: String @tag(name: "public")
     """
     Results of the contracts
     """


### PR DESCRIPTION
### Background

Some organizations may want ephemeral environments for changes. Currently, this is supported via `hive dev` but requires additional data passing to accommodate.

### Description

By exposing the composed API and supergraph for schema checks via our API, we better support this use case. Systems can now pass around only the schema check ID and fetch the supergraph etc from hive api as needed.