### PR TITLE
fix: correct status code for armor protection + do not reject typenames injected via response cache + hive sdk

### DIFF
--- a/.changeset/nice-states-greet.md
+++ b/.changeset/nice-states-greet.md
@@ -1,0 +1,6 @@
+---
+'hive': patch
+---
+
+Send correct status code 400 when alias limit, maximum directive count, max depth limit or token
+limit is exceeded for incoming operation.

--- a/.changeset/plain-maps-cheat.md
+++ b/.changeset/plain-maps-cheat.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway-plugin-console-sdk': patch
+'@graphql-hive/yoga': patch
+---
+
+Prevent validation failure by modifying selection set with hive specific typename aliases within
+`onExecute` plugin hook instead of `onParse` hook.

--- a/integration-tests/tests/api/armor.spec.ts
+++ b/integration-tests/tests/api/armor.spec.ts
@@ -1,0 +1,46 @@
+import { getServiceHost } from '../../testkit/utils';
+
+const registryAddress = await getServiceHost('server', 8082);
+const endpoint = `http://${registryAddress}/graphql`;
+
+test('returns 400 when the maximum number of aliases is exceeded', async () => {
+  const aliases = Array.from({ length: 21 }, (_, index) => `alias${index}: __typename`);
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      accept: 'application/graphql-response+json',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ query: `{ ${aliases.join('\n')} }` }),
+  });
+
+  expect(response.status).toBe(400);
+  expect(await response.json()).toMatchObject({
+    errors: [
+      {
+        message: expect.stringContaining('Aliases limit of 20 exceeded'),
+      },
+    ],
+  });
+});
+
+test('returns 400 when the maximum number of tokens is exceeded', async () => {
+  const fields = Array.from({ length: 801 }, () => '__typename');
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      accept: 'application/graphql-response+json',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ query: `{ ${fields.join('\n')} }` }),
+  });
+
+  expect(response.status).toBe(400);
+  expect(await response.json()).toMatchObject({
+    errors: [
+      {
+        message: expect.stringContaining('Token limit of 800 exceeded'),
+      },
+    ],
+  });
+});

--- a/integration-tests/tests/api/armor.spec.ts
+++ b/integration-tests/tests/api/armor.spec.ts
@@ -3,6 +3,29 @@ import { getServiceHost } from '../../testkit/utils';
 const registryAddress = await getServiceHost('server', 8082);
 const endpoint = `http://${registryAddress}/graphql`;
 
+test.each(['__hive_typename__', '__responseCacheTypeName', '__responseCacheId'])(
+  'returns 400 when the reserved alias %s is used',
+  async alias => {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        accept: 'application/graphql-response+json',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ query: `{ ${alias}: __typename }` }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      errors: [
+        {
+          message: `The alias "${alias}" cannot be used.`,
+        },
+      ],
+    });
+  },
+);
+
 test('returns 400 when the maximum number of aliases is exceeded', async () => {
   const aliases = Array.from({ length: 21 }, (_, index) => `alias${index}: __typename`);
   const response = await fetch(endpoint, {

--- a/packages/libraries/gateway-plugin-console-sdk/src/index.ts
+++ b/packages/libraries/gateway-plugin-console-sdk/src/index.ts
@@ -152,7 +152,9 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
           operationCache.set(query, args.document === modifiedDocument || modifiedDocument);
         }
         if (args.document !== modifiedDocument) {
-          setExecuteFn(executionArgs => executeFn({ ...executionArgs, document: modifiedDocument }));
+          setExecuteFn(executionArgs =>
+            executeFn({ ...executionArgs, document: modifiedDocument }),
+          );
         }
       }
 

--- a/packages/libraries/gateway-plugin-console-sdk/src/index.ts
+++ b/packages/libraries/gateway-plugin-console-sdk/src/index.ts
@@ -129,38 +129,31 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
       latestSchema = schema;
       operationCache?.clear();
     },
-    onParse(parseCtx) {
-      return ctx => {
-        if (ctx.result.kind === 'Document' && fieldLevelMetricsEnabled && operationCache) {
-          // We need __typename on every object in the subgraph result so we can
-          // resolve abstract types (unions/interfaces) to concrete type coordinates
-          // when recording field-level metrics downstream.
-          // This is done here for more performant caching of the result.
-          const query = parseCtx.params.source;
-          const cachedDocument = operationCache.get(query);
-          if (cachedDocument) {
-            // If "true" is cached, then this operation doesn't need stored because it's identical to the original.
-            // Else, the document hash been modified and cached
-            if (cachedDocument !== true) {
-              parseCtx.setParsedDocument(cachedDocument);
-            }
-          } else if (latestSchema) {
-            const modifiedDocument = addHiveTypenames(ctx.result, latestSchema);
-            operationCache.set(query, ctx.result === modifiedDocument || modifiedDocument);
-            if (ctx.result !== modifiedDocument) {
-              parseCtx.setParsedDocument(modifiedDocument);
-            }
-          }
-        }
-      };
-    },
-    onExecute({ args }) {
+    onExecute({ args, executeFn, setExecuteFn }) {
       const collection = hive.collectUsage();
 
       // Inject the collection object into the GraphQL context
       // so it can be accessed downstream by subgraph executions.
       if (args.contextValue) {
         (args.contextValue as any).__hiveUsageCollection = collection;
+      }
+
+      if (fieldLevelMetricsEnabled && operationCache && latestSchema) {
+        // Validation must run against the client document. Add the metadata fields only
+        // to the document passed to execution and cache that transformed document.
+        const query = args.document.loc?.source.body;
+        const cachedDocument = query ? operationCache.get(query) : undefined;
+        const modifiedDocument =
+          cachedDocument === true
+            ? args.document
+            : cachedDocument || addHiveTypenames(args.document, latestSchema);
+
+        if (query && cachedDocument === undefined) {
+          operationCache.set(query, args.document === modifiedDocument || modifiedDocument);
+        }
+        if (args.document !== modifiedDocument) {
+          setExecuteFn(executionArgs => executeFn({ ...executionArgs, document: modifiedDocument }));
+        }
       }
 
       return {

--- a/packages/libraries/gateway-plugin-console-sdk/tests/index.spec.ts
+++ b/packages/libraries/gateway-plugin-console-sdk/tests/index.spec.ts
@@ -1,5 +1,5 @@
-import type { GraphQLResolveInfo } from 'graphql';
-import { createSchema, createYoga } from 'graphql-yoga';
+import { GraphQLError, ValidationRule, type GraphQLResolveInfo } from 'graphql';
+import { createSchema, createYoga, type Plugin } from 'graphql-yoga';
 import { createGatewayRuntime } from '@graphql-hive/gateway-runtime';
 import { createHive, useHive } from '../src';
 
@@ -36,9 +36,25 @@ describe('field-level usage reporting', () => {
         Query: { item: itemResolver },
       },
     });
+
+    const rule: ValidationRule = context => ({
+      Field(node) {
+        if (node.alias?.value === '__hive_typename__') {
+          context.reportError(new GraphQLError('Hive typename was injected too early'));
+        }
+      },
+    });
+
+    const validationPlugin: Plugin = {
+      onValidate({ addValidationRule }) {
+        addValidationRule(rule);
+      },
+    };
+
     await using yoga = createYoga({
       schema: () => schema,
       plugins: [
+        validationPlugin,
         useHive({
           enabled: false,
           token: 'dummy-token',

--- a/packages/libraries/yoga/src/index.ts
+++ b/packages/libraries/yoga/src/index.ts
@@ -111,7 +111,8 @@ export function useHive(clientOrOptions: HiveClient | YogaPluginOptions): Plugin
         });
       }
     },
-    // since response-cache modifies the executed GraphQL document, we need to extract it after parsing.
+    // Capture the original parsed document before execution plugins transform it,
+    // so usage reporting reflects the client operation.
     onParse(parseCtx) {
       return ctx => {
         const result = ctx.result as ASTNode;
@@ -122,35 +123,34 @@ export function useHive(clientOrOptions: HiveClient | YogaPluginOptions): Plugin
             record.parsedDocument = result;
             parsedDocumentCache.set(parseCtx.params.source, result);
           }
-
-          if (fieldLevelMetricsEnabled && operationCache) {
-            // We need __typename on every object in the result so we can
-            // resolve abstract types (unions/interfaces) to concrete type coordinates
-            // when recording field-level metrics downstream.
-            // This is done here for more performant caching of the result.
-            const query = parseCtx.params.source;
-            const cachedDocument = operationCache.get(query);
-            if (cachedDocument) {
-              // If "true" is cached, then this operation doesn't need stored because it's identical to the original.
-              // Else, the document hash been modified and cached
-              if (cachedDocument !== true) {
-                parseCtx.setParsedDocument(cachedDocument);
-              }
-            } else if (latestSchema) {
-              const modifiedDocument = addHiveTypenames(ctx.result, latestSchema);
-              operationCache.set(query, result === modifiedDocument || modifiedDocument);
-              if (result !== modifiedDocument) {
-                parseCtx.setParsedDocument(modifiedDocument);
-              }
-            }
-          }
         }
       };
     },
-    onExecute() {
+    onExecute({ args, executeFn, setExecuteFn }) {
+      const record = contextualCache.get(args.contextValue);
+
+      if (fieldLevelMetricsEnabled && operationCache && latestSchema) {
+        // Validation must run against the client document. Add the metadata fields only
+        // to the document passed to execution and cache that transformed document.
+        const query = record?.paramsArgs.query || args.document.loc?.source.body;
+        const cachedDocument = query ? operationCache.get(query) : undefined;
+        const modifiedDocument =
+          cachedDocument === true
+            ? args.document
+            : cachedDocument || addHiveTypenames(args.document, latestSchema);
+
+        if (query && cachedDocument === undefined) {
+          operationCache.set(query, args.document === modifiedDocument || modifiedDocument);
+        }
+        if (args.document !== modifiedDocument) {
+          setExecuteFn(executionArgs =>
+            executeFn({ ...executionArgs, document: modifiedDocument }),
+          );
+        }
+      }
+
       return {
         onExecuteDone({ args, result }) {
-          const record = contextualCache.get(args.contextValue);
           if (!record) {
             return;
           }

--- a/packages/libraries/yoga/tests/yoga.spec.ts
+++ b/packages/libraries/yoga/tests/yoga.spec.ts
@@ -1,8 +1,8 @@
 import { createServer } from 'node:http';
-import { GraphQLError } from 'graphql';
+import { GraphQLError, type GraphQLResolveInfo, type ValidationRule } from 'graphql';
 import { createClient } from 'graphql-ws';
 import { useServer as useWSServer } from 'graphql-ws/lib/use/ws';
-import { createLogger, createSchema, createYoga } from 'graphql-yoga';
+import { createLogger, createSchema, createYoga, type Plugin } from 'graphql-yoga';
 import { describe, expect, test, vi } from 'vitest';
 import { WebSocket, WebSocketServer } from 'ws';
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
@@ -32,6 +32,67 @@ const resolvers = {
     },
   },
 };
+
+test('injects Hive typenames after validation', async () => {
+  const executedSelections: string[] = [];
+  await using yoga = createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        interface Item {
+          id: ID!
+        }
+        type Product implements Item {
+          id: ID!
+        }
+        type Query {
+          item: Item
+        }
+      `,
+      resolvers: {
+        Query: {
+          item(_parent: unknown, _args: unknown, _context: unknown, info: GraphQLResolveInfo) {
+            executedSelections.push(
+              ...(info.fieldNodes[0].selectionSet?.selections.flatMap(selection =>
+                selection.kind === 'Field' ? [selection.name.value] : [],
+              ) ?? []),
+            );
+            return { __typename: 'Product', id: '1' };
+          },
+        },
+      },
+    }),
+    plugins: [
+      {
+        onValidate({ addValidationRule }) {
+          addValidationRule((context => ({
+            Field(node) {
+              if (node.alias?.value === '__hive_typename__') {
+                context.reportError(new GraphQLError('Hive typename was injected too early'));
+              }
+            },
+          })) satisfies ValidationRule);
+        },
+      } satisfies Plugin,
+      useHive({
+        enabled: false,
+        token: 'dummy-token',
+        reporting: false,
+        usage: { fieldLevelMetricsEnabled: true },
+      }),
+    ],
+    logging: false,
+  });
+
+  const response = await yoga.fetch('http://localhost/graphql', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ query: '{ item { id } }' }),
+  });
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ data: { item: { id: '1' } } });
+  expect(executedSelections).toEqual(['id', '__typename']);
+});
 
 function handleProcess() {
   function fail(error: any) {

--- a/packages/services/server/src/use-armor.ts
+++ b/packages/services/server/src/use-armor.ts
@@ -40,7 +40,6 @@ export function useArmor<
       ctx.addValidationRule(
         maxAliasesRule({
           n: 20,
-          allowList: ['__responseCacheTypeName', '__responseCacheId', '__hive_typename__'],
           onReject: [
             (context, error) => {
               context?.reportError(error);

--- a/packages/services/server/src/use-armor.ts
+++ b/packages/services/server/src/use-armor.ts
@@ -1,4 +1,4 @@
-import type { ParseOptions, Source } from 'graphql';
+import type { ParseOptions, Source, ValidationRule } from 'graphql';
 import { createGraphQLError, type Plugin } from 'graphql-yoga';
 import promClient from 'prom-client';
 import { maxAliasesRule } from '@escape.tech/graphql-armor-max-aliases';
@@ -28,6 +28,22 @@ const getHiveClientVersion = (userAgent: string | null) => {
   return match ? match[1] : null;
 };
 
+const reservedTypenameAliases = new Set([
+  '__hive_typename__',
+  '__responseCacheTypeName',
+  '__responseCacheId',
+]);
+
+const DisallowReservedAliasesRule: ValidationRule = context => {
+  return {
+    Field(field) {
+      if (field.alias?.value && reservedTypenameAliases.has(field.alias.value)) {
+        context.reportError(createGraphQLError(`The alias "${field.alias.value}" cannot be used.`));
+      }
+    },
+  };
+};
+
 export function useArmor<
   PluginContext extends Record<string, any> = object,
   TServerContext extends Record<string, any> = object,
@@ -37,9 +53,12 @@ export function useArmor<
     onValidate(ctx) {
       const hiveClientVersion = getHiveClientVersion(ctx.context.request.headers.get('user-agent'));
 
+      ctx.addValidationRule(DisallowReservedAliasesRule);
+
       ctx.addValidationRule(
         maxAliasesRule({
           n: 20,
+          allowList: [],
           onReject: [
             (context, error) => {
               context?.reportError(error);

--- a/packages/services/server/src/use-armor.ts
+++ b/packages/services/server/src/use-armor.ts
@@ -1,5 +1,5 @@
 import type { ParseOptions, Source } from 'graphql';
-import type { Plugin } from 'graphql-yoga';
+import { createGraphQLError, type Plugin } from 'graphql-yoga';
 import promClient from 'prom-client';
 import { maxAliasesRule } from '@escape.tech/graphql-armor-max-aliases';
 import { maxDepthRule } from '@escape.tech/graphql-armor-max-depth';
@@ -40,9 +40,10 @@ export function useArmor<
       ctx.addValidationRule(
         maxAliasesRule({
           n: 20,
-          allowList: ['__responseCacheTypeName', '__responseCacheId'],
+          allowList: ['__responseCacheTypeName', '__responseCacheId', '__hive_typename__'],
           onReject: [
-            (_, error) => {
+            (context, error) => {
+              context?.reportError(error);
               rejectedRequests.inc({
                 reason: 'maxAliases',
               });
@@ -59,13 +60,15 @@ export function useArmor<
               }
             },
           ],
+          propagateOnRejection: false,
         }),
       );
       ctx.addValidationRule(
         maxDirectivesRule({
           n: 20,
           onReject: [
-            (_, error) => {
+            (context, error) => {
+              context?.reportError(error);
               rejectedRequests.inc({
                 reason: 'maxDirectives',
               });
@@ -82,6 +85,7 @@ export function useArmor<
               }
             },
           ],
+          propagateOnRejection: false,
         }),
       );
       ctx.addValidationRule(
@@ -90,7 +94,8 @@ export function useArmor<
           flattenFragments: true,
           ignoreIntrospection: true,
           onReject: [
-            (_, error) => {
+            (context, error) => {
+              context?.reportError(error);
               rejectedRequests.inc({
                 reason: 'maxDepth',
               });
@@ -107,16 +112,19 @@ export function useArmor<
               }
             },
           ],
+          propagateOnRejection: false,
         }),
       );
     },
     onParse(ctx) {
       function parseWithTokenLimit(source: string | Source, options: ParseOptions) {
+        let tokenLimitError = null as Error | null;
         const parser = new MaxTokensParserWLexer(source, {
           ...options,
           n: 800,
           onReject: [
             (_, error) => {
+              tokenLimitError = error;
               rejectedRequests.inc({
                 reason: 'maxTokenCount',
               });
@@ -137,7 +145,22 @@ export function useArmor<
             },
           ],
         });
-        return parser.parseDocument();
+
+        try {
+          return parser.parseDocument();
+        } catch (error) {
+          if (tokenLimitError && error === tokenLimitError) {
+            throw createGraphQLError(tokenLimitError.message, {
+              extensions: {
+                http: {
+                  spec: true,
+                  status: 400,
+                },
+              },
+            });
+          }
+          throw error;
+        }
       }
 
       ctx.setParseFn(parseWithTokenLimit);


### PR DESCRIPTION
- The armor rule errors are causing a 500 status code instead of a 400 status code -> adds integration tests and fixes the implementation
- The aliases injected by the hive sdk could cause the alias limit rule kick in -> Instead of injecting the typenames in `onParse` (and before `onValidate`), we now inject them in `onExecute` instead, making sure that it cannot be rejected.
- Adds a validation rule to our armor setup to avoid external API users using the aliases we use internally. This is technically breaking, but if people are sending it they are doing something weird :)