### PR TITLE
improve diff/code view experience in schema checks

### DIFF
--- a/e2e/specs/checks.spec.ts
+++ b/e2e/specs/checks.spec.ts
@@ -9,7 +9,6 @@ test.describe('checks', () => {
     seed,
     auth,
   }) => {
-    // const { accessToken, refreshToken, slug } = await seed.seedOrg();
     const { accessToken, refreshToken, slug, resources } = await seed.seedTarget(
       ProjectType.Federation,
     );
@@ -38,44 +37,29 @@ test.describe('checks', () => {
       },
       accessToken,
     ).then(r => r.expectNoGraphQLErrors());
-    await expect(check.schemaCheck.__typename).toBe('SchemaCheckSuccess');
-    if (check.schemaCheck.__typename === 'SchemaCheckSuccess') {
-      async function editorHasNoDeletions() {
-        let previousScrollTop = -1;
-        let currentScrollTop = 0;
-        while (currentScrollTop !== previousScrollTop) {
-          previousScrollTop = currentScrollTop;
-          currentScrollTop = await page.evaluate(async () => {
-            const scroller = document.querySelector(
-              '.monaco-editor .monaco-scrollable-element',
-            ) as HTMLElement;
-            scroller.scrollTop += 400; // Shift downwards
-            return scroller.scrollTop;
-          });
-          await expect(page.locator('.monaco-editor .gutter-delete')).toBeHidden(); // no "removed" diff element
-          await page.waitForTimeout(50);
-        }
-      }
+    expect(check.schemaCheck.__typename).toBe('SchemaCheckSuccess');
 
-      await auth.useSession({ refreshToken, accessToken });
-      await page.goto(
-        `/${slug}/checks/${check.schemaCheck.schemaCheck?.id}?filter_changed=false&filter_failed=false`,
-        {
-          waitUntil: 'domcontentloaded',
-        },
-      );
+    await auth.useSession({ refreshToken, accessToken });
+    await page.goto(
+      `/${slug}/checks/${check.schemaCheck.schemaCheck?.id}?filter_changed=false&filter_failed=false`,
+      {
+        waitUntil: 'domcontentloaded',
+      },
+    );
 
-      await page.getByTestId('service-view-btn').click(); // move to service tab
-      await expect(page.locator('.monaco-editor.gutter')).toBeAttached({ timeout: 2000 }); // schema diff editor exists
-      await editorHasNoDeletions();
+    await page.getByTestId('service-view-btn').click(); // move to service tab
+    await expect(page.getByTestId('schema-title-before')).toHaveText('test@xyz');
+    await expect(page.getByTestId('schema-title')).toHaveText('test@unknown');
+    await expect(page.getByTestId('schema-title-changed')).toHaveText('(unchanged)');
 
-      await page.getByTestId('schema-view-btn').click(); // move to schema tab
-      await expect(page.locator('.monaco-editor.gutter')).toBeAttached({ timeout: 2000 }); // schema diff editor exists
-      await editorHasNoDeletions();
+    await page.getByTestId('schema-view-btn').click(); // move to schema tab
+    await expect(page.getByTestId('schema-title-before')).toHaveText('schema@xyz');
+    await expect(page.getByTestId('schema-title')).toHaveText('schema@unknown');
+    await expect(page.getByTestId('schema-title-changed')).toHaveText('(unchanged)');
 
-      await page.getByTestId('supergraph-view-btn').click(); // move to supergraph tab
-      await expect(page.locator('.monaco-editor.gutter')).toBeAttached({ timeout: 2000 }); // schema diff editor exists
-      await editorHasNoDeletions();
-    }
+    await page.getByTestId('supergraph-view-btn').click(); // move to supergraph tab
+    await expect(page.getByTestId('schema-title-before')).toHaveText('supergraph@xyz');
+    await expect(page.getByTestId('schema-title')).toHaveText('supergraph@unknown');
+    await expect(page.getByTestId('schema-title-changed')).toHaveText('(unchanged)');
   });
 });

--- a/packages/web/app/package.json
+++ b/packages/web/app/package.json
@@ -33,7 +33,7 @@
     "@hive/service-common": "workspace:*",
     "@hookform/resolvers": "3.10.0",
     "@monaco-editor/react": "4.8.0-rc.2",
-    "@pierre/diffs": "1.2.3",
+    "@pierre/diffs": "1.3.5",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-avatar": "1.1.2",

--- a/packages/web/app/src/components/v2/diff-editor.tsx
+++ b/packages/web/app/src/components/v2/diff-editor.tsx
@@ -171,7 +171,7 @@ export const DiffEditor = (props: {
   );
 };
 
-function DownloadButton(props: { contents: string; fileName: string }) {
+export function DownloadButton(props: { contents: string; fileName: string }) {
   return (
     <TooltipProvider>
       <Tooltip>

--- a/packages/web/app/src/pages/target-checks-single.tsx
+++ b/packages/web/app/src/pages/target-checks-single.tsx
@@ -753,18 +753,18 @@ function DefaultSchemaView(props: {
                   <span className="flex items-center gap-1">
                     {schemaCheck.baseline?.meta ? (
                       <>
-                        <span className="font-mono">
+                        <span className="font-mono" data-testid="schema-title-before">
                           {schemaCheck.serviceName}@
                           {schemaCheck.baseline?.meta.commit?.substring(0, 7) ?? 'unknown'}
                         </span>
                         <ArrowRight className="inline size-3" />
                       </>
                     ) : null}
-                    <span className="font-mono">
+                    <span className="font-mono" data-testid="schema-title">
                       {schemaCheck.serviceName}@
                       {schemaCheck.meta?.commit.substring(0, 7) ?? <>unknown</>}
                     </span>
-                    (unchanged)
+                    <span data-testid="schema-title-changed">(unchanged)</span>
                   </span>
                 ) : undefined
               }
@@ -805,18 +805,18 @@ function DefaultSchemaView(props: {
                   <span className="flex items-center gap-1">
                     {schemaCheck.baseline?.meta ? (
                       <>
-                        <span className="font-mono">
-                          {schemaCheck.serviceName}@
+                        <span className="font-mono" data-testid="schema-title-before">
+                          schema@
                           {schemaCheck.baseline?.meta.commit?.substring(0, 7) ?? 'unknown'}
                         </span>
                         <ArrowRight className="inline size-3" />
                       </>
                     ) : null}
-                    <span className="font-mono">
-                      {schemaCheck.serviceName}@
+                    <span className="font-mono" data-testid="schema-title">
+                      schema@
                       {schemaCheck.meta?.commit.substring(0, 7) ?? <>unknown</>}
                     </span>
-                    (unchanged)
+                    <span data-testid="schema-title-changed">(unchanged)</span>
                   </span>
                 ) : undefined
               }
@@ -838,18 +838,18 @@ function DefaultSchemaView(props: {
                   <span className="flex items-center gap-1">
                     {schemaCheck.baseline?.meta ? (
                       <>
-                        <span className="font-mono">
+                        <span className="font-mono" data-testid="schema-title-before">
                           supergraph@
                           {schemaCheck.baseline?.meta.commit?.substring(0, 7) ?? 'unknown'}
                         </span>
                         <ArrowRight className="inline size-3" />
                       </>
                     ) : null}
-                    <span className="font-mono">
+                    <span className="font-mono" data-testid="schema-title">
                       supergraph@
                       {schemaCheck.meta?.commit.substring(0, 7) ?? <>unknown</>}
                     </span>
-                    (unchanged)
+                    <span data-testid="schema-title-changed">(unchanged)</span>
                   </span>
                 ) : undefined
               }

--- a/packages/web/app/src/pages/target-checks-single.tsx
+++ b/packages/web/app/src/pages/target-checks-single.tsx
@@ -13,7 +13,6 @@ import {
   TriangleAlertIcon,
 } from 'lucide-react';
 import { useMutation, useQuery } from 'urql';
-import { SchemaEditor } from '@/components/schema-editor';
 import {
   ChangesBlock,
   CompositionErrorsList,
@@ -21,7 +20,6 @@ import {
   labelize,
   NoGraphChanges,
 } from '@/components/target/history/errors-and-changes';
-import { useTheme } from '@/components/theme/theme-provider';
 import { Button } from '@/components/ui/button';
 import { CopyText } from '@/components/ui/copy-text';
 import { File } from '@/components/ui/diffs';
@@ -959,12 +957,6 @@ function ContractCheckView(props: {
       </div>
     </TooltipProvider>
   );
-}
-
-function withLineAndColumn<T>(
-  marker: T,
-): marker is T & { start: { line: number; column: number } } {
-  return typeof (marker as any)?.start?.line === 'number';
 }
 
 const SchemaPolicyEditor_PolicyWarningsFragment = graphql(`

--- a/packages/web/app/src/pages/target-checks-single.tsx
+++ b/packages/web/app/src/pages/target-checks-single.tsx
@@ -96,6 +96,26 @@ function AnnotatedSDLView(props: {
   );
 }
 
+function SDLSingleView(props: {
+  title?: ReactElement;
+  sdl: string;
+  downloadFileName?: string;
+}): ReactElement {
+  return (
+    <div className="w-full">
+      <div className="border-neutral-3 flex items-center justify-between border-b px-2 py-1">
+        <div className="px-2 font-bold">{props.title}</div>
+        <div className="ml-auto flex h-[36px] items-center px-2">
+          {props.sdl && props.downloadFileName && (
+            <DownloadButton fileName={props.downloadFileName} contents={props.sdl} />
+          )}
+        </div>
+      </div>
+      <SDLView sdl={props.sdl} />
+    </div>
+  );
+}
+
 function SDLSingleDiffToggleView(props: {
   title?: ReactElement;
   before: string | null;
@@ -723,46 +743,124 @@ function DefaultSchemaView(props: {
             <ConditionalBreakingChangesMetadataSection schemaCheck={schemaCheck} />
           </div>
         )}
-        {selectedView === 'service' && (
-          <SDLSingleDiffToggleView
-            title={
-              schemaCheck.serviceName ? (
-                <span className="flex items-center gap-1">
-                  {schemaCheck.baseline?.meta ? (
-                    <>
-                      <span className="font-mono">
-                        {schemaCheck.serviceName}@
-                        {schemaCheck.baseline?.meta.commit?.substring(0, 7) ?? 'unknown'}
-                      </span>
-                      <ArrowRight className="inline size-3" />
-                    </>
-                  ) : null}
-                  <span className="font-mono">
-                    {schemaCheck.serviceName}@
-                    {schemaCheck.meta?.commit.substring(0, 7) ?? <>unknown</>}
+        {selectedView === 'service' &&
+          (schemaCheck.baseline?.sdl === schemaCheck.schemaSDL ? (
+            <SDLSingleView
+              sdl={schemaCheck.schemaSDL}
+              downloadFileName="service.graphqls"
+              title={
+                schemaCheck.serviceName ? (
+                  <span className="flex items-center gap-1">
+                    {schemaCheck.baseline?.meta ? (
+                      <>
+                        <span className="font-mono">
+                          {schemaCheck.serviceName}@
+                          {schemaCheck.baseline?.meta.commit?.substring(0, 7) ?? 'unknown'}
+                        </span>
+                        <ArrowRight className="inline size-3" />
+                      </>
+                    ) : null}
+                    <span className="font-mono">
+                      {schemaCheck.serviceName}@
+                      {schemaCheck.meta?.commit.substring(0, 7) ?? <>unknown</>}
+                    </span>
+                    (unchanged)
                   </span>
-                </span>
-              ) : undefined
-            }
-            before={schemaCheck.baseline?.sdl ?? null}
-            after={schemaCheck.schemaSDL}
-            downloadFileName="service.graphqls"
-          />
-        )}
-        {selectedView === 'schema' && (
-          <SDLSingleDiffToggleView
-            before={schemaCheck.baseline?.publicSdl ?? null}
-            after={schemaCheck.compositeSchemaSDL ?? null}
-            downloadFileName="schema.graphqls"
-          />
-        )}
-        {selectedView === 'supergraph' && (
-          <SDLSingleDiffToggleView
-            before={schemaCheck?.baseline?.supergraphSdl ?? null}
-            after={schemaCheck?.supergraphSDL ?? null}
-            downloadFileName="supergraph.graphqls"
-          />
-        )}
+                ) : undefined
+              }
+            />
+          ) : (
+            <SDLSingleDiffToggleView
+              title={
+                schemaCheck.serviceName ? (
+                  <span className="flex items-center gap-1">
+                    {schemaCheck.baseline?.meta ? (
+                      <>
+                        <span className="font-mono">
+                          {schemaCheck.serviceName}@
+                          {schemaCheck.baseline?.meta.commit?.substring(0, 7) ?? 'unknown'}
+                        </span>
+                        <ArrowRight className="inline size-3" />
+                      </>
+                    ) : null}
+                    <span className="font-mono">
+                      {schemaCheck.serviceName}@
+                      {schemaCheck.meta?.commit.substring(0, 7) ?? <>unknown</>}
+                    </span>
+                  </span>
+                ) : undefined
+              }
+              before={schemaCheck.baseline?.sdl ?? null}
+              after={schemaCheck.schemaSDL}
+              downloadFileName="service.graphqls"
+            />
+          ))}
+        {selectedView === 'schema' &&
+          (schemaCheck.baseline?.publicSdl === schemaCheck.compositeSchemaSDL ? (
+            <SDLSingleView
+              sdl={schemaCheck.schemaSDL}
+              downloadFileName="schema.graphqls"
+              title={
+                schemaCheck.serviceName ? (
+                  <span className="flex items-center gap-1">
+                    {schemaCheck.baseline?.meta ? (
+                      <>
+                        <span className="font-mono">
+                          {schemaCheck.serviceName}@
+                          {schemaCheck.baseline?.meta.commit?.substring(0, 7) ?? 'unknown'}
+                        </span>
+                        <ArrowRight className="inline size-3" />
+                      </>
+                    ) : null}
+                    <span className="font-mono">
+                      {schemaCheck.serviceName}@
+                      {schemaCheck.meta?.commit.substring(0, 7) ?? <>unknown</>}
+                    </span>
+                    (unchanged)
+                  </span>
+                ) : undefined
+              }
+            />
+          ) : (
+            <SDLSingleDiffToggleView
+              before={schemaCheck.baseline?.publicSdl ?? null}
+              after={schemaCheck.compositeSchemaSDL ?? null}
+              downloadFileName="schema.graphqls"
+            />
+          ))}
+        {selectedView === 'supergraph' &&
+          (schemaCheck?.baseline?.supergraphSdl === schemaCheck.supergraphSDL ? (
+            <SDLSingleView
+              sdl={schemaCheck?.baseline?.supergraphSdl ?? ''}
+              downloadFileName="supergraph.graphqls"
+              title={
+                schemaCheck.serviceName ? (
+                  <span className="flex items-center gap-1">
+                    {schemaCheck.baseline?.meta ? (
+                      <>
+                        <span className="font-mono">
+                          supergraph@
+                          {schemaCheck.baseline?.meta.commit?.substring(0, 7) ?? 'unknown'}
+                        </span>
+                        <ArrowRight className="inline size-3" />
+                      </>
+                    ) : null}
+                    <span className="font-mono">
+                      supergraph@
+                      {schemaCheck.meta?.commit.substring(0, 7) ?? <>unknown</>}
+                    </span>
+                    (unchanged)
+                  </span>
+                ) : undefined
+              }
+            />
+          ) : (
+            <SDLSingleDiffToggleView
+              before={schemaCheck?.baseline?.supergraphSdl ?? null}
+              after={schemaCheck?.supergraphSDL ?? null}
+              downloadFileName="supergraph.graphqls"
+            />
+          ))}
         {selectedView === 'policy' && (
           <>
             <div className="my-2 px-2">
@@ -818,6 +916,15 @@ const ContractCheckView_ContractCheckFragment = graphql(`
 const ContractCheckView_SchemaCheckFragment = graphql(`
   fragment ContractCheckView_SchemaCheckFragment on SchemaCheck {
     id
+    serviceName
+    meta {
+      commit
+    }
+    baseline {
+      meta {
+        commit
+      }
+    }
     ...ConditionalBreakingChangesMetadataSection_SchemaCheckFragment
     conditionalBreakingChangeMetadata {
       ...ChangesBlock_SchemaCheckConditionalBreakingChangeMetadataFragment
@@ -940,20 +1047,72 @@ function ContractCheckView(props: {
             )}
           </div>
         )}
-        {selectedView === 'schema' && (
-          <SDLSingleDiffToggleView
-            before={contractCheck?.baseline?.publicSdl ?? null}
-            after={contractCheck.compositeSchemaSDL ?? null}
-            downloadFileName="schema.graphqls"
-          />
-        )}
-        {selectedView === 'supergraph' && (
-          <SDLSingleDiffToggleView
-            before={contractCheck?.baseline?.supergraphSdl ?? null}
-            after={contractCheck?.supergraphSDL ?? null}
-            downloadFileName="supergraph.graphqls"
-          />
-        )}
+        {selectedView === 'schema' &&
+          (contractCheck?.baseline?.publicSdl === contractCheck.compositeSchemaSDL ? (
+            <SDLSingleView
+              sdl={contractCheck.compositeSchemaSDL ?? ''}
+              downloadFileName="service.graphqls"
+              title={
+                schemaCheck.serviceName ? (
+                  <span className="flex items-center gap-1">
+                    {schemaCheck.baseline?.meta ? (
+                      <>
+                        <span className="font-mono">
+                          schema@
+                          {schemaCheck.baseline?.meta.commit?.substring(0, 7) ?? 'unknown'}
+                        </span>
+                        <ArrowRight className="inline size-3" />
+                      </>
+                    ) : null}
+                    <span className="font-mono">
+                      schema@
+                      {schemaCheck.meta?.commit.substring(0, 7) ?? <>unknown</>}
+                    </span>
+                    (unchanged)
+                  </span>
+                ) : undefined
+              }
+            />
+          ) : (
+            <SDLSingleDiffToggleView
+              before={contractCheck?.baseline?.publicSdl ?? null}
+              after={contractCheck.compositeSchemaSDL ?? null}
+              downloadFileName="schema.graphqls"
+            />
+          ))}
+        {selectedView === 'supergraph' &&
+          (contractCheck?.baseline?.supergraphSdl === contractCheck?.supergraphSDL ? (
+            <SDLSingleView
+              sdl={contractCheck?.supergraphSDL ?? ''}
+              downloadFileName="supergraph.graphqls"
+              title={
+                schemaCheck.serviceName ? (
+                  <span className="flex items-center gap-1">
+                    {schemaCheck.baseline?.meta ? (
+                      <>
+                        <span className="font-mono">
+                          supergraph@
+                          {schemaCheck.baseline?.meta.commit?.substring(0, 7) ?? 'unknown'}
+                        </span>
+                        <ArrowRight className="inline size-3" />
+                      </>
+                    ) : null}
+                    <span className="font-mono">
+                      supergraph@
+                      {schemaCheck.meta?.commit.substring(0, 7) ?? <>unknown</>}
+                    </span>
+                    (unchanged)
+                  </span>
+                ) : undefined
+              }
+            />
+          ) : (
+            <SDLSingleDiffToggleView
+              before={contractCheck?.baseline?.supergraphSdl ?? null}
+              after={contractCheck?.supergraphSDL ?? null}
+              downloadFileName="supergraph.graphqls"
+            />
+          ))}
       </div>
     </TooltipProvider>
   );
@@ -1297,7 +1456,7 @@ const ActiveSchemaCheck = (props: {
   }
 
   return (
-    <div className="flex h-full grow flex-col">
+    <div className="flex h-full max-w-[-webkit-fill-available] grow flex-col">
       <div className="py-6">
         <Title>Check {schemaCheck.id}</Title>
         <Subtitle>Detailed view of the schema check</Subtitle>

--- a/packages/web/app/src/pages/target-checks-single.tsx
+++ b/packages/web/app/src/pages/target-checks-single.tsx
@@ -1008,7 +1008,7 @@ const SchemaPolicyEditor = (props: {
             character: (edge.node.end?.column ?? 0) - 1,
           },
           message: edge.node.message,
-          severity: 'warning',
+          severity: 'warning' as const,
         })) ?? []),
         ...(errors?.edges.map(edge => ({
           start: {
@@ -1021,7 +1021,7 @@ const SchemaPolicyEditor = (props: {
           },
           lineNumber: edge.node.start?.line ?? 0,
           message: edge.node.message,
-          severity: 'error',
+          severity: 'error' as const,
         })) ?? []),
       ]}
     />

--- a/packages/web/app/src/pages/target-checks-single.tsx
+++ b/packages/web/app/src/pages/target-checks-single.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useMemo, useState } from 'react';
+import { Fragment, ReactElement, useCallback, useMemo, useState } from 'react';
 import { format } from 'date-fns';
 import {
   ArrowRight,
@@ -9,6 +9,8 @@ import {
   GitCompareIcon,
   InfoIcon,
   Loader2,
+  ShieldAlertIcon,
+  TriangleAlertIcon,
 } from 'lucide-react';
 import { useMutation, useQuery } from 'urql';
 import { SchemaEditor } from '@/components/schema-editor';
@@ -19,23 +21,27 @@ import {
   labelize,
   NoGraphChanges,
 } from '@/components/target/history/errors-and-changes';
+import { useTheme } from '@/components/theme/theme-provider';
 import { Button } from '@/components/ui/button';
 import { CopyText } from '@/components/ui/copy-text';
+import { File } from '@/components/ui/diffs';
 import { DocsLink } from '@/components/ui/docs-note';
 import { EmptyList } from '@/components/ui/empty-list';
 import { Heading } from '@/components/ui/heading';
 import { AlertTriangleIcon, DiffIcon } from '@/components/ui/icon';
+import { Label } from '@/components/ui/label';
 import { Meta } from '@/components/ui/meta';
 import { Subtitle, Title } from '@/components/ui/page';
 import { Popover, PopoverArrow, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { QueryError } from '@/components/ui/query-error';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Spinner } from '@/components/ui/spinner';
+import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { TimeAgo } from '@/components/ui/time-ago';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { DiffEditor } from '@/components/v2/diff-editor';
+import { DownloadButton } from '@/components/v2/diff-editor';
 import { FragmentType, graphql, useFragment } from '@/gql';
 import { ProjectType } from '@/gql/graphql';
 import { cn } from '@/lib/utils';
@@ -45,6 +51,91 @@ import {
   InfoCircledIcon,
   ListBulletIcon,
 } from '@radix-ui/react-icons';
+import { SDLDiffView, SDLView } from './target-history-schema-version';
+
+function AnnotatedSDLView(props: {
+  sdl: string;
+  annotations?: Array<{
+    message: string;
+    severity: 'error' | 'warning';
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  }>;
+}) {
+  return (
+    <div className="max-w-[inherit]">
+      <File
+        file={{
+          name: 'schema.graphql',
+          contents: props.sdl,
+        }}
+        options={{
+          disableFileHeader: true,
+        }}
+        lineAnnotations={props.annotations?.map(annotation => ({
+          lineNumber: annotation.start.line,
+          metadata: { message: annotation.message, severity: annotation.severity },
+        }))}
+        renderAnnotation={annotation => (
+          <div
+            className={cn(
+              'border-l-5 flex items-center pl-1',
+              annotation.metadata.severity === 'warning'
+                ? 'border-yellow-400 bg-yellow-100 text-yellow-800'
+                : 'border-red-500 bg-red-100 text-red-800',
+            )}
+          >
+            <span>{annotation.metadata.message}</span>
+            {annotation.metadata.severity === 'warning' ? (
+              <TriangleAlertIcon className="ml-auto mr-2 size-4 text-yellow-800" />
+            ) : (
+              <ShieldAlertIcon className="ml-auto mr-2 size-4 text-red-800" />
+            )}
+          </div>
+        )}
+      />
+    </div>
+  );
+}
+
+function SDLSingleDiffToggleView(props: {
+  title?: ReactElement;
+  before: string | null;
+  after: string | null;
+  downloadFileName?: string;
+}): ReactElement {
+  const [showDiff, setShowDiff] = useState<boolean>(true);
+  const title = props?.title ?? 'Diff View';
+
+  return (
+    <div className="w-full">
+      <div className="border-neutral-3 flex items-center justify-between border-b px-2 py-1">
+        <div className="px-2 font-bold">{title}</div>
+        <div className="ml-auto flex h-[36px] items-center px-2">
+          {props.after && props.downloadFileName && (
+            <DownloadButton fileName={props.downloadFileName} contents={props.after} />
+          )}
+
+          <div className="ml-2 flex items-center space-x-2">
+            <Label htmlFor="toggle-diff-mode" className="text-xs font-normal">
+              Toggle Diff
+            </Label>
+            <Switch
+              id="toggle-diff-mode"
+              checked={showDiff}
+              onCheckedChange={isChecked => setShowDiff(isChecked)}
+            />
+          </div>
+        </div>
+      </div>
+      {showDiff ? (
+        <SDLDiffView before={props.before ?? ''} after={props.after ?? ''} />
+      ) : (
+        <SDLView sdl={props.after ?? ''} />
+      )}
+    </div>
+  );
+}
 
 const ApproveFailedSchemaCheckMutation = graphql(`
   mutation ApproveFailedSchemaCheckModal_ApproveFailedSchemaCheckMutation(
@@ -635,7 +726,7 @@ function DefaultSchemaView(props: {
           </div>
         )}
         {selectedView === 'service' && (
-          <DiffEditor
+          <SDLSingleDiffToggleView
             title={
               schemaCheck.serviceName ? (
                 <span className="flex items-center gap-1">
@@ -661,14 +752,14 @@ function DefaultSchemaView(props: {
           />
         )}
         {selectedView === 'schema' && (
-          <DiffEditor
+          <SDLSingleDiffToggleView
             before={schemaCheck.baseline?.publicSdl ?? null}
             after={schemaCheck.compositeSchemaSDL ?? null}
             downloadFileName="schema.graphqls"
           />
         )}
         {selectedView === 'supergraph' && (
-          <DiffEditor
+          <SDLSingleDiffToggleView
             before={schemaCheck?.baseline?.supergraphSdl ?? null}
             after={schemaCheck?.supergraphSDL ?? null}
             downloadFileName="supergraph.graphqls"
@@ -852,14 +943,14 @@ function ContractCheckView(props: {
           </div>
         )}
         {selectedView === 'schema' && (
-          <DiffEditor
+          <SDLSingleDiffToggleView
             before={contractCheck?.baseline?.publicSdl ?? null}
             after={contractCheck.compositeSchemaSDL ?? null}
             downloadFileName="schema.graphqls"
           />
         )}
         {selectedView === 'supergraph' && (
-          <DiffEditor
+          <SDLSingleDiffToggleView
             before={contractCheck?.baseline?.supergraphSdl ?? null}
             after={contractCheck?.supergraphSDL ?? null}
             downloadFileName="supergraph.graphqls"
@@ -904,45 +995,35 @@ const SchemaPolicyEditor = (props: {
   const warnings = useFragment(SchemaPolicyEditor_PolicyWarningsFragment, props.warnings);
   const errors = useFragment(SchemaPolicyEditor_PolicyWarningsFragment, props.errors);
   return (
-    <SchemaEditor
-      theme="vs-dark"
-      options={{
-        renderLineHighlightOnlyWhenFocus: true,
-        readOnly: true,
-        lineNumbers: 'on',
-        renderValidationDecorations: 'on',
-      }}
-      onMount={(editor, monaco) => {
-        monaco.editor.setModelMarkers(monaco.editor.getModels()[0], 'owner', [
-          ...(warnings?.edges
-            .map(edge => edge.node)
-            .filter(withLineAndColumn)
-            .map(node => ({
-              message: node.message,
-              startLineNumber: node.start.line,
-              startColumn: node.start.column,
-              endLineNumber: node.end?.line ?? node.start.line,
-              endColumn: node.end?.column ?? node.start.column,
-              severity: monaco.MarkerSeverity.Warning,
-            })) ?? []),
-          ...(errors?.edges
-            .map(edge => edge.node)
-            .filter(withLineAndColumn)
-            .map(node => ({
-              message: node.message,
-              startLineNumber: node.start.line,
-              startColumn: node.start.column,
-              endLineNumber: node.end?.line ?? node.start.line,
-              endColumn: node.end?.column ?? node.start.column,
-              severity: monaco.MarkerSeverity.Error,
-            })) ?? []),
-        ]);
-
-        if (props.scrollToLine) {
-          editor.revealLineInCenter(props.scrollToLine);
-        }
-      }}
-      schema={props.compositeSchemaSDL}
+    <AnnotatedSDLView
+      sdl={props.compositeSchemaSDL}
+      annotations={[
+        ...(warnings?.edges.map(edge => ({
+          start: {
+            line: (edge.node.start?.line ?? 0) - 1,
+            character: (edge.node.start?.column ?? 0) - 1,
+          },
+          end: {
+            line: (edge.node.end?.line ?? 0) - 1,
+            character: (edge.node.end?.column ?? 0) - 1,
+          },
+          message: edge.node.message,
+          severity: 'warning',
+        })) ?? []),
+        ...(errors?.edges.map(edge => ({
+          start: {
+            line: (edge.node.start?.line ?? 0) - 1,
+            character: (edge.node.start?.column ?? 0) - 1,
+          },
+          end: {
+            line: (edge.node.end?.line ?? 0) - 1,
+            character: (edge.node.end?.column ?? 0) - 1,
+          },
+          lineNumber: edge.node.start?.line ?? 0,
+          message: edge.node.message,
+          severity: 'error',
+        })) ?? []),
+      ]}
     />
   );
 };

--- a/packages/web/app/src/pages/target-history-schema-version.tsx
+++ b/packages/web/app/src/pages/target-history-schema-version.tsx
@@ -33,7 +33,6 @@ import {
   ChangesBlock,
   CompositionErrorsSection_SchemaErrorConnection,
 } from '@/components/target/history/errors-and-changes';
-import { useTheme } from '@/components/theme/theme-provider';
 import { BadgeRounded } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { File, MultiFileDiff } from '@/components/ui/diffs';

--- a/packages/web/app/src/pages/target-history-schema-version.tsx
+++ b/packages/web/app/src/pages/target-history-schema-version.tsx
@@ -961,7 +961,7 @@ function GraphVersionSubgraphChangesView(props: {
   );
 }
 
-function SDLDiffView(props: { before: string; after: string }) {
+export function SDLDiffView(props: { before: string; after: string }) {
   return (
     <MultiFileDiff
       options={{
@@ -980,8 +980,7 @@ function SDLDiffView(props: { before: string; after: string }) {
   );
 }
 
-function SDLView(props: { sdl: string }) {
-  const { resolvedTheme } = useTheme();
+export function SDLView(props: { sdl: string }) {
   return (
     <div className="max-w-[inherit]">
       <File
@@ -990,7 +989,6 @@ function SDLView(props: { sdl: string }) {
           contents: props.sdl,
         }}
         options={{
-          theme: resolvedTheme === 'dark' ? 'pierre-dark' : 'pierre-light',
           disableFileHeader: true,
         }}
       />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2115,8 +2115,8 @@ importers:
         specifier: 4.8.0-rc.2
         version: 4.8.0-rc.2(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@pierre/diffs':
-        specifier: 1.2.3
-        version: 1.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.3.5
+        version: 1.3.5(@shikijs/themes@3.23.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-accordion':
         specifier: 1.2.2
         version: 1.2.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7375,15 +7375,35 @@ packages:
     resolution: {integrity: sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==}
     engines: {node: '>=10.12.0'}
 
-  '@pierre/diffs@1.2.3':
-    resolution: {integrity: sha512-ul83DHH1yqgGxJAw2tqQm2gDO+oQsaF82ZVocwJYfXAm2FhZyyKPTdtv6jswR4A5eF/ILPjiQxyfScMhQcofbA==}
+  '@pierre/diffs@1.3.5':
+    resolution: {integrity: sha512-BhaLEiUvR+BdIyOYdogA4JLQjluWPubuwySmmIqEkcE0FwIWRbgJgHNC/r884dlxEr89fO4hTk/sBln0a7NSOw==}
     peerDependencies:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
 
-  '@pierre/theme@1.0.3':
-    resolution: {integrity: sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==}
+  '@pierre/theme@2.0.0':
+    resolution: {integrity: sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw==}
     engines: {vscode: ^1.0.0}
+
+  '@pierre/theming@1.0.1':
+    resolution: {integrity: sha512-WCI5Qd7iprDpISL9fBYOLe8RV53+b7mFNA3bPzl60/2CKCSrsKN8zEcep6Y3BAzvARlmca50zGjDodqPGiTUKA==}
+    peerDependencies:
+      '@pierre/theme': ^1.1.0 || ^2.0.0
+      '@shikijs/themes': ^3.0.0 || ^4.0.0
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+      shiki: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@pierre/theme':
+        optional: true
+      '@shikijs/themes':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      shiki:
+        optional: true
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -12812,6 +12832,10 @@ packages:
 
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+    engines: {node: '>=0.3.1'}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -28063,18 +28087,29 @@ snapshots:
       tslib: 2.8.1
       webcrypto-core: 1.7.5
 
-  '@pierre/diffs@1.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@pierre/diffs@1.3.5(@shikijs/themes@3.23.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@pierre/theme': 1.0.3
+      '@pierre/theme': 2.0.0
+      '@pierre/theming': 1.0.1(@pierre/theme@2.0.0)(@shikijs/themes@3.23.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(shiki@3.23.0)
       '@shikijs/transformers': 3.23.0
-      diff: 8.0.3
+      diff: 9.0.0
       hast-util-to-html: 9.0.5
       lru_map: 0.4.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       shiki: 3.23.0
+    transitivePeerDependencies:
+      - '@shikijs/themes'
 
-  '@pierre/theme@1.0.3': {}
+  '@pierre/theme@2.0.0': {}
+
+  '@pierre/theming@1.0.1(@pierre/theme@2.0.0)(@shikijs/themes@3.23.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(shiki@3.23.0)':
+    optionalDependencies:
+      '@pierre/theme': 2.0.0
+      '@shikijs/themes': 3.23.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      shiki: 3.23.0
 
   '@pinojs/redact@0.4.0': {}
 
@@ -34089,6 +34124,8 @@ snapshots:
   didyoumean@1.2.2: {}
 
   diff@8.0.3: {}
+
+  diff@9.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:


### PR DESCRIPTION
Replaces the monaco setup in schema checks with pierre/diffs, which we already use for schema versions (history).

**Schema / Public SDL / Service Schema diff**
<img width="1309" height="734" alt="Screenshot 2026-08-21 at 13 37 44" src="https://github.com/user-attachments/assets/2a048711-bfa6-4f97-9c01-2f9e5dd690ee" />

**Schema Policy**

<img width="1308" height="923" alt="Screenshot 2026-08-21 at 13 38 18" src="https://github.com/user-attachments/assets/ac74669e-cec5-4e60-ba2c-f28b6c7645c7" />

Note: The previous monaco thing was highlighting the inline code with an underline, but did not show the actual error message. Pierre/diffs does currently not support inline markers/gutters for view mode (see https://github.com/pierrecomputer/pierre/issues/306).

I still thing the current UI is an improvement compared to before.