### PR TITLE
bump otel collector alpine version

### DIFF
--- a/.changeset/fifty-months-sit.md
+++ b/.changeset/fifty-months-sit.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Bump `otel-collector` docker image otel collector version from `3.14.10` to `3.22`.

--- a/docker/otel-collector.dockerfile
+++ b/docker/otel-collector.dockerfile
@@ -21,7 +21,7 @@ COPY --from=config extension-statsviz/ ./extension-statsviz/
 RUN CGO_ENABLED=0 builder --config=/build/builder-config.yaml
 
 # Stage 2: Final Image
-FROM alpine:3.14
+FROM alpine:3.22
 
 WORKDIR /app
 


### PR DESCRIPTION
Your Alpine Linux version is no longer receiving security updates since 2023-05-01.