### PR TITLE
feat: apollo persisted query manifest support

### DIFF
--- a/.changeset/funny-moles-kick.md
+++ b/.changeset/funny-moles-kick.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': minor
+---
+
+Support uploading an Apollo persisted query manifest file with the `hive app:create` command.

--- a/integration-tests/tests/cli/app.spec.ts
+++ b/integration-tests/tests/cli/app.spec.ts
@@ -320,7 +320,7 @@ test('app:create accepts an Apollo persisted query manifest', async () => {
   expect(result.target?.appDeployment?.documents?.edges.map(edge => edge.node)).toEqual(
     expect.arrayContaining([
       {
-        hash: 'apollo-operation-1',
+        hash: 'sha256:apollo-operation-1',
         body: 'query GetHello { hello }',
       },
       {

--- a/integration-tests/tests/cli/app.spec.ts
+++ b/integration-tests/tests/cli/app.spec.ts
@@ -245,6 +245,92 @@ test('app:create accepts a JSON file as operations input', async () => {
   });
 });
 
+test('app:create accepts an Apollo persisted query manifest', async () => {
+  const { createOrg } = await initSeed().createOwner();
+  const { createProject, setFeatureFlag, organization } = await createOrg();
+  await setFeatureFlag('appDeployments', true);
+  const { createTargetAccessToken, project, target } = await createProject();
+  const token = await createTargetAccessToken({});
+
+  await token.publishSchema({
+    sdl: /* GraphQL */ `
+      type Query {
+        hello: String
+        goodbye: String
+      }
+    `,
+  });
+
+  const manifest = {
+    format: 'apollo-persisted-query-manifest',
+    version: 1,
+    operations: [
+      {
+        id: 'sha256:apollo-operation-1',
+        body: 'query GetHello { hello }',
+        name: 'GetHello',
+        type: 'query',
+      },
+      {
+        id: 'apollo-operation-2',
+        body: 'query GetGoodbye { goodbye }',
+        name: 'GetGoodbye',
+        type: 'query',
+      },
+    ],
+  };
+  const operationsFile = join(tmpdir(), `apollo-operations-${Date.now()}.json`);
+  await writeFile(operationsFile, JSON.stringify(manifest), 'utf-8');
+
+  await appCreate([
+    '--registry.accessToken',
+    token.secret,
+    '--name',
+    'apollo-manifest-app',
+    '--version',
+    '1.0.0',
+    operationsFile,
+  ]);
+
+  await appPublish([
+    '--registry.accessToken',
+    token.secret,
+    '--name',
+    'apollo-manifest-app',
+    '--version',
+    '1.0.0',
+  ]);
+
+  const result = await execute({
+    document: CLI_GetAppDeploymentDocuments,
+    variables: {
+      targetSelector: {
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
+      },
+      appDeploymentName: 'apollo-manifest-app',
+      appDeploymentVersion: '1.0.0',
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+
+  expect(result.target?.appDeployment?.status).toBe('active');
+  expect(result.target?.appDeployment?.documents?.edges).toHaveLength(2);
+  expect(result.target?.appDeployment?.documents?.edges.map(edge => edge.node)).toEqual(
+    expect.arrayContaining([
+      {
+        hash: 'apollo-operation-1',
+        body: 'query GetHello { hello }',
+      },
+      {
+        hash: 'apollo-operation-2',
+        body: 'query GetGoodbye { goodbye }',
+      },
+    ]),
+  );
+});
+
 test('app:create accepts a directory of .graphql files as operations input', async () => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject, setFeatureFlag, organization } = await createOrg();

--- a/packages/libraries/cli/src/commands/app/create.ts
+++ b/packages/libraries/cli/src/commands/app/create.ts
@@ -117,19 +117,22 @@ export default class AppCreate extends Command<typeof AppCreate> {
     if (isFile) {
       const contents = this.readJSON(file);
       const operations: unknown = JSON.parse(contents);
-      const apolloValidationResult = ApolloManifestModel.safeParse(operations);
       const manifestValidationResult = ManifestModel.safeParse(operations);
 
       let entries: Array<[string, string]>;
-      if (apolloValidationResult.success) {
-        entries = apolloValidationResult.data.operations.map(operation => [
-          operation.id,
-          operation.body,
-        ]);
-      } else if (manifestValidationResult.success) {
+
+      if (manifestValidationResult.success) {
         entries = Object.entries(manifestValidationResult.data);
       } else {
-        throw new PersistedOperationsMalformedError(file);
+        const apolloValidationResult = ApolloManifestModel.safeParse(operations);
+        if (apolloValidationResult.success) {
+          entries = apolloValidationResult.data.operations.map(operation => [
+            operation.id,
+            operation.body,
+          ]);
+        } else {
+          throw new PersistedOperationsMalformedError(file);
+        }
       }
 
       manifest = {};

--- a/packages/libraries/cli/src/commands/app/create.ts
+++ b/packages/libraries/cli/src/commands/app/create.ts
@@ -54,7 +54,7 @@ export default class AppCreate extends Command<typeof AppCreate> {
       name: 'operations',
       required: true,
       description:
-        'Path to the persisted operations manifest (JSON file), a directory containing .graphql files, or a glob pattern matching .graphql files.',
+        'Path to the persisted operations manifest (GraphQL Code Generator, Relay or Apollo persisted query manifest JSON file), a directory containing .graphql files, or a glob pattern matching .graphql files.',
       hidden: false,
     }),
   };
@@ -117,11 +117,26 @@ export default class AppCreate extends Command<typeof AppCreate> {
     if (isFile) {
       const contents = this.readJSON(file);
       const operations: unknown = JSON.parse(contents);
-      const validationResult = ManifestModel.safeParse(operations);
-      if (validationResult.success === false) {
+      const apolloValidationResult = ApolloManifestModel.safeParse(operations);
+      const manifestValidationResult = ManifestModel.safeParse(operations);
+
+      let entries: Array<[string, string]>;
+      if (apolloValidationResult.success) {
+        entries = apolloValidationResult.data.operations.map(operation => [
+          operation.id,
+          operation.body,
+        ]);
+      } else if (manifestValidationResult.success) {
+        entries = Object.entries(manifestValidationResult.data);
+      } else {
         throw new PersistedOperationsMalformedError(file);
       }
-      manifest = validationResult.data;
+
+      manifest = {};
+      for (const [hash, body] of entries) {
+        const normalizedHash = hash.replace(/^[a-z][a-z0-9-]*:/i, '');
+        manifest[normalizedHash] = body;
+      }
     } else {
       // file is a glob or directory - generate the manifest in-memory
       const globPattern = (() => {
@@ -311,6 +326,17 @@ export default class AppCreate extends Command<typeof AppCreate> {
 }
 
 const ManifestModel = z.record(z.string());
+
+const ApolloManifestModel = z.object({
+  format: z.literal('apollo-persisted-query-manifest'),
+  version: z.literal(1),
+  operations: z.array(
+    z.object({
+      id: z.string(),
+      body: z.string(),
+    }),
+  ),
+});
 
 const CreateAppDeploymentMutation = graphql(/* GraphQL */ `
   mutation CreateAppDeployment($input: CreateAppDeploymentInput!) {

--- a/packages/libraries/cli/src/commands/app/create.ts
+++ b/packages/libraries/cli/src/commands/app/create.ts
@@ -134,11 +134,7 @@ export default class AppCreate extends Command<typeof AppCreate> {
         }
       }
 
-      manifest = {};
-      for (const [hash, body] of entries) {
-        const normalizedHash = hash.replace(/^[a-z][a-z0-9-]*:/i, '');
-        manifest[normalizedHash] = body;
-      }
+      manifest = Object.fromEntries(entries);
     } else {
       // file is a glob or directory - generate the manifest in-memory
       const globPattern = (() => {

--- a/packages/libraries/cli/src/commands/app/create.ts
+++ b/packages/libraries/cli/src/commands/app/create.ts
@@ -117,9 +117,8 @@ export default class AppCreate extends Command<typeof AppCreate> {
     if (isFile) {
       const contents = this.readJSON(file);
       const operations: unknown = JSON.parse(contents);
-      const manifestValidationResult = ManifestModel.safeParse(operations);
-
       let entries: Array<[string, string]>;
+      const manifestValidationResult = ManifestModel.safeParse(operations);
 
       if (manifestValidationResult.success) {
         entries = Object.entries(manifestValidationResult.data);

--- a/packages/libraries/cli/src/helpers/errors.ts
+++ b/packages/libraries/cli/src/helpers/errors.ts
@@ -355,7 +355,8 @@ export class PersistedOperationsMalformedError extends HiveCLIError {
     super(
       ExitCode.BAD_INIT,
       errorCode(ErrorCategory.APP_CREATE, 0),
-      `Persisted Operations file "${file}" is malformed.`,
+      `Persisted Operations file "${file}" is malformed.` +
+        ' Please make sure it follows either the GraphQL Code Generator, Relay or Apollo Persisted Query Manifest Format.',
     );
   }
 }


### PR DESCRIPTION
Adds support for apollo persisted document manifest when doing `hive app:create`.

docs: https://github.com/graphql-hive/docs/pull/164