### PR TITLE
fix: persisted documents hash allow colon

### DIFF
--- a/.changeset/sweet-feet-find.md
+++ b/.changeset/sweet-feet-find.md
@@ -1,0 +1,5 @@
+---
+'hive': minor
+---
+
+Allow colon characters (`:`) as part of the persisted documents hash. This allows uploading a persisted document manifest that contains a hash prefixed with the algorithm, e.g. `sha1:c9a2a17494906eeb5fff2c81a1980ae1c0b6650f`.

--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -758,6 +758,62 @@ test('add documents to app deployment fails if document hash is less than 1 char
   });
 });
 
+test('add documents to app deployment accepts a hash with an algorithm prefix', async () => {
+  const { createOrg } = await initSeed().createOwner();
+  const { createProject, setFeatureFlag } = await createOrg();
+  await setFeatureFlag('appDeployments', true);
+  const { createTargetAccessToken } = await createProject();
+  const token = await createTargetAccessToken({});
+
+  await token.publishSchema({
+    sdl: /* GraphQL */ `
+      type Query {
+        hello: String
+      }
+    `,
+  });
+
+  await execute({
+    document: CreateAppDeployment,
+    variables: {
+      input: {
+        appName: 'my-app',
+        appVersion: '1.0.0',
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+
+  const { addDocumentsToAppDeployment } = await execute({
+    document: AddDocumentsToAppDeployment,
+    variables: {
+      input: {
+        appName: 'my-app',
+        appVersion: '1.0.0',
+        documents: [
+          {
+            hash: 'sha256:abc123',
+            body: 'query { hello }',
+          },
+        ],
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+
+  expect(addDocumentsToAppDeployment).toEqual({
+    error: null,
+    ok: {
+      appDeployment: {
+        id: expect.any(String),
+        name: 'my-app',
+        version: '1.0.0',
+        status: 'pending',
+      },
+    },
+  });
+});
+
 test('add documents to app deployment fails if document hash is longer than 256 characters', async () => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject, setFeatureFlag } = await createOrg();

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
@@ -35,8 +35,8 @@ const AppDeploymentOperationHashModel = z
   .min(1, 'Hash must be at least 1 characters long')
   .max(128, 'Hash must be at most 128 characters long')
   .regex(
-    /^([A-Za-z]|[0-9]|_|-)+$/,
-    "Operation hash can only contain letters, numbers, '_', and '-'",
+    /^([A-Za-z]|[0-9]|_|-|:)+$/,
+    "Operation hash can only contain letters, numbers, '_', ':' and '-'",
   );
 
 const AppDeploymentOperationBodyModel = z.string().min(3, 'Body must be at least 3 character long');


### PR DESCRIPTION
Latest graphql codegen introduced hashes being prefixed with `hash:`. In order to support that, we can just allow the colon character for the persisted document hash.