### PR TITLE
fix: skip subscription reporting without subscription type

### DIFF
--- a/.changeset/chubby-sites-grin.md
+++ b/.changeset/chubby-sites-grin.md
@@ -2,5 +2,5 @@
 '@graphql-hive/yoga': patch
 ---
 
-Do not attempt to report a subscription opertion via usage reporting if the schema has no
+Do not attempt to report a subscription operation via usage reporting if the schema has no
 subscription root type.

--- a/.changeset/chubby-sites-grin.md
+++ b/.changeset/chubby-sites-grin.md
@@ -1,0 +1,6 @@
+---
+'@graphql-hive/yoga': patch
+---
+
+Do not attempt to report a subscription opertion via usage reporting if the schema has no
+subscription root type.

--- a/packages/libraries/yoga/src/index.ts
+++ b/packages/libraries/yoga/src/index.ts
@@ -42,7 +42,7 @@ type CacheRecord = {
    */
   parsedDocument?: DocumentNode;
   /** persisted document id */
-  experimental__documentId?: string;
+  documentId?: string;
 };
 
 export type YogaPluginOptions = HivePluginOptions & {
@@ -170,7 +170,7 @@ export function useHive(clientOrOptions: HiveClient | YogaPluginOptions): Plugin
                   document: record.parsedDocument ?? record.executionArgs.document,
                 },
                 result,
-                record.experimental__documentId,
+                record.documentId,
               ),
             );
             return;
@@ -198,7 +198,7 @@ export function useHive(clientOrOptions: HiveClient | YogaPluginOptions): Plugin
                       record.parsedDocument ?? record.executionArgs?.document ?? args.document,
                   },
                   errors.length ? { errors } : {},
-                  record.experimental__documentId,
+                  record.documentId,
                 ),
               );
             },
@@ -207,11 +207,14 @@ export function useHive(clientOrOptions: HiveClient | YogaPluginOptions): Plugin
       };
     },
     onSubscribe(context) {
+      if (!context.args.schema.getSubscriptionType()) {
+        return;
+      }
       const record = contextualCache.get(context.args.contextValue);
 
       return {
         onSubscribeResult() {
-          const experimental__persistedDocumentHash = record?.experimental__documentId;
+          const persistedDocumentId = record?.documentId;
           hive.collectSubscriptionUsage({
             args: {
               ...context.args, // spread the context because the record might not have all the necessary fields
@@ -219,7 +222,7 @@ export function useHive(clientOrOptions: HiveClient | YogaPluginOptions): Plugin
               document:
                 record?.parsedDocument ?? record?.executionArgs?.document ?? context.args.document,
             },
-            experimental__persistedDocumentHash,
+            experimental__persistedDocumentHash: persistedDocumentId,
           });
         },
       };
@@ -253,7 +256,7 @@ export function useHive(clientOrOptions: HiveClient | YogaPluginOptions): Plugin
                 contextValue: serverContext,
               },
               result,
-              record.experimental__documentId,
+              record.documentId,
             ),
           );
         } catch (err) {
@@ -339,7 +342,7 @@ export function useHive(clientOrOptions: HiveClient | YogaPluginOptions): Plugin
               if (document) {
                 const record = contextualCache.get(context);
                 if (record) {
-                  record.experimental__documentId = key;
+                  record.documentId = key;
                   record.paramsArgs = {
                     ...record.paramsArgs,
                     query: document,

--- a/packages/libraries/yoga/src/index.ts
+++ b/packages/libraries/yoga/src/index.ts
@@ -207,6 +207,10 @@ export function useHive(clientOrOptions: HiveClient | YogaPluginOptions): Plugin
       };
     },
     onSubscribe(context) {
+      // In GraphQL.js 16 `onSubscribe` is called even if the schema does not contain a subscription type.
+      // In GraphQL.js 17 there is a new validation rule [`KnownOperationTypes`](https://github.com/graphql/graphql-js/pull/3601)
+      // that prevents `onSubscribe` being called if the schema has no subscription type.
+      // We want to avoid running SDK code here as it would raise an exception in the schema coordinate collection.
       if (!context.args.schema.getSubscriptionType()) {
         return;
       }

--- a/packages/libraries/yoga/tests/yoga.spec.ts
+++ b/packages/libraries/yoga/tests/yoga.spec.ts
@@ -674,6 +674,50 @@ test('respects "graphql-client-name" and "graphql-client-version" headers by def
 });
 
 describe('subscription usage reporting', () => {
+  test('ignores subscribe hooks for schemas without subscriptions', async () => {
+    const logger = createHiveTestingLogger();
+
+    const hive = createHive({
+      enabled: true,
+      token: 'dummy-token',
+      agent: {
+        logger,
+        maxSize: 1,
+        sendInterval: 1,
+      },
+      usage: {
+        endpoint: 'http://localhost/usage',
+        clientInfo() {
+          return {
+            name: 'brrr',
+            version: '1',
+          };
+        },
+      },
+    });
+    const collectSubscriptionUsage = vi.spyOn(hive, 'collectSubscriptionUsage');
+    const yoga = createYoga({
+      schema: createSchema({ typeDefs, resolvers }),
+      plugins: [useHive(hive)],
+    });
+
+    const response = await yoga.fetch('http://localhost/graphql', {
+      method: 'POST',
+      headers: {
+        accept: 'text/event-stream',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ query: 'subscription { hello }' }),
+    });
+    await response.text();
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+
+    // make sure no error occurs
+    expect(logger.getLogs()).toEqual('');
+    expect(collectSubscriptionUsage).not.toHaveBeenCalled();
+    await hive.dispose();
+  });
+
   describe('built-in see', () => {
     test('reports usage for successful subscription operation', async ({ expect }) => {
       const d = Promise.withResolvers<RequestInit>();

--- a/packages/libraries/yoga/tests/yoga.spec.ts
+++ b/packages/libraries/yoga/tests/yoga.spec.ts
@@ -709,7 +709,15 @@ describe('subscription usage reporting', () => {
       },
       body: JSON.stringify({ query: 'subscription { hello }' }),
     });
-    await response.text();
+    expect(await response.text()).toMatchInlineSnapshot(`
+      :
+
+      event: next
+      data: {"errors":[{"message":"Schema is not configured to execute subscription operation.","locations":[{"line":1,"column":1}]}]}
+
+      event: complete
+      data:
+    `);
     expect(response.headers.get('content-type')).toContain('text/event-stream');
 
     // make sure no error occurs


### PR DESCRIPTION
### Background

This fixes the root cause that was mitigated in https://github.com/graphql-hive/console/pull/8308

### Description

The Yoga SDK attempts to do usage reporting for subscription operations even though the subscription failed due to the schema not having a subscription root type when using GraphQL.js 16.

This does not happen in GraphQL.js 17, as there is a new validation rule [`KnownOperationTypes`](https://github.com/graphql/graphql-js/pull/3601) that raises a validation error and stops `onSubscribe` being called if the schema has no subscription type.