### PR TITLE
chore: allow ci to run on external contributions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,10 +30,11 @@ jobs:
   # Build all packages and applications, and creates Docker images
   build:
     name: build
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ./.github/workflows/build-and-dockerize.yaml
     needs: changeset-version
     with:
-      dockerize: ${{ !github.event.pull_request.head.repo.fork }}
+      dockerize: true
       imageTag: ${{ github.event.pull_request.head.sha }}
       publishLatest: false
       targets: 'build'
@@ -55,20 +56,37 @@ jobs:
   integration-tests:
     name: test
     needs: build
+    if: >-
+      ${{
+        always() &&
+        (
+          needs.build.result == 'success' ||
+          github.event.pull_request.head.repo.full_name != github.repository
+        )
+      }}
     uses: ./.github/workflows/tests-integration.yaml
-    secrets:
-      stripeTestPublicKey: ${{ secrets.TEST_STRIPE_PUBLIC_KEY }}
-      stripeTestSecretKey: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
     with:
       imageTag: ${{ github.event.pull_request.head.sha }}
+      buildImagesLocally: >-
+        ${{ github.event.pull_request.head.repo.full_name != github.repository }}
 
   # e2e tests using Playwright, runs Hive from pre-built Docker images.
   e2e:
     name: test
     needs: build
+    if: >-
+      ${{
+        always() &&
+        (
+          needs.build.result == 'success' ||
+          github.event.pull_request.head.repo.full_name != github.repository
+        )
+      }}
     uses: ./.github/workflows/tests-e2e.yaml
     with:
       imageTag: ${{ github.event.pull_request.head.sha }}
+      buildImagesLocally: >-
+        ${{ github.event.pull_request.head.repo.full_name != github.repository }}
 
   # Changeset Validation
   # Validates that changesets reference valid packages that exist in the monorepo
@@ -86,5 +104,9 @@ jobs:
   # Build and test standalone CLI artifacts
   alpha:
     uses: ./.github/workflows/release-alpha.yaml
-    if: ${{ github.event.pull_request.title != 'Upcoming Release Changes' }}
+    if: >-
+      ${{
+        github.event.pull_request.title != 'Upcoming Release Changes' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,9 @@ permissions:
 
 jobs:
   snapshot:
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name ==
+      github.repository
     uses: the-guild-org/shared-config/.github/workflows/release-snapshot.yml@v1
     with:
       npmTag:

--- a/.github/workflows/tests-e2e.yaml
+++ b/.github/workflows/tests-e2e.yaml
@@ -10,10 +10,15 @@ on:
       imageTag:
         required: true
         type: string
+      buildImagesLocally:
+        default: false
+        type: boolean
 
 jobs:
   e2e:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
 
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}/${{ inputs.imageName }}/
@@ -29,6 +34,34 @@ jobs:
         with:
           codegen: true
           actor: test-e2e
+
+      - name: build packages and applications
+        if: ${{ inputs.buildImagesLocally }}
+        run: pnpm build
+
+      - name: configure Docker Node.js image tag
+        id: node-version-tag
+        if: ${{ inputs.buildImagesLocally }}
+        run: echo "value=:$(< .node-version)-slim" >> "$GITHUB_OUTPUT"
+
+      - name: configure Docker buildx
+        if: ${{ inputs.buildImagesLocally }}
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+
+      - name: build local Docker images
+        if: ${{ inputs.buildImagesLocally }}
+        env:
+          COMMIT_SHA: ${{ inputs.imageTag }}
+          RELEASE: ${{ inputs.imageTag }}
+          BRANCH_NAME: external-pr
+          BUILD_TYPE: ''
+          DOCKER_REGISTRY: ''
+          DOCKER_TAG: :${{ inputs.imageTag }}
+          NODE_VERSION_TAG: ${{ steps.node-version-tag.outputs.value }}
+        run: |
+          echo "DOCKER_REGISTRY=" >> "$GITHUB_ENV"
+          echo "DOCKER_TAG=:${{ inputs.imageTag }}" >> "$GITHUB_ENV"
+          docker buildx bake -f docker/docker.hcl build --load
 
       - name: install playwright browsers
         timeout-minutes: 15
@@ -66,7 +99,7 @@ jobs:
             logs
 
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
-        if: ${{ failure() }}
+        if: ${{ failure() && !inputs.buildImagesLocally }}
         with:
           name: playwright
           path: |

--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -1,10 +1,5 @@
 on:
   workflow_call:
-    secrets:
-      stripeTestPublicKey:
-        required: true
-      stripeTestSecretKey:
-        required: true
     inputs:
       registry:
         default: ghcr.io
@@ -18,11 +13,16 @@ on:
       configureEnv:
         default: ''
         type: string
+      buildImagesLocally:
+        default: false
+        type: boolean
 
 jobs:
   integration:
     runs-on: ubuntu-22.04
     name: integration (${{ matrix.shardIndex }})
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +53,7 @@ jobs:
 
       - name: configure Docker Node.js image tag
         id: node-version-tag
-        if: ${{ inputs.dockerize }}
+        if: ${{ inputs.buildImagesLocally }}
         run: echo "value=:$(< .node-version)-slim" >> "$GITHUB_OUTPUT"
 
       - name: setup environment
@@ -63,6 +63,25 @@ jobs:
 
       - name: prepare packages
         run: pnpm --filter integration-tests prepare:env
+
+      - name: configure Docker buildx
+        if: ${{ inputs.buildImagesLocally }}
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+
+      - name: build local Docker images
+        if: ${{ inputs.buildImagesLocally }}
+        env:
+          COMMIT_SHA: ${{ inputs.imageTag }}
+          RELEASE: ${{ inputs.imageTag }}
+          BRANCH_NAME: external-pr
+          BUILD_TYPE: ''
+          DOCKER_REGISTRY: ''
+          DOCKER_TAG: :${{ inputs.imageTag }}
+          NODE_VERSION_TAG: ${{ steps.node-version-tag.outputs.value }}
+        run: |
+          echo "DOCKER_REGISTRY=" >> "$GITHUB_ENV"
+          echo "DOCKER_TAG=:${{ inputs.imageTag }}" >> "$GITHUB_ENV"
+          docker buildx bake -f docker/docker.hcl integration-tests --load
 
       - name: patch compose file volumes
         uses: mikefarah/yq@4839dbbf80445070a31c7a9c1055da527db2d5ee # v4.44.6


### PR DESCRIPTION
<!--
Before Contributing, please review the contribution guide:
https://the-guild.dev/graphql/hive/docs/schema-registry/contributing
--->

### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for developing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
