### PR TITLE
Deprecate reporting schemas from useHive

### DIFF
--- a/.changeset/large-streets-remain.md
+++ b/.changeset/large-streets-remain.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/core': patch
+---
+
+Deprecate reporting schemas from useHive

--- a/.changeset/large-streets-remain.md
+++ b/.changeset/large-streets-remain.md
@@ -1,5 +1,11 @@
 ---
 '@graphql-hive/core': patch
+'@graphql-hive/apollo': patch
+'@graphql-hive/envelop': patch
+'@graphql-hive/gateway-plugin-console-sdk': patch
+'@graphql-hive/yoga': patch
 ---
 
-Deprecate reporting schemas from useHive
+Deprecate run-time reporting schemas from `useHive` plugin.
+
+Use Hive CLI (`@graphql-hive/cli`) to publish the schema file instead. This aligns with best practices for schema management and prevents an issue where multiple service instances result in numerous publishes to Hive.

--- a/packages/libraries/core/src/client/reporting.ts
+++ b/packages/libraries/core/src/client/reporting.ts
@@ -19,6 +19,10 @@ export interface SchemaReporter {
   dispose(): Promise<void>;
 }
 
+/**
+ *
+ * @deprecated Use @graphql-hive/cli to report schemas instead.
+ */
 export function createReporting(pluginOptions: HiveInternalPluginOptions): SchemaReporter {
   if (!pluginOptions.reporting || pluginOptions.enabled === false) {
     return {

--- a/packages/libraries/core/src/client/reporting.ts
+++ b/packages/libraries/core/src/client/reporting.ts
@@ -36,6 +36,10 @@ export function createReporting(pluginOptions: HiveInternalPluginOptions): Schem
   const reportingOptions = pluginOptions.reporting;
   const logger = pluginOptions.logger.child({ module: 'hive-reporting' });
 
+  logger.warn(
+    '[hive][reporting] Run-time schema reporting is deprecated. Use `@graphql-hive/cli` to safely check and publish schemas.',
+  );
+
   logIf(
     typeof reportingOptions.author !== 'string' || reportingOptions.author.length === 0,
     '[hive][reporting] author is missing',

--- a/packages/libraries/core/src/client/types.ts
+++ b/packages/libraries/core/src/client/types.ts
@@ -297,6 +297,8 @@ export type HivePluginOptions = OptionalWhenFalse<
      * Schema reporting
      *
      * Disabled by default
+     *
+     * @deprecated Use Hive CLI (@graphql-hive/cli) to publish the schema file instead. This is prevents an issue where multiple service instances result in numerous publishes to Hive.
      */
     reporting?: HiveReportingPluginOptions | false;
     /**


### PR DESCRIPTION
### Background

Schema reporting at runtime is an anti pattern that can cause a schema to be published multiple times since it reports on boot. Although we can detect that this schema is the same within hive, it can still take significant bandwidth to validate etc depending on the size of the schema.

One such situation is if this feature is enabled for lambdas, since these can scale rapidly.

### Description

To avoid potential issues with the system, rather than continue supporting this feature by adding a target ID, we've decided to deprecate it and it will eventually be removed.

The method of uploading a schema should be to use `@graphql-hive/cli` to publish the schema within a deployment flow.
