### PR TITLE
Track errors thrown by the gateway separately in usage data

### DIFF
--- a/.changeset/tangy-ideas-join.md
+++ b/.changeset/tangy-ideas-join.md
@@ -3,4 +3,6 @@
 '@graphql-hive/core': patch
 ---
 
-Support errors thrown by the gateway. I.e. during validation
+Explicitly supports errors thrown in the gateway. I.e. authentication during execution.
+
+This adds a new field to the usage payload that specifically contains errors thrown within the gateway. This separates gateway errors from subgraph errors. All errors are currently ingested similarly into Clickhouse, but this change supports future improvements to show the source (subgraph name or gateway) of errors.

--- a/.changeset/tangy-ideas-join.md
+++ b/.changeset/tangy-ideas-join.md
@@ -1,0 +1,6 @@
+---
+'@graphql-hive/gateway-plugin-console-sdk': patch
+'@graphql-hive/core': patch
+---
+
+Support errors thrown by the gateway. I.e. during validation

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -21,7 +21,7 @@
     "@graphql-hive/core": "workspace:*",
     "@graphql-hive/gateway-plugin-console-sdk": "workspace:*",
     "@graphql-hive/gateway-runtime": "^1.0.0 || ^2.0.0",
-    "@graphql-hive/router-runtime": "^1.4.0",
+    "@graphql-hive/router-runtime": "^1.4.23",
     "@graphql-typed-document-node/core": "3.2.0",
     "@hive/commerce": "workspace:*",
     "@hive/postgres": "workspace:*",

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -83,6 +83,7 @@ function pollInternal(
   /** In milliseconds */
   startTime: number = Date.now(),
 ) {
+  let lastError: unknown;
   setTimeout(
     async () => {
       try {
@@ -92,18 +93,35 @@ function pollInternal(
         } else {
           const waited = Date.now() - startTime;
           if (waited > maxWait) {
-            reject(new Error(`Polling failed. Condition was not satisfied within ${maxWait}ms`));
+            reject(
+              new Error(`Polling failed. Condition was not satisfied within ${maxWait}ms`, {
+                cause: lastError,
+              }),
+            );
           } else {
             pollInternal(check, pollFrequency, maxWait, jitter, resolve, reject, startTime);
           }
         }
       } catch (e) {
+        lastError = e;
         reject(e);
       }
     },
     Math.round(pollFrequency + Math.random() * jitter),
   );
 }
+
+// Use this function to give our backend (clickhouse) time to insert into the materialized views' tables
+export const waitForExpectations = (expectation: () => Promise<void>) => {
+  return pollFor(async () => {
+    try {
+      await expectation();
+      return true;
+    } catch (e) {
+      return false;
+    }
+  });
+};
 
 export function pollFor(
   check: () => Promise<boolean>,

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -131,7 +131,7 @@ export function pollFor(
     pollInternal(
       check,
       opts?.pollFrequency ?? 500,
-      opts?.maxWait ?? 10_000,
+      opts?.maxWait ?? 15_000,
       opts?.jitter ?? 100,
       resolve,
       reject,

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -94,9 +94,12 @@ function pollInternal(
           const waited = Date.now() - startTime;
           if (waited > maxWait) {
             reject(
-              new Error(`Polling failed. Condition was not satisfied within ${maxWait}ms`, {
-                cause: lastError,
-              }),
+              new Error(
+                `Polling failed. Condition was not satisfied within ${maxWait}ms. Causeed by ${String(lastError)}`,
+                {
+                  cause: lastError,
+                },
+              ),
             );
           } else {
             pollInternal(check, pollFrequency, maxWait, jitter, resolve, reject, startTime);

--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -60,6 +60,7 @@ import {
   updateTargetDangerousChangeClassification,
   updateTargetFailingDangerousChanges,
   updateTargetValidationSettings,
+  waitForExpectations,
 } from './flow';
 import * as GraphQLSchema from './gql/graphql';
 import {
@@ -1276,7 +1277,7 @@ export function initSeed() {
                 ) {
                   const from = formatISO(_from ?? subHours(Date.now(), 1));
                   const to = formatISO(_to ?? Date.now());
-                  const check = async () => {
+                  await waitForExpectations(async () => {
                     const statsResult = await readOperationsStats(
                       {
                         bySelector: {
@@ -1292,10 +1293,8 @@ export function initSeed() {
                       {},
                       ownerToken,
                     ).then(r => r.expectNoGraphQLErrors());
-                    return statsResult.target?.operationsStats.totalOperations == n;
-                  };
-
-                  return pollFor(check);
+                    expect(statsResult.target?.operationsStats.totalOperations).toBe(n);
+                  });
                 },
                 async waitForRequestsCollected(
                   n: number,
@@ -1307,7 +1306,8 @@ export function initSeed() {
                 ) {
                   const from = formatISO(opts?.from ?? subHours(Date.now(), 1));
                   const to = formatISO(opts?.to ?? Date.now());
-                  const check = async () => {
+
+                  await waitForExpectations(async () => {
                     const statsResult = await readTotalRequests(
                       {
                         bySelector: {
@@ -1322,10 +1322,8 @@ export function initSeed() {
                       },
                       ownerToken,
                     ).then(r => r.expectNoGraphQLErrors());
-                    return statsResult.target?.totalRequests == n;
-                  };
-
-                  return pollFor(check);
+                    expect(statsResult.target?.totalRequests).toBe(n);
+                  });
                 },
                 async readOperationsStats(
                   from: string,

--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -292,8 +292,14 @@ export function initSeed() {
             r.expectNoGraphQLErrors(),
           );
 
+          if (!orgResult.createOrganization.ok) {
+            throw new Error(
+              `Cannot create organization: ${JSON.stringify(orgResult.createOrganization.error)}`,
+            );
+          }
+
           const organization =
-            orgResult.createOrganization.ok!.createdOrganizationPayload.organization;
+            orgResult.createOrganization.ok.createdOrganizationPayload.organization;
 
           return {
             organization,

--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -1,6 +1,6 @@
 import { buildASTSchema, parse } from 'graphql';
 import { createLogger } from 'graphql-yoga';
-import { pollFor } from 'testkit/flow';
+import { pollFor, waitForExpectations } from 'testkit/flow';
 import { initSeed } from 'testkit/seed';
 import { getServiceHost } from 'testkit/utils';
 import z from 'zod';
@@ -2208,22 +2208,22 @@ test('app deployment usage reporting', async () => {
     'app-name~app-version~aaa',
   );
 
-  await waitForOperationsCollected(1);
-
-  data = await execute({
-    document: GetAppDeployment,
-    variables: {
-      targetSelector: {
-        organizationSlug: organization.slug,
-        projectSlug: project.slug,
-        targetSlug: target.slug,
+  await waitForExpectations(async () => {
+    data = await execute({
+      document: GetAppDeployment,
+      variables: {
+        targetSelector: {
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
+        },
+        appDeploymentName: 'app-name',
+        appDeploymentVersion: 'app-version',
       },
-      appDeploymentName: 'app-name',
-      appDeploymentVersion: 'app-version',
-    },
-    authToken: ownerToken,
-  }).then(res => res.expectNoGraphQLErrors());
-  expect(data.target?.appDeployment?.lastUsed).toEqual(expect.any(String));
+      authToken: ownerToken,
+    }).then(res => res.expectNoGraphQLErrors());
+    expect(data.target?.appDeployment?.lastUsed).toEqual(expect.any(String));
+  });
 });
 
 test('app deployment manifest is written to and accessible via CDN', async () => {
@@ -2786,55 +2786,55 @@ test('activeAppDeployments filters by lastUsedBefore', async () => {
     'used-app~1.0.0~hash',
   );
 
-  await waitForOperationsCollected(1);
+  await waitForExpectations(async () => {
+    // Query for deployments last used before tomorrow (should include our deployment)
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
 
-  // Query for deployments last used before tomorrow (should include our deployment)
-  const tomorrow = new Date();
-  tomorrow.setDate(tomorrow.getDate() + 1);
-
-  const result = await execute({
-    document: GetActiveAppDeployments,
-    variables: {
-      targetSelector: {
-        organizationSlug: organization.slug,
-        projectSlug: project.slug,
-        targetSlug: target.slug,
+    const result = await execute({
+      document: GetActiveAppDeployments,
+      variables: {
+        targetSelector: {
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
+        },
+        filter: {
+          lastUsedBefore: tomorrow.toISOString(),
+        },
       },
-      filter: {
-        lastUsedBefore: tomorrow.toISOString(),
-      },
-    },
-    authToken: ownerToken,
-  }).then(res => res.expectNoGraphQLErrors());
+      authToken: ownerToken,
+    }).then(res => res.expectNoGraphQLErrors());
 
-  expect(result.target?.activeAppDeployments.edges).toHaveLength(1);
-  expect(result.target?.activeAppDeployments.edges[0].node).toMatchObject({
-    name: 'used-app',
-    version: '1.0.0',
-    status: 'active',
+    expect(result.target?.activeAppDeployments.edges).toHaveLength(1);
+    expect(result.target?.activeAppDeployments.edges[0].node).toMatchObject({
+      name: 'used-app',
+      version: '1.0.0',
+      status: 'active',
+    });
+    expect(result.target?.activeAppDeployments.edges[0].node.lastUsed).toBeTruthy();
+
+    // Query for deployments last used before yesterday (should NOT include our deployment)
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const result2 = await execute({
+      document: GetActiveAppDeployments,
+      variables: {
+        targetSelector: {
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
+        },
+        filter: {
+          lastUsedBefore: yesterday.toISOString(),
+        },
+      },
+      authToken: ownerToken,
+    }).then(res => res.expectNoGraphQLErrors());
+
+    expect(result2.target?.activeAppDeployments.edges).toHaveLength(0);
   });
-  expect(result.target?.activeAppDeployments.edges[0].node.lastUsed).toBeTruthy();
-
-  // Query for deployments last used before yesterday (should NOT include our deployment)
-  const yesterday = new Date();
-  yesterday.setDate(yesterday.getDate() - 1);
-
-  const result2 = await execute({
-    document: GetActiveAppDeployments,
-    variables: {
-      targetSelector: {
-        organizationSlug: organization.slug,
-        projectSlug: project.slug,
-        targetSlug: target.slug,
-      },
-      filter: {
-        lastUsedBefore: yesterday.toISOString(),
-      },
-    },
-    authToken: ownerToken,
-  }).then(res => res.expectNoGraphQLErrors());
-
-  expect(result2.target?.activeAppDeployments.edges).toHaveLength(0);
 });
 
 test('activeAppDeployments applies OR logic between lastUsedBefore and neverUsedAndCreatedBefore', async () => {
@@ -2948,39 +2948,39 @@ test('activeAppDeployments applies OR logic between lastUsedBefore and neverUsed
     'used-app~1.0.0~hash1',
   );
 
-  await waitForOperationsCollected(1);
-
   const tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 1);
 
-  const result = await execute({
-    document: GetActiveAppDeployments,
-    variables: {
-      targetSelector: {
-        organizationSlug: organization.slug,
-        projectSlug: project.slug,
-        targetSlug: target.slug,
+  waitForExpectations(async () => {
+    const result = await execute({
+      document: GetActiveAppDeployments,
+      variables: {
+        targetSelector: {
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
+        },
+        filter: {
+          lastUsedBefore: tomorrow.toISOString(),
+          neverUsedAndCreatedBefore: tomorrow.toISOString(),
+        },
       },
-      filter: {
-        lastUsedBefore: tomorrow.toISOString(),
-        neverUsedAndCreatedBefore: tomorrow.toISOString(),
-      },
-    },
-    authToken: ownerToken,
-  }).then(res => res.expectNoGraphQLErrors());
+      authToken: ownerToken,
+    }).then(res => res.expectNoGraphQLErrors());
 
-  // Both deployments should match via OR logic
-  expect(result.target?.activeAppDeployments.edges).toHaveLength(2);
-  const names = result.target?.activeAppDeployments.edges.map(e => e.node.name).sort();
-  expect(names).toEqual(['unused-app', 'used-app']);
+    // Both deployments should match via OR logic
+    expect(result.target?.activeAppDeployments.edges).toHaveLength(2);
+    const names = result.target?.activeAppDeployments.edges.map(e => e.node.name).sort();
+    expect(names).toEqual(['unused-app', 'used-app']);
 
-  // Verify one has lastUsed and one doesn't
-  const usedApp = result.target?.activeAppDeployments.edges.find(e => e.node.name === 'used-app');
-  const unusedApp = result.target?.activeAppDeployments.edges.find(
-    e => e.node.name === 'unused-app',
-  );
-  expect(usedApp?.node.lastUsed).toBeTruthy();
-  expect(unusedApp?.node.lastUsed).toBeNull();
+    // Verify one has lastUsed and one doesn't
+    const usedApp = result.target?.activeAppDeployments.edges.find(e => e.node.name === 'used-app');
+    const unusedApp = result.target?.activeAppDeployments.edges.find(
+      e => e.node.name === 'unused-app',
+    );
+    expect(usedApp?.node.lastUsed).toBeTruthy();
+    expect(unusedApp?.node.lastUsed).toBeNull();
+  });
 });
 
 test('activeAppDeployments pagination with first and after', async () => {
@@ -3456,95 +3456,77 @@ test('schema check shows affected app deployments for breaking changes', async (
   let schemaCheckData: any = null;
 
   // ClickHouse eventual consistency
-  await pollFor(
-    async () => {
-      const checkResult = await execute({
-        document: graphql(`
-          mutation SchemaCheckForAffectedAppDeploymentsPoll($input: SchemaCheckInput!) {
-            schemaCheck(input: $input) {
-              __typename
-              ... on SchemaCheckSuccess {
-                schemaCheck {
-                  id
-                }
+  await waitForExpectations(async () => {
+    const checkResult = await execute({
+      document: graphql(`
+        mutation SchemaCheckForAffectedAppDeploymentsPoll($input: SchemaCheckInput!) {
+          schemaCheck(input: $input) {
+            __typename
+            ... on SchemaCheckSuccess {
+              schemaCheck {
+                id
               }
-              ... on SchemaCheckError {
-                schemaCheck {
-                  id
-                }
+            }
+            ... on SchemaCheckError {
+              schemaCheck {
+                id
               }
             }
           }
-        `),
-        variables: {
-          input: {
-            sdl: /* GraphQL */ `
-              type Query {
-                world: String
-              }
-            `,
-          },
+        }
+      `),
+      variables: {
+        input: {
+          sdl: /* GraphQL */ `
+            type Query {
+              world: String
+            }
+          `,
         },
-        authToken: token.secret,
-      }).then(res => res.expectNoGraphQLErrors());
+      },
+      authToken: token.secret,
+    }).then(res => res.expectNoGraphQLErrors());
 
-      if (checkResult.schemaCheck.__typename !== 'SchemaCheckError') {
-        return false;
-      }
+    assert(checkResult.schemaCheck.__typename === 'SchemaCheckError');
 
-      const schemaCheckId = checkResult.schemaCheck.schemaCheck?.id;
-      if (!schemaCheckId) {
-        return false;
-      }
+    const schemaCheckId = checkResult.schemaCheck.schemaCheck?.id;
+    assert(schemaCheckId);
 
-      schemaCheckData = await execute({
-        document: SchemaCheckWithAffectedAppDeployments,
-        variables: {
-          organizationSlug: organization.slug,
-          projectSlug: project.slug,
-          targetSlug: target.slug,
-          schemaCheckId,
-        },
-        authToken: ownerToken,
-      });
+    schemaCheckData = await execute({
+      document: SchemaCheckWithAffectedAppDeployments,
+      variables: {
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
+        schemaCheckId,
+      },
+      authToken: ownerToken,
+    });
 
-      const breakingChanges =
-        schemaCheckData.rawBody.data?.target?.schemaCheck?.breakingSchemaChanges?.edges;
+    const breakingChanges =
+      schemaCheckData.rawBody.data?.target?.schemaCheck?.breakingSchemaChanges?.edges;
 
-      // Check if the hello field removal has affectedAppDeployments
-      const helloFieldRemoval = breakingChanges?.find((edge: { node: { message: string } }) =>
-        edge.node.message.includes('hello'),
-      );
-      return !!(helloFieldRemoval?.node.affectedAppDeployments?.edges?.length ?? 0);
-    },
-    { maxWait: 15_000 },
-  );
+    // Check if the hello field removal has affectedAppDeployments
+    const helloFieldRemoval = breakingChanges?.find((edge: { node: { message: string } }) =>
+      edge.node.message.includes('hello'),
+    );
+    expect(helloFieldRemoval?.node.affectedAppDeployments?.edges).toHaveLength(1);
 
-  const breakingChanges =
-    schemaCheckData!.rawBody.data?.target?.schemaCheck?.breakingSchemaChanges?.edges;
+    expect(breakingChanges).toBeDefined();
+    expect(breakingChanges!.length).toBeGreaterThan(0);
 
-  // console.log('breakingChanges:', JSON.stringify(breakingChanges, null, 2));
+    expect(helloFieldRemoval).toBeDefined();
+    expect(helloFieldRemoval?.node.affectedAppDeployments?.edges).toBeDefined();
+    expect(helloFieldRemoval?.node.affectedAppDeployments?.edges?.length).toBe(1);
 
-  expect(breakingChanges).toBeDefined();
-  expect(breakingChanges!.length).toBeGreaterThan(0);
-
-  const helloFieldRemoval = breakingChanges!.find((edge: { node: { message: string } }) =>
-    edge.node.message.includes('hello'),
-  );
-
-  // console.log('helloFieldRemoval:', JSON.stringify(helloFieldRemoval, null, 2));
-
-  expect(helloFieldRemoval).toBeDefined();
-  expect(helloFieldRemoval?.node.affectedAppDeployments?.edges).toBeDefined();
-  expect(helloFieldRemoval?.node.affectedAppDeployments?.edges?.length).toBe(1);
-
-  const affectedDeployment = helloFieldRemoval?.node.affectedAppDeployments?.edges?.[0]?.node;
-  expect(affectedDeployment?.name).toBe('test-app');
-  expect(affectedDeployment?.version).toBe('1.0.0');
-  expect(affectedDeployment?.affectedOperations.edges).toBeDefined();
-  expect(affectedDeployment?.affectedOperations.edges.length).toBe(1);
-  expect(affectedDeployment?.affectedOperations.edges[0].node.hash).toBe('hello-query-hash');
-  expect(affectedDeployment?.affectedOperations.edges[0].node.name).toBe('GetHello');
+    const affectedDeployment = helloFieldRemoval?.node.affectedAppDeployments?.edges?.[0]?.node;
+    expect(affectedDeployment?.name).toBe('test-app');
+    expect(affectedDeployment?.version).toBe('1.0.0');
+    expect(affectedDeployment?.affectedOperations.edges).toBeDefined();
+    expect(affectedDeployment?.affectedOperations.edges.length).toBe(1);
+    expect(affectedDeployment?.affectedOperations.edges[0].node.hash).toBe('hello-query-hash');
+    expect(affectedDeployment?.affectedOperations.edges[0].node.name).toBe('GetHello');
+  });
 });
 
 test('breaking changes show only deployments affected by their specific coordinate', async () => {

--- a/integration-tests/tests/api/auth/scim.spec.ts
+++ b/integration-tests/tests/api/auth/scim.spec.ts
@@ -5056,7 +5056,10 @@ describe('provisioned user jail', () => {
     oidcMock.setUser({ email, userIdClaim: externalId });
     const auth = await oidcMock.runGetAuthorizationUrl();
     const signInResult = await oidcMock.runSignInUp({ state: auth.state });
-    invariant(signInResult.type === 'success', 'Expected sign in to succeed.');
+    invariant(
+      signInResult.type === 'success',
+      `Expected sign in to succeed. But got ${JSON.stringify(signInResult.body)}`,
+    );
 
     const slug = `scim-${crypto.randomUUID()}`;
     const result = await createOrganization({ slug }, signInResult.accessToken).then(response =>

--- a/integration-tests/tests/api/otel-collector.spec.ts
+++ b/integration-tests/tests/api/otel-collector.spec.ts
@@ -1,4 +1,4 @@
-import { pollFor } from 'testkit/flow';
+import { pollFor, waitForExpectations } from 'testkit/flow';
 import { clickHouseQuery } from '../../testkit/clickhouse';
 import { graphql } from '../../testkit/gql';
 import { GraphQlOperationType, ResourceAssignmentModeType } from '../../testkit/gql/graphql';
@@ -540,19 +540,6 @@ test('traces can be filtered via GraphQL API', async () => {
   await waitForTraceInNormalized(trace1Id);
   await waitForTraceInNormalized(trace2Id);
   await waitForTraceInNormalized(trace3Id);
-
-  // Use this function to give our backend (clickhouse) time to insert into the materialized views' tables
-  const waitForExpectations = (expectation: () => Promise<void>) => {
-    return pollFor(async () => {
-      try {
-        await expectation();
-        return true;
-      } catch (e) {
-        console.error(e);
-        return false;
-      }
-    });
-  };
 
   // Test 1: Filter by operation name
   await waitForExpectations(async () => {

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -16,9 +16,9 @@ import { collectSchemaCoordinates } from '../../../../packages/libraries/core/sr
 import { clickHouseQuery } from '../../../testkit/clickhouse';
 import {
   createTarget,
-  pollFor,
   updateTargetValidationSettings,
   waitFor,
+  waitForExpectations,
 } from '../../../testkit/flow';
 import { initSeed } from '../../../testkit/seed';
 import { CollectedOperation } from '../../../testkit/usage';
@@ -2729,47 +2729,114 @@ test.concurrent(
   },
 );
 
-test.concurrent(
-  'subscription operation is used for conditional breaking change detection',
-  async ({ expect }) => {
-    const { createOrg, ownerToken } = await initSeed().createOwner();
-    const { organization, createProject } = await createOrg();
-    const {
-      project,
-      target,
-      createTargetAccessToken,
-      toggleTargetValidation,
-      updateTargetValidationSettings,
-    } = await createProject(ProjectType.Single);
-    const token = await createTargetAccessToken({});
+test('subscription operation is used for conditional breaking change detection', async ({
+  expect,
+}) => {
+  const { createOrg, ownerToken } = await initSeed().createOwner();
+  const { organization, createProject } = await createOrg();
+  const {
+    project,
+    target,
+    createTargetAccessToken,
+    toggleTargetValidation,
+    updateTargetValidationSettings,
+  } = await createProject(ProjectType.Single);
+  const token = await createTargetAccessToken({});
 
-    const sdl = /* GraphQL */ `
+  const sdl = /* GraphQL */ `
+    type Query {
+      a: String
+      b: String
+    }
+
+    type Subscription {
+      a: String
+      b: String
+    }
+  `;
+
+  const schema = buildASTSchema(parse(sdl));
+
+  const schemaPublishResult = await token
+    .publishSchema({
+      sdl,
+      author: 'Kamil',
+      commit: 'initial',
+    })
+    .then(res => res.expectNoGraphQLErrors());
+
+  expect(schemaPublishResult.schemaPublish.__typename).toEqual('SchemaPublishSuccess');
+
+  await toggleTargetValidation(true);
+
+  const unused = await token
+    .checkSchema(/* GraphQL */ `
       type Query {
         a: String
         b: String
       }
 
       type Subscription {
-        a: String
         b: String
       }
-    `;
+    `)
+    .then(r => r.expectNoGraphQLErrors());
 
-    const schema = buildASTSchema(parse(sdl));
+  if (unused.schemaCheck.__typename !== 'SchemaCheckSuccess') {
+    throw new Error(`Expected SchemaCheckSuccess, got ${unused.schemaCheck.__typename}`);
+  }
 
-    const schemaPublishResult = await token
-      .publishSchema({
-        sdl,
-        author: 'Kamil',
-        commit: 'initial',
-      })
-      .then(res => res.expectNoGraphQLErrors());
+  expect(unused.schemaCheck.changes).toEqual(
+    expect.objectContaining({
+      nodes: expect.arrayContaining([
+        expect.objectContaining({
+          message:
+            "Field 'a' was removed from object type 'Subscription' (non-breaking based on usage)",
+        }),
+      ]),
+      total: 1,
+    }),
+  );
 
-    expect(schemaPublishResult.schemaPublish.__typename).toEqual('SchemaPublishSuccess');
+  const usageAddress = await getServiceHost('usage', 8081);
 
-    await toggleTargetValidation(true);
+  const client = createHive({
+    enabled: true,
+    token: token.secret,
+    usage: true,
+    debug: false,
+    agent: {
+      logger: createLogger('debug'),
+      maxSize: 1,
+    },
+    selfHosting: {
+      usageEndpoint: 'http://' + usageAddress,
+      graphqlEndpoint: 'http://noop/',
+      applicationUrl: 'http://noop/',
+    },
+  });
 
-    const unused = await token
+  const request = new Request('http://localhost:4000/graphql', {
+    method: 'POST',
+    headers: {
+      'x-graphql-client-name': 'integration-tests',
+      'x-graphql-client-version': '6.6.6',
+    },
+  });
+
+  client.collectSubscriptionUsage({
+    args: {
+      document: parse('subscription { a }'),
+      schema,
+      contextValue: {
+        request,
+      },
+    },
+  });
+
+  let firstSchemaCheckId: string | undefined;
+  await waitForExpectations(async () => {
+    const used = await token
       .checkSchema(/* GraphQL */ `
         type Query {
           a: String
@@ -2782,11 +2849,115 @@ test.concurrent(
       `)
       .then(r => r.expectNoGraphQLErrors());
 
-    if (unused.schemaCheck.__typename !== 'SchemaCheckSuccess') {
-      throw new Error(`Expected SchemaCheckSuccess, got ${unused.schemaCheck.__typename}`);
-    }
+    assert(used.schemaCheck.__typename === 'SchemaCheckError');
+    expect(used.schemaCheck.errors).toEqual({
+      nodes: [
+        {
+          message: "Field 'a' was removed from object type 'Subscription'",
+        },
+      ],
+      total: 1,
+    });
+    expect(used.schemaCheck.schemaCheck?.id).not.toBeNullable();
+    firstSchemaCheckId = used.schemaCheck.schemaCheck?.id;
+  });
 
-    expect(unused.schemaCheck.changes).toEqual(
+  await waitForExpectations(async () => {
+    const firstSchemaCheck = await execute({
+      document: SubscriptionSchemaCheckQuery,
+      variables: {
+        id: firstSchemaCheckId!,
+        selector: {
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
+        },
+      },
+      authToken: ownerToken,
+    }).then(r => r.expectNoGraphQLErrors());
+
+    expect(firstSchemaCheck.target?.schemaCheck?.breakingSchemaChanges?.nodes).toHaveLength(1);
+    const node = firstSchemaCheck.target?.schemaCheck?.breakingSchemaChanges?.nodes[0]!;
+    expect(node.isSafeBasedOnUsage).toEqual(false);
+    expect(node.usageStatistics?.topAffectedOperations).toEqual([
+      {
+        countFormatted: '1',
+        hash: 'c1bbc8385a4a6f4e4988be7394800adc',
+        name: 'anonymous',
+        percentage: 100,
+        percentageFormatted: '100.00%',
+        operation: {
+          body: 'subscription{a}',
+          hash: 'c1bbc8385a4a6f4e4988be7394800adc',
+          name: 'anonymous',
+          type: 'SUBSCRIPTION',
+        },
+      },
+    ]);
+    expect(node.usageStatistics?.topAffectedClients).toEqual([
+      {
+        countFormatted: '1',
+        name: 'integration-tests',
+        percentage: 100,
+        percentageFormatted: '100.00%',
+      },
+    ]);
+  });
+
+  // Now let's make subscription insignificant by making 3 queries
+
+  client.collectUsage().finish(
+    {
+      document: parse('{ a }'),
+      schema,
+      contextValue: {
+        request,
+      },
+    },
+    {},
+  );
+  client.collectUsage().finish(
+    {
+      document: parse('{ a }'),
+      schema,
+      contextValue: {
+        request,
+      },
+    },
+    {},
+  );
+  client.collectUsage().finish(
+    {
+      document: parse('{ a }'),
+      schema,
+      contextValue: {
+        request,
+      },
+    },
+    {},
+  );
+
+  await updateTargetValidationSettings({
+    excludedClients: [],
+    percentage: 50,
+  });
+
+  await waitForExpectations(async () => {
+    const irrelevant = await token
+      .checkSchema(/* GraphQL */ `
+        type Query {
+          a: String
+          b: String
+        }
+
+        type Subscription {
+          b: String
+        }
+      `)
+      .then(r => r.expectNoGraphQLErrors());
+
+    assert(irrelevant?.schemaCheck.__typename === 'SchemaCheckSuccess');
+    expect(irrelevant.schemaCheck.changes).toEqual(
       expect.objectContaining({
         nodes: expect.arrayContaining([
           expect.objectContaining({
@@ -2797,271 +2968,63 @@ test.concurrent(
         total: 1,
       }),
     );
+  });
 
-    const usageAddress = await getServiceHost('usage', 8081);
+  // Make it relevant again, by making 3 subscriptions
 
-    const client = createHive({
-      enabled: true,
-      token: token.secret,
-      usage: true,
-      debug: false,
-      agent: {
-        logger: createLogger('debug'),
-        maxSize: 1,
+  client.collectSubscriptionUsage({
+    args: {
+      document: parse('subscription { a }'),
+      schema,
+      contextValue: {
+        request,
       },
-      selfHosting: {
-        usageEndpoint: 'http://' + usageAddress,
-        graphqlEndpoint: 'http://noop/',
-        applicationUrl: 'http://noop/',
+    },
+  });
+  client.collectSubscriptionUsage({
+    args: {
+      document: parse('subscription { a }'),
+      schema,
+      contextValue: {
+        request,
       },
-    });
-
-    const request = new Request('http://localhost:4000/graphql', {
-      method: 'POST',
-      headers: {
-        'x-graphql-client-name': 'integration-tests',
-        'x-graphql-client-version': '6.6.6',
+    },
+  });
+  client.collectSubscriptionUsage({
+    args: {
+      document: parse('subscription { a }'),
+      schema,
+      contextValue: {
+        request,
       },
-    });
+    },
+  });
 
-    client.collectSubscriptionUsage({
-      args: {
-        document: parse('subscription { a }'),
-        schema,
-        contextValue: {
-          request,
-        },
-      },
-    });
-
-    let firstSchemaCheckId: string | undefined;
-    await pollFor(async () => {
-      try {
-        const used = await token
-          .checkSchema(/* GraphQL */ `
-            type Query {
-              a: String
-              b: String
-            }
-
-            type Subscription {
-              b: String
-            }
-          `)
-          .then(r => r.expectNoGraphQLErrors());
-
-        if (used.schemaCheck.__typename === 'SchemaCheckError') {
-          expect(used.schemaCheck.errors).toEqual({
-            nodes: [
-              {
-                message: "Field 'a' was removed from object type 'Subscription'",
-              },
-            ],
-            total: 1,
-          });
-          firstSchemaCheckId = used.schemaCheck.schemaCheck?.id;
-          return true;
-        }
-        return false;
-      } catch (e) {
-        console.error(e);
-        return false;
-      }
-    });
-
-    if (!firstSchemaCheckId) {
-      throw new Error('Expected schemaCheckId to be defined');
-    }
-
-    await pollFor(async () => {
-      try {
-        const firstSchemaCheck = await execute({
-          document: SubscriptionSchemaCheckQuery,
-          variables: {
-            id: firstSchemaCheckId!,
-            selector: {
-              organizationSlug: organization.slug,
-              projectSlug: project.slug,
-              targetSlug: target.slug,
-            },
-          },
-          authToken: ownerToken,
-        }).then(r => r.expectNoGraphQLErrors());
-
-        const node = firstSchemaCheck.target?.schemaCheck?.breakingSchemaChanges?.nodes[0];
-
-        if (!node) {
-          throw new Error('Expected node to be defined');
+  await waitForExpectations(async () => {
+    const relevant = await token
+      .checkSchema(/* GraphQL */ `
+        type Query {
+          a: String
+          b: String
         }
 
-        expect(node.isSafeBasedOnUsage).toEqual(false);
-        expect(node.usageStatistics?.topAffectedOperations).toEqual([
-          {
-            countFormatted: '1',
-            hash: 'c1bbc8385a4a6f4e4988be7394800adc',
-            name: 'anonymous',
-            percentage: 100,
-            percentageFormatted: '100.00%',
-            operation: {
-              body: 'subscription{a}',
-              hash: 'c1bbc8385a4a6f4e4988be7394800adc',
-              name: 'anonymous',
-              type: 'SUBSCRIPTION',
-            },
-          },
-        ]);
-        expect(node.usageStatistics?.topAffectedClients).toEqual([
-          {
-            countFormatted: '1',
-            name: 'integration-tests',
-            percentage: 100,
-            percentageFormatted: '100.00%',
-          },
-        ]);
-        return true;
-      } catch (e) {
-        console.error(e);
-        return false;
-      }
-    });
-
-    // Now let's make subscription insignificant by making 3 queries
-
-    client.collectUsage().finish(
-      {
-        document: parse('{ a }'),
-        schema,
-        contextValue: {
-          request,
-        },
-      },
-      {},
-    );
-    client.collectUsage().finish(
-      {
-        document: parse('{ a }'),
-        schema,
-        contextValue: {
-          request,
-        },
-      },
-      {},
-    );
-    client.collectUsage().finish(
-      {
-        document: parse('{ a }'),
-        schema,
-        contextValue: {
-          request,
-        },
-      },
-      {},
-    );
-
-    await updateTargetValidationSettings({
-      excludedClients: [],
-      percentage: 50,
-    });
-
-    await pollFor(async () => {
-      try {
-        const irrelevant = await token
-          .checkSchema(/* GraphQL */ `
-            type Query {
-              a: String
-              b: String
-            }
-
-            type Subscription {
-              b: String
-            }
-          `)
-          .then(r => r.expectNoGraphQLErrors());
-        if (irrelevant?.schemaCheck.__typename === 'SchemaCheckSuccess') {
-          expect(irrelevant.schemaCheck.changes).toEqual(
-            expect.objectContaining({
-              nodes: expect.arrayContaining([
-                expect.objectContaining({
-                  message:
-                    "Field 'a' was removed from object type 'Subscription' (non-breaking based on usage)",
-                }),
-              ]),
-              total: 1,
-            }),
-          );
-          return true;
+        type Subscription {
+          b: String
         }
-        return false;
-      } catch (e) {
-        console.error(e);
-        return false;
-      }
-    });
+      `)
+      .then(r => r.expectNoGraphQLErrors());
 
-    // Make it relevant again, by making 3 subscriptions
-
-    client.collectSubscriptionUsage({
-      args: {
-        document: parse('subscription { a }'),
-        schema,
-        contextValue: {
-          request,
+    assert(relevant.schemaCheck.__typename === 'SchemaCheckError');
+    expect(relevant.schemaCheck.errors).toEqual({
+      nodes: [
+        {
+          message: "Field 'a' was removed from object type 'Subscription'",
         },
-      },
+      ],
+      total: 1,
     });
-    client.collectSubscriptionUsage({
-      args: {
-        document: parse('subscription { a }'),
-        schema,
-        contextValue: {
-          request,
-        },
-      },
-    });
-    client.collectSubscriptionUsage({
-      args: {
-        document: parse('subscription { a }'),
-        schema,
-        contextValue: {
-          request,
-        },
-      },
-    });
-
-    await pollFor(async () => {
-      try {
-        const relevant = await token
-          .checkSchema(/* GraphQL */ `
-            type Query {
-              a: String
-              b: String
-            }
-
-            type Subscription {
-              b: String
-            }
-          `)
-          .then(r => r.expectNoGraphQLErrors());
-
-        if (relevant.schemaCheck.__typename === 'SchemaCheckError') {
-          expect(relevant.schemaCheck.errors).toEqual({
-            nodes: [
-              {
-                message: "Field 'a' was removed from object type 'Subscription'",
-              },
-            ],
-            total: 1,
-          });
-          return true;
-        }
-        return false;
-      } catch (e) {
-        console.error(e);
-        return false;
-      }
-    });
-  },
-);
+  });
+});
 
 test.concurrent('ensure percentage precision up to 2 decimal places', async ({ expect }) => {
   const { createOrg, ownerToken } = await initSeed().createOwner();
@@ -3112,25 +3075,28 @@ test.concurrent('ensure percentage precision up to 2 decimal places', async ({ e
 
   await waitForRequestsCollected(9801 + 199);
 
-  const result = await clickHouseQuery(`
-    SELECT
-      target
-      , sum(total) as total
-    FROM clients_daily
-    WHERE
-      timestamp >= subtractDays(now(), 30)
-      AND timestamp <= now()
-      AND target = '${target.id}'
-    GROUP BY target
-  `);
+  // wait again to ensure the requests have been processed by the clients_daily table
+  waitForExpectations(async () => {
+    const result = await clickHouseQuery(`
+      SELECT
+        target
+        , sum(total) as total
+      FROM clients_daily
+      WHERE
+        timestamp >= subtractDays(now(), 30)
+        AND timestamp <= now()
+        AND target = '${target.id}'
+      GROUP BY target
+    `);
 
-  expect(result.rows).toEqual(1);
-  expect(result.data).toContainEqual(
-    expect.objectContaining({
-      target: target.id,
-      total: expect.stringMatching('10000'),
-    }),
-  );
+    expect(result.rows).toEqual(1);
+    expect(result.data).toContainEqual(
+      expect.objectContaining({
+        target: target.id,
+        total: expect.stringMatching('10000'),
+      }),
+    );
+  });
 
   const targetValidationResult = await toggleTargetValidation(true);
   expect(targetValidationResult.isEnabled).toEqual(true);

--- a/integration-tests/tests/cli/dev.spec.ts
+++ b/integration-tests/tests/cli/dev.spec.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { waitForExpectations } from 'testkit/flow';
 import { ProjectType } from 'testkit/gql/graphql';
 import { createCLI } from '../../testkit/cli';
 import { initSeed } from '../../testkit/seed';
@@ -151,20 +152,22 @@ describe('dev --remote', () => {
     });
 
     const supergraph = tmpFile('graphql');
-    const cmd = cli.dev({
-      remote: true,
-      services: [
-        {
-          name: 'bar',
-          url: 'http://localhost/bar',
-          sdl: 'type Query { bar: String }',
-        },
-      ],
-      write: supergraph.filepath,
-    });
+    waitForExpectations(async () => {
+      const cmd = cli.dev({
+        remote: true,
+        services: [
+          {
+            name: 'bar',
+            url: 'http://localhost/bar',
+            sdl: 'type Query { bar: String }',
+          },
+        ],
+        write: supergraph.filepath,
+      });
 
-    await expect(cmd).resolves.toMatch(supergraph.filepath);
-    await expect(supergraph.read()).resolves.toMatch('http://localhost/bar');
+      await expect(cmd).resolves.toMatch(supergraph.filepath);
+      await expect(supergraph.read()).resolves.toMatch('http://localhost/bar');
+    });
   });
 
   test('uses latest composable version by default', async () => {

--- a/integration-tests/tests/gateway-plugin-console-sdk/plugin.spec.ts
+++ b/integration-tests/tests/gateway-plugin-console-sdk/plugin.spec.ts
@@ -690,42 +690,20 @@ describe.each(['js', 'rust'] as const)('GraphQL Hive Plugin (%s)', gatewayType =
       subgraphs,
       gatewayType,
       [
-        /** Mimic the useGenericAuth plugin to run validation onExecute as an example. */
         {
           onSchemaChange({ schema }) {
             typeInfo = new TypeInfo(schema);
           },
           async onExecute({ args, setResultAndStopExecution }) {
-            const errors: GraphQLError[] = [];
-            typeInfo ??= new TypeInfo(args.schema);
-            const validationContext = new ValidationContext(
-              args.schema,
-              args.document,
-              typeInfo,
-              e => {
-                errors.push(e);
-              },
-            );
-            const visitor = visitInParallel([
-              {
-                Field(node: FieldNode) {
-                  if (node.name.value === 'product') {
-                    validationContext.reportError(
-                      new GraphQLError('hm', {
-                        nodes: [node],
-                        extensions: { code: 'NOPE' },
-                        path: ['product'], // assumes "path" is set so it can be attributed to a coordinate.
-                      }),
-                    );
-                    return null;
-                  }
-                },
-              },
-            ]);
-            args.document = visit(args.document, visitWithTypeInfo(typeInfo, visitor));
-            if (errors.length > 0) {
-              return setResultAndStopExecution({ data: null, errors });
-            }
+            setResultAndStopExecution({
+              data: null,
+              errors: [
+                new GraphQLError('oops', {
+                  extensions: { code: 'NOPE' },
+                  path: ['product'],
+                }),
+              ],
+            });
           },
         },
       ],

--- a/integration-tests/tests/gateway-plugin-console-sdk/plugin.spec.ts
+++ b/integration-tests/tests/gateway-plugin-console-sdk/plugin.spec.ts
@@ -1,5 +1,11 @@
 import { AddressInfo } from 'node:net';
-import { DocumentNode, GraphQLError, parse } from 'graphql';
+import {
+  GraphQLError,
+  parse,
+  type DocumentNode,
+  type FieldNode,
+  type ValidationContext,
+} from 'graphql';
 import { createLogger, createYoga } from 'graphql-yoga';
 import { pollFor, readOperationsStats } from 'testkit/flow';
 import { ProjectType } from 'testkit/gql/graphql';
@@ -8,7 +14,7 @@ import { getServiceHost } from 'testkit/utils';
 import { describe, expect, test } from 'vitest';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { useHive } from '@graphql-hive/gateway-plugin-console-sdk';
-import { createGatewayRuntime } from '@graphql-hive/gateway-runtime';
+import { createGatewayRuntime, GatewayPlugin } from '@graphql-hive/gateway-runtime';
 import { unifiedGraphHandler, useQueryPlan } from '@graphql-hive/router-runtime';
 import { createServer } from '@hive/service-common';
 import { composeServices, ServiceDefinition } from '@theguild/federation-composition';
@@ -57,6 +63,7 @@ async function setup(
     };
   },
   gatewayType: 'js' | 'rust',
+  additionalPlugins?: GatewayPlugin[],
 ) {
   const { createOrg } = await initSeed().createOwner();
   const { createProject } = await createOrg();
@@ -85,6 +92,7 @@ async function setup(
       graphqlEndpoint: 'http://noop/',
       applicationUrl: 'http://noop/',
     },
+    logger: createLogger('debug') as any,
   });
 
   const services = await Promise.all(
@@ -101,13 +109,13 @@ async function setup(
   expect(supergraph.errors).toBeUndefined();
   const jsGateway = createGatewayRuntime({
     supergraph: supergraph.supergraphSdl!,
-    plugins: () => [plugin],
+    plugins: () => [plugin, ...(additionalPlugins ?? [])],
   });
 
   const rustGateway = createGatewayRuntime({
     unifiedGraphHandler: unifiedGraphHandler as any,
     supergraph: supergraph.supergraphSdl!,
-    plugins: () => [plugin, useQueryPlan() as any],
+    plugins: () => [plugin, useQueryPlan() as any, ...(additionalPlugins ?? [])],
   });
 
   return {
@@ -316,6 +324,12 @@ describe.each(['js', 'rust'] as const)('GraphQL Hive Plugin (%s)', gatewayType =
     });
   });
 
+  /**
+   * The unifiedGraphHandler parses and generates the query plan earlier in this flow. The document
+   * passed to the subgraph is then already determined ahead of time. To support rust, it's necessary
+   * to either address the root cause and somehow modify the document prior to planning, or
+   * to add the hive typenames on subgraph execute every time.
+   */
   test.skipIf(gatewayType === 'rust')('supports abstract type', async () => {
     const subgraphs = {
       products: {
@@ -332,12 +346,17 @@ describe.each(['js', 'rust'] as const)('GraphQL Hive Plugin (%s)', gatewayType =
           type GoodieBag implements Product @key(fields: "id") {
             id: ID!
             price: Int
+            contents: String
           }
         `),
         resolvers: {
           Query: {
             product: () => {
-              return { __typename: 'GoodieBag', id: 1, price: 20.2 };
+              return {
+                __typename: 'GoodieBag',
+                id: 1,
+                price: 20.2,
+              };
             },
           },
         },
@@ -615,6 +634,111 @@ describe.each(['js', 'rust'] as const)('GraphQL Hive Plugin (%s)', gatewayType =
         stats.target?.schemaCoordinateStats.totalFailures === 1 &&
         operationsStatsResult.target?.operationsStats.operations.edges[0].node.count === 1
       );
+    });
+  });
+
+  test('errors thrown in the gateway are tracked', async () => {
+    const subgraphs = {
+      products: {
+        typeDefs: parse(/* GraphQL */ `
+          extend type Query {
+            product: Product
+          }
+
+          type Product @key(fields: "id") {
+            id: ID!
+            price: Int
+          }
+        `),
+        resolvers: {
+          Query: {
+            product: () => {
+              return { id: 1, price: 20.2 };
+            },
+          },
+        },
+      },
+      users: {
+        typeDefs: parse(/* GraphQL */ `
+          extend type Query {
+            users: [User]
+          }
+          type User {
+            id: ID!
+            name: String
+          }
+        `),
+        resolvers: {
+          Query: {
+            users: () => [{ id: 2 }],
+          },
+          User: {
+            name: () => {
+              'j';
+            },
+          },
+        },
+      },
+    };
+
+    const { readErrorCodes, gateway, waitForRequestsCollected } = await setup(
+      subgraphs,
+      gatewayType,
+      [
+        {
+          onValidate({ addValidationRule }) {
+            addValidationRule((context: ValidationContext) => {
+              return {
+                Field(node: FieldNode) {
+                  if (node.name.value === 'product') {
+                    context.reportError(
+                      new GraphQLError('hm', {
+                        nodes: [node],
+                        extensions: { code: 'NOPE' },
+                        path: ['product'], // assumes "path" is set so it can be attributed to a coordinate.
+                      }),
+                    );
+                    return null;
+                  }
+                },
+              };
+            });
+          },
+        },
+      ],
+    );
+
+    const request = new Request('http://localhost:4000/graphql', {
+      method: 'POST',
+      headers: {
+        'x-graphql-client-name': 'app-name',
+        'x-graphql-client-version': 'app-version',
+        'content-type': 'application/json',
+        accept: 'application/json',
+      },
+      body: JSON.stringify({
+        query: `
+          { product { id } }
+        `,
+      }),
+    });
+
+    const usageCollected = waitForRequestsCollected(1);
+    await gateway.handle(request);
+    await usageCollected;
+
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const period = {
+      from: yesterday.toISOString(),
+      to: new Date().toISOString(),
+    };
+
+    await pollFor(async () => {
+      const errorCodes = await readErrorCodes('Query.product', period);
+      const code = errorCodes.target?.schemaCoordinateStats?.errorCodes?.edges?.[0]?.node?.code;
+
+      return code === 'NOPE';
     });
   });
 

--- a/integration-tests/tests/gateway-plugin-console-sdk/plugin.spec.ts
+++ b/integration-tests/tests/gateway-plugin-console-sdk/plugin.spec.ts
@@ -2,9 +2,13 @@ import { AddressInfo } from 'node:net';
 import {
   GraphQLError,
   parse,
+  TypeInfo,
+  ValidationContext,
+  visit,
+  visitInParallel,
+  visitWithTypeInfo,
   type DocumentNode,
   type FieldNode,
-  type ValidationContext,
 } from 'graphql';
 import { createLogger, createYoga } from 'graphql-yoga';
 import { pollFor, readOperationsStats } from 'testkit/flow';
@@ -681,17 +685,32 @@ describe.each(['js', 'rust'] as const)('GraphQL Hive Plugin (%s)', gatewayType =
       },
     };
 
+    let typeInfo: TypeInfo | undefined;
     const { readErrorCodes, gateway, waitForRequestsCollected } = await setup(
       subgraphs,
       gatewayType,
       [
+        /** Mimic the useGenericAuth plugin to run validation onExecute as an example. */
         {
-          onValidate({ addValidationRule }) {
-            addValidationRule((context: ValidationContext) => {
-              return {
+          onSchemaChange({ schema }) {
+            typeInfo = new TypeInfo(schema);
+          },
+          async onExecute({ args, setResultAndStopExecution }) {
+            const errors: GraphQLError[] = [];
+            typeInfo ??= new TypeInfo(args.schema);
+            const validationContext = new ValidationContext(
+              args.schema,
+              args.document,
+              typeInfo,
+              e => {
+                errors.push(e);
+              },
+            );
+            const visitor = visitInParallel([
+              {
                 Field(node: FieldNode) {
                   if (node.name.value === 'product') {
-                    context.reportError(
+                    validationContext.reportError(
                       new GraphQLError('hm', {
                         nodes: [node],
                         extensions: { code: 'NOPE' },
@@ -701,8 +720,12 @@ describe.each(['js', 'rust'] as const)('GraphQL Hive Plugin (%s)', gatewayType =
                     return null;
                   }
                 },
-              };
-            });
+              },
+            ]);
+            args.document = visit(args.document, visitWithTypeInfo(typeInfo, visitor));
+            if (errors.length > 0) {
+              return setResultAndStopExecution({ data: null, errors });
+            }
           },
         },
       ],

--- a/packages/libraries/core/src/client/types.ts
+++ b/packages/libraries/core/src/client/types.ts
@@ -1,4 +1,10 @@
-import type { DocumentNode, ExecutionArgs, GraphQLErrorExtensions, GraphQLSchema } from 'graphql';
+import type {
+  DocumentNode,
+  ExecutionArgs,
+  GraphQLError,
+  GraphQLErrorExtensions,
+  GraphQLSchema,
+} from 'graphql';
 import type { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue.js';
 import { LogLevel as HiveLoggerLevel, Logger } from '@graphql-hive/logger';
 import { MaybePromise } from '@graphql-tools/utils';
@@ -11,6 +17,10 @@ import type { SchemaReporter } from './reporting.js';
 type HeadersObject = {
   get(name: string): string | null;
 };
+
+export type TrackGatewayErrorsCallback = (args: {
+  errors?: any[] | readonly Error[] | readonly GraphQLError[] | null;
+}) => void;
 
 export type SubRequestCallback = (args: {
   /** Which subgraph resolved this path */
@@ -44,6 +54,7 @@ export type FinishSubRequestCallback = (args: {
 }) => void;
 
 export type CollectUsage = {
+  trackGatewayErrors: TrackGatewayErrorsCallback;
   subrequest: SubRequestCallback;
   finish: CollectUsageCallback;
 };
@@ -335,6 +346,11 @@ export type Maybe<T> = null | undefined | T;
 export type GraphQLResult<TData = Record<string, unknown>> = {
   data?: TData | null;
 } & GraphQLErrorsResult;
+
+export interface TrackedGraphQLError {
+  coordinate: string;
+  code?: string;
+}
 
 export interface GraphQLErrorsResult {
   errors?: ReadonlyArray<{

--- a/packages/libraries/core/src/client/usage.ts
+++ b/packages/libraries/core/src/client/usage.ts
@@ -163,7 +163,6 @@ export function createUsage(pluginOptions: HiveInternalPluginOptions): UsageColl
                 fields: subgraphFields,
               };
             });
-
             reportOperations.push({
               operationMapKey: operation.key,
               timestamp: operation.timestamp,

--- a/packages/libraries/core/src/client/usage.ts
+++ b/packages/libraries/core/src/client/usage.ts
@@ -1,5 +1,6 @@
 import {
   DocumentNode,
+  GraphQLError,
   GraphQLSchema,
   Kind,
   OperationDefinitionNode,
@@ -24,6 +25,7 @@ import type {
   GraphQLResult,
   HiveInternalPluginOptions,
   HiveUsagePluginOptions,
+  TrackedGraphQLError,
 } from './types.js';
 import {
   cache,
@@ -32,6 +34,7 @@ import {
   logIf,
   measureDuration,
   memo,
+  toTrackedError,
 } from './utils.js';
 
 interface UsageCollector {
@@ -45,6 +48,7 @@ interface UsageCollector {
     experimental__persistedDocumentHash?: string;
     /** Optionally send subgraph request information. This provides a deeper level of usage metrics */
     fetches?: CollectedOperationSubRequest[] | null;
+    gatewayErrors?: TrackedGraphQLError[] | null;
   }): void;
   /** collect a long-lived GraphQL request/subscription (subscription operation) */
   collectSubscription(args: {
@@ -61,6 +65,7 @@ function isAbortAction(result: Parameters<CollectUsageCallback>[1]): result is A
 const noopUsageCollector: UsageCollector = {
   collect() {
     return {
+      trackGatewayErrors() {},
       subrequest() {
         return () => {};
       },
@@ -167,6 +172,7 @@ export function createUsage(pluginOptions: HiveInternalPluginOptions): UsageColl
                 duration: operation.execution.duration,
                 errorsTotal: operation.execution.errorsTotal,
                 fetches,
+                gatewayErrors: operation.execution.gatewayErrors,
               },
               metadata: {
                 client: operation.client ?? undefined,
@@ -260,6 +266,7 @@ export function createUsage(pluginOptions: HiveInternalPluginOptions): UsageColl
           ? excludingValue.test(operationName)
           : operationName === excludingValue,
       );
+      let gatewayErrors = args.gatewayErrors;
       if (
         !isMatch &&
         shouldInclude({
@@ -277,28 +284,49 @@ export function createUsage(pluginOptions: HiveInternalPluginOptions): UsageColl
         });
 
         let fetches = args.fetches;
-        if (!fetches?.length && options.fieldLevelMetricsEnabled) {
-          /**
-           * No subgraph requests, so this must be a monolith.
-           * We still want to track the field metrics, so create an artificial
-           * fetch that represents the local lookup.
-           */
-          const rootPath =
-            getDefinedRootType(args.args.schema, rootOperation.operation ?? OperationTypeNode.QUERY)
-              ?.name ?? 'Query';
+        let errorsTotal = 0;
+        if (options.fieldLevelMetricsEnabled) {
+          if (!fetches?.length) {
+            /**
+             * No subgraph requests, so this must be a monolith.
+             * We still want to track the field metrics, so create an artificial
+             * fetch that represents the local lookup.
+             */
+            const rootPath =
+              getDefinedRootType(
+                args.args.schema,
+                rootOperation.operation ?? OperationTypeNode.QUERY,
+              )?.name ?? 'Query';
 
-          fetches = [
-            {
-              document: args.args.document,
-              duration: args.duration,
-              start: 0,
-              subgraph: '',
-              subgraphSchema: args.args.schema,
-              type: 'ROOT',
-              paths: rootPath,
-              result, // make sure this isnt taking too much memory to store. Can this be stripped out?
-            },
-          ];
+            fetches = [
+              {
+                document: args.args.document,
+                duration: args.duration,
+                start: 0,
+                subgraph: '',
+                subgraphSchema: args.args.schema,
+                type: 'ROOT',
+                paths: rootPath,
+                result: { data: result.data }, // errors are captured by gateway errors in this instance
+              },
+            ];
+            // Use the result errors in this case since it will be for the entire payload and there are no fetch errors.
+            // Use the gatewayErrors as a fallback since those should also be tracked.
+            gatewayErrors =
+              result.errors
+                ?.map(e => toTrackedError(e, args.args.schema, args.args.document, result.data))
+                .filter(e => !!e) ?? args.gatewayErrors;
+            errorsTotal = result.errors?.length ?? 0;
+          } else {
+            for (const subRequest of fetches) {
+              errorsTotal += subRequest.result?.errors?.length ?? 0;
+            }
+            if (args.gatewayErrors) {
+              errorsTotal += args.gatewayErrors?.length ?? 0;
+            }
+          }
+        } else {
+          errorsTotal = result.errors?.length ?? 0;
         }
 
         agent.capture(
@@ -314,8 +342,9 @@ export function createUsage(pluginOptions: HiveInternalPluginOptions): UsageColl
                 execution: {
                   ok: !result.errors?.length,
                   duration: args.duration,
-                  errorsTotal: result.errors?.length ?? 0,
+                  errorsTotal,
                   fetches,
+                  gatewayErrors,
                 },
                 // TODO: operationHash is ready to accept hashes of persisted operations
                 client: args.experimental__persistedDocumentHash
@@ -349,7 +378,14 @@ export function createUsage(pluginOptions: HiveInternalPluginOptions): UsageColl
     collect() {
       const sinceStart = measureDuration();
       const subRequests: CollectedOperationSubRequest[] = [];
+      let gatewayErrors: any[] | Error[] | GraphQLError[][] | undefined = undefined;
       return {
+        trackGatewayErrors({ errors }) {
+          if (errors) {
+            gatewayErrors ??= [];
+            gatewayErrors.push(...errors);
+          }
+        },
         subrequest({ subgraph, type, paths }) {
           const start = sinceStart();
           const sinceSubStart = measureDuration();
@@ -376,6 +412,16 @@ export function createUsage(pluginOptions: HiveInternalPluginOptions): UsageColl
             duration,
             experimental__persistedDocumentHash,
             fetches: subRequests.length > 0 ? subRequests : null,
+            gatewayErrors: gatewayErrors
+              ?.map(err =>
+                toTrackedError(
+                  err,
+                  args.schema,
+                  args.document,
+                  isAbortAction(result) ? undefined : result.data,
+                ),
+              )
+              .filter(e => !!e),
           });
         },
       };
@@ -581,6 +627,7 @@ interface CollectedOperation {
     duration: number;
     errorsTotal: number;
     fetches?: CollectedOperationSubRequest[] | null;
+    gatewayErrors?: TrackedGraphQLError[] | null;
   };
   persistedDocumentHash?: string;
   client?: ClientInfo | null;
@@ -604,6 +651,7 @@ interface RequestOperation {
     duration: number;
     errorsTotal: number;
     fetches?: OperationSubRequest[] | null;
+    gatewayErrors?: TrackedGraphQLError[] | null;
   };
   persistedDocumentHash?: string;
   metadata?: {

--- a/packages/libraries/core/src/client/utils.ts
+++ b/packages/libraries/core/src/client/utils.ts
@@ -1,7 +1,9 @@
+import { DocumentNode, GraphQLError, GraphQLSchema } from 'graphql';
 import { Attributes, Logger } from '@graphql-hive/logger';
 import { crypto, TextEncoder } from '@whatwg-node/fetch';
 import { hiveClientSymbol } from './client.js';
-import type { HiveClient, HivePluginOptions, LegacyLogger } from './types.js';
+import { errorPathToCoordinate } from './subrequests/error-path-to-coordinate.js';
+import type { HiveClient, HivePluginOptions, LegacyLogger, TrackedGraphQLError } from './types.js';
 
 async function digest(algo: 'SHA-256' | 'SHA-1', output: 'hex' | 'base64', data: string) {
   const buffer = await crypto.subtle.digest(algo, new TextEncoder().encode(data));
@@ -268,4 +270,27 @@ function getErrorsFromAttrs(attrs: Attributes | null | undefined): Array<string>
   }
 
   return [`${error.name ?? error.class}: ${error.message}`];
+}
+
+/**
+ * Converts a parse or GraphQL error into a format that can be ingested by the usage collector.
+ */
+export function toTrackedError(
+  err: Error | any | GraphQLError,
+  schema: GraphQLSchema,
+  document: DocumentNode,
+  data: any,
+): TrackedGraphQLError | null {
+  if (Array.isArray(err?.path)) {
+    const coordinate = errorPathToCoordinate(schema, err.path, document, data);
+    const maybeCode = (err as GraphQLError).extensions?.code;
+    const code = typeof maybeCode === 'string' ? maybeCode : undefined;
+    if (typeof coordinate === 'string') {
+      return {
+        coordinate,
+        code,
+      };
+    }
+  }
+  return null;
 }

--- a/packages/libraries/gateway-plugin-console-sdk/src/index.ts
+++ b/packages/libraries/gateway-plugin-console-sdk/src/index.ts
@@ -1,24 +1,37 @@
 import {
+  ExecutionArgs,
   GraphQLSchema,
   OperationTypeNode,
+  parse,
   responsePathAsArray,
   type DocumentNode,
   type GraphQLError,
 } from 'graphql';
+import type { GraphQLHTTPExtensions } from 'graphql-yoga';
+import type { ExecutionResultWithSerializer } from 'graphql-yoga/typings/plugins/types.js';
 import { lru } from 'tiny-lru';
 import {
   addHiveTypenames,
+  CollectUsage,
   createHive as createHiveClient,
   getDefinedRootType,
   hideInjectedTypenames,
+  HiveClient,
+  HivePluginOptions,
   isAsyncIterable,
   isHiveClient,
-  type HiveClient,
-  type HivePluginOptions,
 } from '@graphql-hive/core';
-import { GatewayPlugin } from '@graphql-hive/gateway-runtime';
+import type { GatewayPlugin } from '@graphql-hive/gateway-runtime';
 import { isEntityRequest } from './is-entity-request.js';
 import { version } from './version.js';
+
+export {
+  atLeastOnceSampler,
+  createSchemaFetcher,
+  createServicesFetcher,
+  createSupergraphSDLFetcher,
+} from '@graphql-hive/core';
+export type { SupergraphSDLFetcherOptions } from '@graphql-hive/core';
 
 export function createHive(clientOrOptions: HivePluginOptions) {
   return createHiveClient({
@@ -39,6 +52,14 @@ export type GatewayPluginOptions = HivePluginOptions & {
   cache?: number;
 };
 
+type CacheRecord = {
+  collector: CollectUsage;
+  paramsArgs: Record<string, any>;
+  document?: DocumentNode;
+  executionArgs?: ExecutionArgs;
+  experimental__documentId?: string;
+};
+
 export function useHive(clientOrOptions: HiveClient): GatewayPlugin;
 export function useHive(clientOrOptions: GatewayPluginOptions): GatewayPlugin;
 export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): GatewayPlugin {
@@ -53,14 +74,16 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
       });
 
   void hive.info();
-  /** stores the resulting status from fetches */
+
+  const contextualCache = new WeakMap<object, CacheRecord>();
   const statusMap = new WeakMap<object, number>();
+
   const fieldLevelMetricsEnabled = isHiveClient(clientOrOptions)
     ? false
     : (typeof clientOrOptions.usage === 'object' &&
         clientOrOptions.usage?.fieldLevelMetricsEnabled) ||
       false;
-  /** stores the original query SDL to avoid having to print */
+
   const operationCache = fieldLevelMetricsEnabled
     ? lru<DocumentNode | true>(
         isHiveClient(clientOrOptions) ? 10_000 : (clientOrOptions.cache ?? 10_000),
@@ -71,7 +94,6 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
 
   return {
     onFetch({ executionRequest }) {
-      /** Only if the execution request is set, then this is a subgraph execution. */
       if (!executionRequest) {
         return;
       }
@@ -82,29 +104,17 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
     },
 
     onSubgraphExecute({ executionRequest, subgraphName, subgraph: subgraphSchema }) {
-      if (!fieldLevelMetricsEnabled) {
-        // short circuit the entire hook to avoid processing this data.
+      if (!fieldLevelMetricsEnabled || !executionRequest.context) {
+        return;
+      }
+      const cache = contextualCache.get(executionRequest.context);
+      if (!cache) {
         return;
       }
 
-      const collection = executionRequest.context?.__hiveUsageCollection as
-        | ReturnType<HiveClient['collectUsage']>
-        | undefined;
-
-      if (!collection) {
-        // This is set onExecute so this should exist... but just to be safe
-        return;
-      }
-
-      /**
-       * Note that we need __typename on every abstract type in the subgraph call.
-       * This is added in the "onExecute" hook to the entire document. So subgraph
-       * calls should also include this field.
-       */
-      const finishSubRequest = collection.subrequest({
+      const finishSubRequest = cache.collector.subrequest({
         subgraph: subgraphName,
         type: isEntityRequest(executionRequest.document) ? 'ENTITY' : 'ROOT',
-        /** @NOTE this field's format supports batched requests, but onSubgraphExecute does not. */
         paths: executionRequest.info?.path
           ? [responsePathAsArray(executionRequest.info.path).join('.')]
           : getDefinedRootType(
@@ -119,24 +129,38 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
             status: statusMap.get(executionRequest) ?? 200,
             subgraphSchema,
             result,
+            // The Rust query planner generates and caches this document up front.
+            // This depends on the operation and variables.
+            // So if we need to add typenames to the request, it needs to happen
+            // here also. E.g. `addHiveTypenames(executionRequest.document, subgraphSchema)`.
+            // But for the js gateway execution, this is redundant and an unnecessary expense.
             document: executionRequest.document,
           });
         }
       };
     },
+
     onSchemaChange({ schema }) {
       hive.reportSchema({ schema });
       latestSchema = schema;
       operationCache?.clear();
     },
-    onExecute({ args, executeFn, setExecuteFn }) {
-      const collection = hive.collectUsage();
 
-      // Inject the collection object into the GraphQL context
-      // so it can be accessed downstream by subgraph executions.
-      if (args.contextValue) {
-        (args.contextValue as any).__hiveUsageCollection = collection;
+    onParams(context) {
+      if ((context.params.query || 'documentId' in context.params) && latestSchema) {
+        contextualCache.set(context.context, {
+          collector: hive.collectUsage(),
+          paramsArgs: context.params,
+        });
       }
+    },
+
+    onExecute({ args, context, setExecuteFn, executeFn }) {
+      const ctx = args.contextValue || context;
+      const cache = contextualCache.get(ctx);
+      if (!cache) return;
+
+      cache.executionArgs = args;
 
       if (fieldLevelMetricsEnabled && operationCache && latestSchema) {
         // Validation must run against the client document. Add the metadata fields only
@@ -145,7 +169,7 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
         const cachedDocument = query ? operationCache.get(query) : undefined;
         const modifiedDocument =
           cachedDocument === true
-            ? args.document
+            ? (args.document as DocumentNode)
             : cachedDocument || addHiveTypenames(args.document, latestSchema);
 
         if (query && cachedDocument === undefined) {
@@ -156,40 +180,145 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
             executeFn({ ...executionArgs, document: modifiedDocument }),
           );
         }
+        cache.document = modifiedDocument;
       }
 
       return {
-        onExecuteDone({ result }) {
+        onExecuteDone({ result, args }) {
           if (!isAsyncIterable(result)) {
-            if (result.data && fieldLevelMetricsEnabled) {
-              hideInjectedTypenames(result.data);
+            if (result.errors) {
+              const gatewayErrors = result.errors?.filter(
+                e =>
+                  e.extensions?.code !== 'DOWNSTREAM_SERVICE_ERROR' && !e.extensions?.subgraphName,
+              );
+              if (cache && gatewayErrors?.length > 0) {
+                console.dir(result.errors);
+                cache.collector.trackGatewayErrors({ errors: gatewayErrors });
+              }
             }
-            void collection.finish(args, result);
+
+            args.contextValue.waitUntil(
+              cache.collector.finish(
+                args,
+                // {
+                //   ...args,
+                //   document: ctx.document ?? args.document,
+                // },
+                result,
+                cache.experimental__documentId,
+              ),
+            );
             return;
           }
 
           const errors: GraphQLError[] = [];
           return {
-            onNext({ result }) {
-              if (result.data && fieldLevelMetricsEnabled) {
-                hideInjectedTypenames(result.data);
-              }
-              if (result.errors) {
-                errors.push(...result.errors);
+            onNext({ result: iterResult }) {
+              if (iterResult.errors) {
+                errors.push(...iterResult.errors);
               }
             },
             onEnd() {
-              void collection.finish(args, errors.length ? { errors } : {});
+              ctx.waitUntil(
+                cache.collector.finish(
+                  args,
+                  // {
+                  //   ...args,
+                  //   document: cache.document ?? args.document,
+                  // },
+                  // how to pass in data here?
+                  errors.length ? { errors } : {},
+                  cache.experimental__documentId,
+                ),
+              );
             },
           };
         },
       };
     },
-    onSubscribe({ args }) {
-      hive.collectSubscriptionUsage({ args });
+
+    onSubscribe({ args, context }) {
+      const ctx = args.contextValue || context;
+      const record = contextualCache.get(ctx);
+
+      return {
+        onSubscribeResult() {
+          const experimental__persistedDocumentHash = record?.experimental__documentId;
+          hive.collectSubscriptionUsage({
+            args,
+            // args: {
+            //   ...args,
+            //   document: record?.executionArgs?.document ?? args.document,
+            // },
+            experimental__persistedDocumentHash,
+          });
+        },
+      };
     },
-    onDispose: async () => {
-      await hive.dispose();
+
+    async onResultProcess({ serverContext, result, setResult }) {
+      const record = contextualCache.get(serverContext);
+
+      if (!record || Array.isArray(result) || isAsyncIterable(result) || record.executionArgs) {
+        if (fieldLevelMetricsEnabled) {
+          if (isAsyncIterable(result)) {
+            const modifyStream = async function* (): AsyncIterable<
+              ExecutionResultWithSerializer<
+                any,
+                {
+                  http?: GraphQLHTTPExtensions;
+                }
+              >
+            > {
+              for await (const r of result) {
+                hideInjectedTypenames(r.data);
+                yield r;
+              }
+            };
+            setResult(modifyStream());
+          } else if (Array.isArray(result)) {
+            for (let r of result) {
+              hideInjectedTypenames(r.data);
+            }
+          } else {
+            hideInjectedTypenames(result.data);
+          }
+        }
+        return;
+      }
+
+      if (record.paramsArgs.query && latestSchema) {
+        try {
+          let doc = record.document;
+          if (!doc) {
+            doc = parse(record.paramsArgs.query);
+          }
+
+          serverContext.waitUntil(
+            record.collector.finish(
+              {
+                document: doc,
+                schema: latestSchema,
+                variableValues: record.paramsArgs.variables,
+                operationName: record.paramsArgs.operationName,
+                contextValue: serverContext,
+              },
+              result,
+              record.experimental__documentId,
+            ),
+          );
+        } catch (err) {
+          // Fail silently if parse fails inside cached block handling
+        }
+      }
+
+      if (fieldLevelMetricsEnabled) {
+        hideInjectedTypenames(result.data);
+      }
+    },
+
+    onDispose() {
+      return hive.dispose();
     },
   };
 }

--- a/packages/libraries/gateway-plugin-console-sdk/src/index.ts
+++ b/packages/libraries/gateway-plugin-console-sdk/src/index.ts
@@ -189,21 +189,24 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
             if (result.errors) {
               const gatewayErrors = result.errors?.filter(
                 e =>
-                  e.extensions?.code !== 'DOWNSTREAM_SERVICE_ERROR' && !e.extensions?.subgraphName,
+                  /**
+                   * DOWNSTREAM_SERVICE_ERROR is set by the executor to wrap subgraph errors. A serviceName is also
+                   * used to indicate the source of the error. If either of these are found, then it's safe to assume
+                   * the error was not thrown in the gateway.
+                   */
+                  e.extensions?.code !== 'DOWNSTREAM_SERVICE_ERROR' && !e.extensions?.serviceName,
               );
               if (cache && gatewayErrors?.length > 0) {
-                console.dir(result.errors);
                 cache.collector.trackGatewayErrors({ errors: gatewayErrors });
               }
             }
 
             args.contextValue.waitUntil(
               cache.collector.finish(
-                args,
-                // {
-                //   ...args,
-                //   document: ctx.document ?? args.document,
-                // },
+                {
+                  ...args,
+                  document: cache.document ?? ctx.document ?? args.document,
+                },
                 result,
                 cache.experimental__documentId,
               ),
@@ -221,11 +224,10 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
             onEnd() {
               ctx.waitUntil(
                 cache.collector.finish(
-                  args,
-                  // {
-                  //   ...args,
-                  //   document: cache.document ?? args.document,
-                  // },
+                  {
+                    ...args,
+                    document: cache.document ?? args.document,
+                  },
                   // how to pass in data here?
                   errors.length ? { errors } : {},
                   cache.experimental__documentId,
@@ -245,11 +247,10 @@ export function useHive(clientOrOptions: HiveClient | GatewayPluginOptions): Gat
         onSubscribeResult() {
           const experimental__persistedDocumentHash = record?.experimental__documentId;
           hive.collectSubscriptionUsage({
-            args,
-            // args: {
-            //   ...args,
-            //   document: record?.executionArgs?.document ?? args.document,
-            // },
+            args: {
+              ...args,
+              document: record?.document ?? record?.executionArgs?.document ?? args.document,
+            },
             experimental__persistedDocumentHash,
           });
         },

--- a/packages/services/usage/src/usage-processor-2.ts
+++ b/packages/services/usage/src/usage-processor-2.ts
@@ -191,9 +191,15 @@ export const usageProcessorV2 = traceInlineSync(
         },
       });
 
-      const errors = operation.execution.fetches
-        ?.flatMap(f => f.errors)
-        .filter(e => e !== undefined);
+      let errors = operation.execution.fetches?.flatMap(f => f.errors).filter(e => e !== undefined);
+      if (operation.execution.gatewayErrors?.length) {
+        // append gateway errors onto the reported rawErrors.
+        if (!errors?.length) {
+          errors = operation.execution.gatewayErrors;
+        } else {
+          errors.push(...operation.execution.gatewayErrors);
+        }
+      }
       if (errors?.length) {
         rawErrors.push({
           operationMapKey,
@@ -280,6 +286,8 @@ const OperationMapRecordSchema = tb.Object(
 
 type OperationMapRecord = tb.Static<typeof OperationMapRecordSchema>;
 
+const TrackedErrorSchema = tb.Object({ coordinate: tb.String(), code: tb.Optional(tb.String()) });
+
 const SubgraphRequestSchema = tb.Object(
   {
     /** Delta start time from "timestamp" */
@@ -306,9 +314,7 @@ const SubgraphRequestSchema = tb.Object(
     fields: tb.Record(tb.String(), tb.Number()),
 
     /** Error code for a coordinate, with a code returned from the graphql extensions */
-    errors: tb.Optional(
-      tb.Array(tb.Object({ coordinate: tb.String(), code: tb.Optional(tb.String()) })),
-    ),
+    errors: tb.Optional(tb.Array(TrackedErrorSchema)),
 
     /** Which subgraph resolved this path */
     subgraph: tb.String(),
@@ -347,6 +353,7 @@ const ExecutionSchema = tb.Type.Object(
       maximum: Math.pow(2, 16) - 1,
     }),
     fetches: OptionalAndNullable(tb.Array(SubgraphRequestSchema)),
+    gatewayErrors: OptionalAndNullable(tb.Array(TrackedErrorSchema)),
   },
   {
     title: 'Execution',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,8 +338,8 @@ importers:
         specifier: ^1.0.0 || ^2.0.0
         version: 2.9.10(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)(ws@8.21.0)
       '@graphql-hive/router-runtime':
-        specifier: ^1.4.0
-        version: 1.4.22(@types/node@25.5.0)(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)
+        specifier: ^1.4.23
+        version: 1.4.23(@types/node@25.5.0)(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.9.0)
@@ -4342,8 +4342,8 @@ packages:
     resolution: {integrity: sha512-KTvconFeSdKejudY6hUrfP8nvkxp+bg2uuNqbIZF1pmlFzjlDHGoUO8qpvKxdmWijXSuEcQBzWnn4rpMkzgC/A==}
     engines: {bun: ^1, node: '>=20'}
 
-  '@graphql-hive/router-runtime@1.4.22':
-    resolution: {integrity: sha512-XDsLCfDlecAGUjO8kVwkXk4iufP/vJ2CH9PCL44tcu/BeOrjo8C4kt9ykI/BUN24/gx4ykNCGIK0D2D5LdQSJA==}
+  '@graphql-hive/router-runtime@1.4.23':
+    resolution: {integrity: sha512-mPzAZFMlRZMpt9fYlOIRQ2zHY+7uGrr9VezAkb3wGuViBepuisDYMstBZT+PiDJOM5rBw/md8mtqUpo01CHkJQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -22679,7 +22679,7 @@ snapshots:
 
   '@graphql-hive/router-query-planner@0.0.38': {}
 
-  '@graphql-hive/router-runtime@1.4.22(@types/node@25.5.0)(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)':
+  '@graphql-hive/router-runtime@1.4.23(@types/node@25.5.0)(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)':
     dependencies:
       '@envelop/core': 5.5.1
       '@graphql-hive/router-query-planner': 0.0.38
@@ -23135,7 +23135,7 @@ snapshots:
       '@envelop/core': 5.6.0
       '@envelop/instrumentation': 1.0.0
       '@graphql-hive/logger': 1.1.1(pino@10.3.0)
-      '@graphql-mesh/cross-helpers': 0.4.14(graphql@16.9.0)
+      '@graphql-mesh/cross-helpers': 0.4.16(graphql@16.9.0)
       '@graphql-mesh/transport-common': 1.0.20(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)
       '@graphql-mesh/types': 0.105.1(graphql@16.9.0)(ioredis@5.10.1)
       '@graphql-mesh/utils': 0.104.38(graphql@16.9.0)(ioredis@5.10.1)
@@ -23487,8 +23487,8 @@ snapshots:
 
   '@graphql-mesh/types@0.104.30(graphql@16.9.0)(ioredis@5.10.1)':
     dependencies:
-      '@graphql-hive/pubsub': 2.1.1(ioredis@5.10.1)
-      '@graphql-tools/batch-delegate': 10.0.28(graphql@16.9.0)
+      '@graphql-hive/pubsub': 2.2.1(ioredis@5.10.1)
+      '@graphql-tools/batch-delegate': 10.0.29(graphql@16.9.0)
       '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
       '@graphql-tools/utils': 11.2.2(graphql@16.9.0)
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
@@ -23497,6 +23497,7 @@ snapshots:
       graphql: 16.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@nats-io/jetstream'
       - '@nats-io/nats-core'
       - ioredis
 
@@ -23570,10 +23571,10 @@ snapshots:
       '@graphql-mesh/cross-helpers': 0.4.16(graphql@16.9.0)
       '@graphql-mesh/string-interpolation': 0.5.18(graphql@16.9.0)
       '@graphql-mesh/types': 0.104.30(graphql@16.9.0)(ioredis@5.10.1)
-      '@graphql-tools/batch-delegate': 10.0.28(graphql@16.9.0)
+      '@graphql-tools/batch-delegate': 10.0.29(graphql@16.9.0)
       '@graphql-tools/delegate': 12.1.1(graphql@16.9.0)
       '@graphql-tools/utils': 11.2.2(graphql@16.9.0)
-      '@graphql-tools/wrap': 11.1.20(graphql@16.9.0)
+      '@graphql-tools/wrap': 11.1.21(graphql@16.9.0)
       '@whatwg-node/disposablestack': 0.0.6
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
@@ -23585,6 +23586,7 @@ snapshots:
       tiny-lru: 13.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@nats-io/jetstream'
       - '@nats-io/nats-core'
       - ioredis
 


### PR DESCRIPTION
### Background

This adds support for errors thrown during the validation phase in the gateway. Previously, if subgraph requests were being made, then only those requests were used to collect the errors.

### Description

Adds a new `gatewayErrors` field to the payload, which will need documentation updated.

The rest of the gateway request is still appended to the `fetches` array as a single "fetch". So in this case, the errors are stripped from this faked "fetch" and added to the gatewayErrors array. This is to avoid double counting the errors, and to keep the gatewayErrors as a consistent place for, well, errors in the gateway.

This also modifies some of the operation building to more closely match the yoga plugin. E.g. using `context.waitUntil` and support for persisted documents.

### Checklist

- [X] Input validation
- [X] Output encoding
- [X] Error handling and logging
- [X] Testing
