### PR TITLE
chore: update federation composition to 0.25.0

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -30,7 +30,7 @@
     "@hive/service-common": "workspace:*",
     "@hive/storage": "workspace:*",
     "@hive/workflows": "workspace:*",
-    "@theguild/federation-composition": "0.24.1",
+    "@theguild/federation-composition": "0.25.0",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@types/async-retry": "1.4.8",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@sentry/cli": "2.40.0",
     "@swc/core": "1.13.5",
     "@theguild/eslint-config": "0.12.1",
-    "@theguild/federation-composition": "0.24.1",
+    "@theguild/federation-composition": "0.25.0",
     "@theguild/prettier-config": "2.0.7",
     "@types/node": "24.13.3",
     "bob-the-bundler": "7.0.1",

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -60,7 +60,7 @@
     "@oclif/core": "3.26.6",
     "@oclif/plugin-help": "6.2.36",
     "@oclif/plugin-update": "4.7.16",
-    "@theguild/federation-composition": "0.24.1",
+    "@theguild/federation-composition": "0.25.0",
     "cli-table3": "0.6.5",
     "colors": "1.4.0",
     "env-ci": "7.3.0",

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -49,7 +49,7 @@
     "@sentry/node": "7.120.2",
     "@sentry/types": "7.120.2",
     "@slack/web-api": "7.10.0",
-    "@theguild/federation-composition": "0.24.1",
+    "@theguild/federation-composition": "0.25.0",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@types/bcryptjs": "2.4.6",

--- a/packages/services/demo/federation/package.json
+++ b/packages/services/demo/federation/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@apollo/subgraph": "2.13.2",
-    "@theguild/federation-composition": "0.24.1",
+    "@theguild/federation-composition": "0.25.0",
     "graphql": "16.9.0",
     "graphql-yoga": "5.22.0"
   },

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -16,7 +16,7 @@
     "@graphql-tools/utils": "11.1.0",
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.120.2",
-    "@theguild/federation-composition": "0.24.1",
+    "@theguild/federation-composition": "0.25.0",
     "@trpc/server": "10.45.3",
     "@types/async-retry": "1.4.8",
     "@types/ioredis-mock": "8.2.5",

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -37,7 +37,7 @@
     "@hive/workflows": "workspace:*",
     "@sentry/node": "7.120.2",
     "@swc/core": "1.13.5",
-    "@theguild/federation-composition": "0.24.1",
+    "@theguild/federation-composition": "0.25.0",
     "@trpc/server": "10.45.3",
     "@whatwg-node/server": "0.10.17",
     "dotenv": "16.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: 0.12.1
         version: 0.12.1(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3)
       '@theguild/federation-composition':
-        specifier: 0.24.1
-        version: 0.24.1(graphql@16.9.0)
+        specifier: 0.25.0
+        version: 0.25.0(graphql@16.9.0)
       '@theguild/prettier-config':
         specifier: 2.0.7
         version: 2.0.7(prettier@3.4.2)
@@ -365,8 +365,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/services/workflows
       '@theguild/federation-composition':
-        specifier: 0.24.1
-        version: 0.24.1(graphql@16.9.0)
+        specifier: 0.25.0
+        version: 0.25.0(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -544,8 +544,8 @@ importers:
         specifier: 4.7.16
         version: 4.7.16
       '@theguild/federation-composition':
-        specifier: 0.24.1
-        version: 0.24.1(graphql@16.9.0)
+        specifier: 0.25.0
+        version: 0.25.0(graphql@16.9.0)
       cli-table3:
         specifier: 0.6.5
         version: 0.6.5
@@ -1216,8 +1216,8 @@ importers:
         specifier: 7.10.0
         version: 7.10.0
       '@theguild/federation-composition':
-        specifier: 0.24.1
-        version: 0.24.1(graphql@16.9.0)
+        specifier: 0.25.0
+        version: 0.25.0(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -1453,8 +1453,8 @@ importers:
         specifier: 2.13.2
         version: 2.13.2(graphql@16.9.0)
       '@theguild/federation-composition':
-        specifier: 0.24.1
-        version: 0.24.1(graphql@16.9.0)
+        specifier: 0.25.0
+        version: 0.25.0(graphql@16.9.0)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -1562,8 +1562,8 @@ importers:
         specifier: 7.120.2
         version: 7.120.2
       '@theguild/federation-composition':
-        specifier: 0.24.1
-        version: 0.24.1(graphql@16.9.0)
+        specifier: 0.25.0
+        version: 0.25.0(graphql@16.9.0)
       '@trpc/server':
         specifier: 10.45.3
         version: 10.45.3
@@ -1682,8 +1682,8 @@ importers:
         specifier: 1.13.5
         version: 1.13.5
       '@theguild/federation-composition':
-        specifier: 0.24.1
-        version: 0.24.1(graphql@16.9.0)
+        specifier: 0.25.0
+        version: 0.25.0(graphql@16.9.0)
       '@trpc/server':
         specifier: 10.45.3
         version: 10.45.3
@@ -10699,11 +10699,11 @@ packages:
     peerDependencies:
       graphql: ^16.0.0
 
-  '@theguild/federation-composition@0.24.1':
-    resolution: {integrity: sha512-NBjo7F10Z8pShdrGHXgElEntWJ9JAC9zlTv+mrRU8PY513d98FvtX0sPLE7hS/rMRWfPsSUMjgOO9uwstQ2onA==}
+  '@theguild/federation-composition@0.25.0':
+    resolution: {integrity: sha512-Nvl38wnVGsUE+F0qJAP/cS8B+PZceCeL3qgyt0oGp5WKRHfVqfwW0L029E/UELU0i6ON4RkRRdUPNtmoAR9lOA==}
     engines: {node: '>=18'}
     peerDependencies:
-      graphql: ^16.0.0
+      graphql: ^16.0.0 || ^17.0.0
 
   '@theguild/prettier-config@2.0.7':
     resolution: {integrity: sha512-FqpgGAaAFbYHFQmkWEZjIhqmk+Oow82/t+0k408qoBd9RsB4QTwSQSDDbNSgFa/K7c8Dcwau5z3XbHUR/ksKqw==}
@@ -32023,7 +32023,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@theguild/federation-composition@0.24.1(graphql@16.9.0)':
+  '@theguild/federation-composition@0.25.0(graphql@16.9.0)':
     dependencies:
       constant-case: 3.0.4
       debug: 4.4.3(supports-color@8.1.1)


### PR DESCRIPTION
updates to latest federation composition which introduced graphql@17 setup. This brings us one step closer towards upgrading to graphq@17.

Follow up for https://github.com/graphql-hive/console/pull/8385