### PR TITLE
fix: omit sha prefix not supported by the registry

### DIFF
--- a/.changeset/tame-turtles-matter.md
+++ b/.changeset/tame-turtles-matter.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+Strip out `hash:` prefix from hash uploaded to the schema registry.

--- a/integration-tests/tests/cli/app.spec.ts
+++ b/integration-tests/tests/cli/app.spec.ts
@@ -200,7 +200,7 @@ test('app:create accepts a JSON file as operations input', async () => {
     `,
   });
 
-  const manifest = { 'op-hash-1': 'query { hello }' };
+  const manifest = { 'sha256:op-hash-1': 'query { hello }' };
   const operationsFile = join(tmpdir(), `operations-${Date.now()}.json`);
   await writeFile(operationsFile, JSON.stringify(manifest), 'utf-8');
 

--- a/packages/libraries/cli/src/commands/app/create.ts
+++ b/packages/libraries/cli/src/commands/app/create.ts
@@ -270,7 +270,7 @@ export default class AppCreate extends Command<typeof AppCreate> {
     };
 
     for (const [hash, body] of Object.entries(manifest)) {
-      buffer.push({ hash, body });
+      buffer.push({ hash: hash.replace(/^[a-z][a-z0-9-]*:/i, ''), body });
       counter++;
       await flush();
     }


### PR DESCRIPTION
Latest codegen version introduced that the persisted document contains the sha hash as part of the document map.