### PR TITLE
fix: monolith promotion to empty target

### DIFF
--- a/.changeset/dry-nails-prove.md
+++ b/.changeset/dry-nails-prove.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Fix internal server error when promoting a monolith schema to an empty target.

--- a/integration-tests/tests/api/schema/promotion.spec.ts
+++ b/integration-tests/tests/api/schema/promotion.spec.ts
@@ -1165,7 +1165,7 @@ test.concurrent('promote monolith version to empty target', async () => {
     privateAccessKey,
   ).then(r => r.expectNoGraphQLErrors());
 
-  const [versionToPromote] = await fetchVersions(2);
+  const [versionToPromote] = await fetchVersions(1);
 
   assertNonNullish(otherTarget.createTarget.ok);
   let promoteResult = await schemaVersionPromote(

--- a/integration-tests/tests/api/schema/promotion.spec.ts
+++ b/integration-tests/tests/api/schema/promotion.spec.ts
@@ -1131,3 +1131,57 @@ test.concurrent('promote monolith schema version succeeds', async ({ expect }) =
   });
   expect(promotedVersionDetails.sdl).toContain('b: String!');
 });
+
+test.concurrent('promote monolith version to empty target', async () => {
+  const { createOrg } = await initSeed().createOwner();
+  const { createProject, createOrganizationAccessToken } = await createOrg();
+  const { target, fetchVersions, createTarget } = await createProject(ProjectType.Single);
+  const otherTarget = await createTarget().then(r => r.expectNoGraphQLErrors());
+  const { privateAccessKey } = await createOrganizationAccessToken({
+    resources: {
+      mode: ResourceAssignmentModeType.All,
+    },
+    permissions: [
+      'schemaVersion:publish',
+      'target:modifySettings',
+      'project:describe',
+      'schemaVersion:promote',
+    ],
+  });
+
+  await publishSchema(
+    {
+      author: 'a',
+      commit: 'a',
+      sdl: /* GraphQL */ `
+        type Query {
+          a: String!
+        }
+      `,
+      target: {
+        byId: target.id,
+      },
+    },
+    privateAccessKey,
+  ).then(r => r.expectNoGraphQLErrors());
+
+  const [versionToPromote] = await fetchVersions(2);
+
+  assertNonNullish(otherTarget.createTarget.ok);
+  let promoteResult = await schemaVersionPromote(
+    {
+      source: {
+        fromSchemaVersionById: versionToPromote.id,
+      },
+      target: {
+        toTarget: {
+          byId: otherTarget.createTarget.ok.createdTarget.id,
+        },
+      },
+    },
+    privateAccessKey,
+  ).then(r => r.expectNoGraphQLErrors());
+
+  expect(promoteResult.schemaVersionPromote.error).toEqual(null);
+  assertNonNullish(promoteResult.schemaVersionPromote.ok);
+});

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -2416,7 +2416,7 @@ export class SchemaPublisher {
     );
 
     return {
-      deleted: [],
+      removed: [],
       added: [],
       changed: [
         {
@@ -2526,7 +2526,7 @@ export class SchemaPublisher {
     // Let's create the new Graph version edges and delete logs (if needed)
 
     const schemaLogs: SchemaLogDiffInput = {
-      deleted: [],
+      removed: [],
       added: [],
       changed: [],
       unchanged: [],
@@ -2538,13 +2538,13 @@ export class SchemaPublisher {
 
         // Note: we seed the ID here so we do not need to map some more within the logic within `SchemaVersions.promoteSchemaVersionToTarget`
         const logId = crypto.randomUUID();
-        schemaLogs.deleted.push({
+        schemaLogs.removed.push({
           id: logId,
           previousId: diff.previousLog.id,
           serviceName: diff.previousLog.service_name,
           targetId: args.target.id,
           projectId: args.target.projectId,
-          type: 'deleted',
+          type: 'removed',
         });
         continue;
       }
@@ -2607,7 +2607,7 @@ export class SchemaPublisher {
     this.logger.debug(
       'producing schema log diff finished (addedCount=%d, deletedCount=%d, changedCount=%d).',
       schemaLogs.added.length,
-      schemaLogs.deleted.length,
+      schemaLogs.removed.length,
       schemaLogs.changed.length,
       schemaLogs.unchanged.length,
     );

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -2400,8 +2400,40 @@ export class SchemaPublisher {
       });
   }
 
+  private diffSingleSchemaLogs(args: {
+    logs: {
+      target: Array<SchemaLogWithEdges>;
+      origin: Array<SchemaLogWithEdges>;
+    };
+    target: Target;
+  }): SchemaLogDiffInput {
+    // we do not need to diff the services
+    // the "main" diff already covers all changes
+    invariant(args.logs.origin.length === 1, 'In a single schema there can only be one log.');
+    invariant(args.logs.target.length <= 1, 'In a single schema there can only be up to one log.');
+
+    return {
+      deleted: [],
+      added: [],
+      changed: [
+        {
+          id: args.logs.origin[0].actionId,
+          // we do not need a direct link to the previous log
+          previousId: null,
+          serviceName: null,
+          // we can omit the type for a monolith schema; there is always only one "subgraph"
+          type: null,
+          // there are no service specific changes
+          // the changes are already covered via the main graph
+          changes: null,
+        },
+      ],
+      unchanged: [],
+    };
+  }
+
   @traceFn('SchemaPublisher.diffSchemaLogs')
-  private async diffSchemaLogs(args: {
+  private async diffCompositeSchemaLogs(args: {
     logs: {
       target: Array<SchemaLogWithEdges>;
       origin: Array<SchemaLogWithEdges>;
@@ -2510,6 +2542,7 @@ export class SchemaPublisher {
           serviceName: diff.previousLog.service_name,
           targetId: args.target.id,
           projectId: args.target.projectId,
+          type: 'deleted',
         });
         continue;
       }
@@ -2522,42 +2555,45 @@ export class SchemaPublisher {
           serviceName: diff.newLog.service_name,
           projectId: args.target.projectId,
           targetId: args.target.id,
+          type: 'added',
         });
         continue;
       }
 
       if (diff.type === 'unchanged') {
-        schemaLogs.unchanged.push({ id: diff.log.id, serviceName: diff.log.service_name });
+        schemaLogs.unchanged.push({
+          id: diff.log.id,
+          serviceName: diff.log.service_name,
+          type: 'unchanged',
+        });
         continue;
       }
 
       if (diff.type === 'changed') {
-        let changes = null;
+        invariant(diff.newLog.service_name != null, 'Changed logs require a service name.');
 
-        // We only want a diff for non-monolith schemas
-        if (diff.newLog.service_name) {
-          changes = await this.registryChecks
-            .diff({
-              existingSdl: diff.previousLog.sdl ?? null,
-              incomingSdl: diff.newLog.sdl ?? null,
-              approvedChanges: null,
-              conditionalBreakingChangeConfig: null,
-              includeUrlChanges: false,
-              filterOutFederationChanges: false,
-              failDiffOnDangerousChange: false,
-              failAllDangerousChanges: false,
-              failDangerousChangeTypes: [],
-              filterNestedChanges: true,
-              getAffectedAppDeployments: null,
-            })
-            .then(r => r.result?.all ?? r.reason?.all ?? null);
-        }
+        const changes = await this.registryChecks
+          .diff({
+            existingSdl: diff.previousLog.sdl ?? null,
+            incomingSdl: diff.newLog.sdl ?? null,
+            approvedChanges: null,
+            conditionalBreakingChangeConfig: null,
+            includeUrlChanges: false,
+            filterOutFederationChanges: false,
+            failDiffOnDangerousChange: false,
+            failAllDangerousChanges: false,
+            failDangerousChangeTypes: [],
+            filterNestedChanges: true,
+            getAffectedAppDeployments: null,
+          })
+          .then(r => r.result?.all ?? r.reason?.all ?? null);
 
         schemaLogs.changed.push({
           id: diff.newLog.id,
           previousId: diff.previousLog.id,
           serviceName: diff.newLog.service_name,
           changes,
+          type: 'changed',
         });
         continue;
       }
@@ -2937,13 +2973,21 @@ export class SchemaPublisher {
       contracts,
       conditionalBreakingChangeMetadata,
     ] = await Promise.all([
-      this.diffSchemaLogs({
-        logs: {
-          target: targetLogEdges,
-          origin: originLogEdges,
-        },
-        target,
-      }),
+      project.type === Types.ProjectType.SINGLE
+        ? this.diffSingleSchemaLogs({
+            logs: {
+              target: targetLogEdges,
+              origin: originLogEdges,
+            },
+            target,
+          })
+        : this.diffCompositeSchemaLogs({
+            logs: {
+              target: targetLogEdges,
+              origin: originLogEdges,
+            },
+            target,
+          }),
       this.registryChecks
         .diff({
           existingSdl: targetLatestValidSchemaVersion?.compositeSchemaSDL ?? null,

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -2409,8 +2409,11 @@ export class SchemaPublisher {
   }): SchemaLogDiffInput {
     // we do not need to diff the services
     // the "main" diff already covers all changes
-    invariant(args.logs.origin.length === 1, 'In a single schema there can only be one log.');
-    invariant(args.logs.target.length <= 1, 'In a single schema there can only be up to one log.');
+    invariant(args.logs.origin.length === 1, 'In a monolith project there can only be one log.');
+    invariant(
+      args.logs.target.length <= 1,
+      'In a monolith project there can only be up to one log.',
+    );
 
     return {
       deleted: [],

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -2468,14 +2468,15 @@ export class SchemaPublisher {
         continue;
       }
 
+      invariant(targetLogEdge.node.service_name !== null, 'A service name must exist.');
+
       // Note: we use fallback value of '' to support single schema workflows.
-      const serviceName = targetLogEdge.node.service_name ?? '';
       invariant(
-        diffMap.has(serviceName) === false,
+        diffMap.has(targetLogEdge.node.service_name) === false,
         'Invalid database state. A log for the same service can not appear more than once.',
       );
 
-      diffMap.set(serviceName, {
+      diffMap.set(targetLogEdge.node.service_name, {
         type: 'removed',
         previousLog: targetLogEdge.node,
       });
@@ -2486,13 +2487,11 @@ export class SchemaPublisher {
         continue;
       }
 
-      const serviceName = originLogEdge.node.service_name ?? '';
+      invariant(originLogEdge.node.service_name !== null, 'A service name must exist.');
 
-      let record = diffMap.get(serviceName);
+      let record = diffMap.get(originLogEdge.node.service_name);
 
       if (!record) {
-        invariant(originLogEdge.node.service_name !== null, 'A service name must exist.');
-
         diffMap.set(originLogEdge.node.service_name, {
           type: 'added',
           newLog: originLogEdge.node,
@@ -2503,7 +2502,7 @@ export class SchemaPublisher {
       invariant(record.type === 'removed', 'At this point the type can only be removed.');
 
       if (record.previousLog.id === originLogEdge.node.id) {
-        diffMap.set(serviceName, {
+        diffMap.set(originLogEdge.node.service_name, {
           type: 'unchanged',
           log: record.previousLog,
         });
@@ -2511,7 +2510,7 @@ export class SchemaPublisher {
       }
 
       if (record.previousLog.id !== originLogEdge.node.id) {
-        diffMap.set(serviceName, {
+        diffMap.set(originLogEdge.node.service_name, {
           type: 'changed',
           newLog: originLogEdge.node,
           previousLog: record.previousLog,

--- a/packages/services/api/src/modules/schema/providers/schema-version-store.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-store.ts
@@ -1051,7 +1051,6 @@ export class SchemaVersionStore {
       const edgesBySchemaVersionId = new Map<string, Array<RawSchemaLogEdge>>();
 
       for (const row of rows) {
-        console.log(row);
         const edge = RawSchemaLogEdgeModel.parse(row);
         let edges = edgesBySchemaVersionId.get(edge.schemaVersionId);
         if (!Array.isArray(edges)) {

--- a/packages/services/api/src/modules/schema/providers/schema-version-store.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-store.ts
@@ -1350,7 +1350,7 @@ export class SchemaVersionStore {
         });
       }
 
-      if (args.schemaLogs.deleted.length) {
+      if (args.schemaLogs.removed.length) {
         // Insert new nodes
         const insertDeleteSchemaLogsQuery = psql` /* insertDeleteSchemaLogs */
           INSERT INTO "schema_log" (
@@ -1363,7 +1363,7 @@ export class SchemaVersionStore {
             , "action"
           )
           SELECT * FROM ${psql.unnest(
-            args.schemaLogs.deleted.map(log => [
+            args.schemaLogs.removed.map(log => [
               log.id,
               log.projectId,
               log.targetId,
@@ -1383,7 +1383,7 @@ export class SchemaVersionStore {
       if (
         args.schemaLogs.added.length ||
         args.schemaLogs.changed.length ||
-        args.schemaLogs.deleted.length ||
+        args.schemaLogs.removed.length ||
         args.schemaLogs.unchanged.length
       ) {
         const insertAddedAndChangedSchemaLogEdges = psql` /* insertAddedAndChangedSchemaLogEdges */
@@ -1396,7 +1396,7 @@ export class SchemaVersionStore {
             , "subgraph_name"
           )
           SELECT * FROM ${psql.unnest(
-            args.schemaLogs.deleted
+            args.schemaLogs.removed
               .map(log => [
                 schemaVersion.id,
                 log.id,
@@ -1758,13 +1758,13 @@ const schemaLogEdgesFields = (prefix = psql``) => psql`
 `;
 
 export type SchemaLogDiffInput = {
-  deleted: Array<{
+  removed: Array<{
     id: string;
     previousId: string;
     serviceName: string;
     targetId: string;
     projectId: string;
-    type: 'deleted';
+    type: 'removed';
   }>;
   added: Array<{
     id: string;

--- a/packages/services/api/src/modules/schema/providers/schema-version-store.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-store.ts
@@ -1051,6 +1051,7 @@ export class SchemaVersionStore {
       const edgesBySchemaVersionId = new Map<string, Array<RawSchemaLogEdge>>();
 
       for (const row of rows) {
+        console.log(row);
         const edge = RawSchemaLogEdgeModel.parse(row);
         let edges = edgesBySchemaVersionId.get(edge.schemaVersionId);
         if (!Array.isArray(edges)) {
@@ -1400,7 +1401,7 @@ export class SchemaVersionStore {
               .map(log => [
                 schemaVersion.id,
                 log.id,
-                'removed',
+                log.type,
                 log.previousId,
                 null,
                 log.serviceName,
@@ -1409,7 +1410,7 @@ export class SchemaVersionStore {
                 args.schemaLogs.changed.map(log => [
                   schemaVersion.id,
                   log.id,
-                  'changed',
+                  log.type,
                   log.previousId,
                   JSON.stringify(log.changes?.map(toSerializableSchemaChange)) ?? null,
                   log.serviceName,
@@ -1419,7 +1420,7 @@ export class SchemaVersionStore {
                 args.schemaLogs.added.map(log => [
                   schemaVersion.id,
                   log.id,
-                  'added',
+                  log.type,
                   null,
                   null,
                   log.serviceName,
@@ -1429,7 +1430,7 @@ export class SchemaVersionStore {
                 args.schemaLogs.unchanged.map(log => [
                   schemaVersion.id,
                   log.id,
-                  'unchanged',
+                  log.type,
                   null,
                   null,
                   log.serviceName,
@@ -1764,15 +1765,32 @@ export type SchemaLogDiffInput = {
     serviceName: string;
     targetId: string;
     projectId: string;
+    type: 'deleted';
   }>;
-  added: Array<{ id: string; serviceName: string; targetId: string; projectId: string }>;
-  changed: Array<{
+  added: Array<{
     id: string;
-    previousId: string | null;
-    serviceName: string | null;
-    changes: Array<SchemaChangeType> | null;
+    serviceName: string;
+    targetId: string;
+    projectId: string;
+    type: 'added';
   }>;
-  unchanged: Array<{ id: string; serviceName: string | null }>;
+  changed: Array<
+    | {
+        id: string;
+        previousId: string | null;
+        serviceName: string;
+        type: 'changed';
+        changes: Array<SchemaChangeType> | null;
+      }
+    | {
+        id: string;
+        previousId: null;
+        serviceName: null;
+        type: null;
+        changes: null;
+      }
+  >;
+  unchanged: Array<{ id: string; serviceName: string | null; type: 'unchanged' }>;
 };
 
 const SchemaLogWithEdgesModel = z.union([


### PR DESCRIPTION
Fixes a monolith schema promotion to an empty target (no prior published schema) raise an internal server error.

The logic had flaws for handling the monolith schema correctly. Instead of bending the implementation to cover both composite and monolith, we now shortcut in the monolith scenario as most of the additional information we store is not needed anyways.