### PR TITLE
Transform external composed sdl to public sdl

### DIFF
--- a/.changeset/plenty-windows-retire.md
+++ b/.changeset/plenty-windows-retire.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Add a worker environment option to transform external composed supergraph to public sdl instead of reading the public SDL from the external composer.

--- a/deployment/services/schema.ts
+++ b/deployment/services/schema.ts
@@ -48,6 +48,7 @@ export function deploySchema({
           observability.enabled && observability.tracingEndpoint
             ? observability.tracingEndpoint
             : '',
+        TRANSFORM_EXTERNAL_SUPERGRAPH_TO_PUBLIC_SDL: '1',
       },
       readinessProbe: '/_readiness',
       livenessProbe: '/_health',

--- a/packages/services/schema/__tests__/external.spec.ts
+++ b/packages/services/schema/__tests__/external.spec.ts
@@ -1,0 +1,107 @@
+import { print } from 'graphql';
+import nock from 'nock';
+import { composeExternalFederation } from '../src/lib/compose';
+
+test('external composition sdl is transformed to a public schema if it includes supergraph SDL', async ({
+  expect,
+}) => {
+  const http = nock('http://localhost')
+    .post('/broker')
+    .once()
+    .reply((_, _body) => {
+      const supergraphSdl = `schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+scalar join__FieldSet
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+enum join__Graph {
+  PRODUCTS @join__graph(name: "products", url: "https://products.example.com/graphql")
+}
+
+type Product @join__type(graph: PRODUCTS, key: "id") {
+  id: ID!
+}
+
+type Query @join__type(graph: PRODUCTS) {
+  product: Product
+}`;
+      const result = {
+        type: 'success',
+        includesException: false,
+        result: {
+          sdl: 'unused',
+          supergraph: supergraphSdl,
+        },
+      };
+      return [200, result];
+    });
+
+  const result = await composeExternalFederation({
+    decrypt: v => v,
+    external: {
+      endpoint: 'http://localhost/not-important',
+      encryptedSecret: 'foo',
+      broker: {
+        endpoint: 'http://localhost/broker',
+        signature: '123',
+      },
+    },
+    requestId: '1',
+    requestTimeoutMs: 5000,
+    subgraphs: [
+      /** unimportant */
+    ],
+    transformToPublicSdl: true,
+  });
+
+  expect(result.type).toBe('success');
+  assert(result.type === 'success');
+  expect(result.result.sdl).toMatchInlineSnapshot(`
+    type Product {
+      id: ID!
+    }
+
+    type Query {
+      product: Product
+    }
+  `);
+  // ensure the AST also matches the correct SDL result
+  expect(print(result.result.sdlDocumentNode)).toBe(result.result.sdl);
+  http.done();
+});

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -27,6 +27,7 @@
     "got": "14.4.7",
     "graphql": "16.9.0",
     "ioredis-mock": "8.9.0",
+    "nock": "14.0.10",
     "pino-pretty": "11.3.0",
     "reflect-metadata": "0.2.2",
     "zod": "3.25.76"

--- a/packages/services/schema/src/composition-worker.ts
+++ b/packages/services/schema/src/composition-worker.ts
@@ -68,6 +68,7 @@ export function createCompositionWorker(args: {
             decrypt,
             logger: baseLogger.child({ reqId: message.data.args.requestId }) as FastifyBaseLogger,
             requestTimeoutMs: args.env.timings.schemaExternalCompositionTimeout,
+            transformToPublicSdl: args.env.transformExternalSupergraphToPublicSdl,
           });
           const composed = await composeFederation(message.data.args);
 

--- a/packages/services/schema/src/composition/federation.ts
+++ b/packages/services/schema/src/composition/federation.ts
@@ -39,6 +39,7 @@ export type ComposeFederationDeps = {
   logger?: ServiceLogger;
   decrypt: (value: string) => string;
   requestTimeoutMs: number;
+  transformToPublicSdl?: boolean;
 };
 
 export type ComposeFederationArgs = {
@@ -152,6 +153,7 @@ export const createComposeFederation = (deps: ComposeFederationDeps) =>
           requestId: args.requestId,
           subgraphs,
           requestTimeoutMs: deps.requestTimeoutMs,
+          transformToPublicSdl: deps.transformToPublicSdl,
         });
     } else {
       deps.logger?.debug(

--- a/packages/services/schema/src/environment.ts
+++ b/packages/services/schema/src/environment.ts
@@ -43,7 +43,7 @@ const EnvironmentModel = zod.object({
   ).optional(),
   TRANSFORM_EXTERNAL_SUPERGRAPH_TO_PUBLIC_SDL: emptyString(
     zod.union([zod.literal('1'), zod.literal('0')]),
-  ),
+  ).optional(),
 });
 
 const RequestBrokerModel = zod.union([

--- a/packages/services/schema/src/environment.ts
+++ b/packages/services/schema/src/environment.ts
@@ -41,6 +41,9 @@ const EnvironmentModel = zod.object({
   COMPOSITION_WORKER_TRACK_MEMORY_USAGE: emptyString(
     zod.union([zod.literal('1'), zod.literal('0')]),
   ).optional(),
+  TRANSFORM_EXTERNAL_SUPERGRAPH_TO_PUBLIC_SDL: emptyString(
+    zod.union([zod.literal('1'), zod.literal('0')]),
+  ),
 });
 
 const RequestBrokerModel = zod.union([
@@ -211,4 +214,5 @@ export const env = {
     maxOldGenerationSizeMb: base.COMPOSITION_WORKER_MAX_OLD_GENERATION_SIZE_MB,
     trackMemoryUsage: base.COMPOSITION_WORKER_TRACK_MEMORY_USAGE === '1',
   },
+  transformExternalSupergraphToPublicSdl: base.TRANSFORM_EXTERNAL_SUPERGRAPH_TO_PUBLIC_SDL === '1',
 } as const;

--- a/packages/services/schema/src/lib/compose.ts
+++ b/packages/services/schema/src/lib/compose.ts
@@ -270,25 +270,17 @@ export async function composeExternalFederation(args: {
 
     const supergraph = parseResult.data.result.supergraph;
     let sdl = parseResult.data.result.sdl;
+    const supergraphDocumentNode = parse(supergraph);
+
     let sdlDocumentNode: ASTNode;
     if (args.transformToPublicSdl) {
-      try {
-        /**
-         * Ensure the externally composed schema doesn't include supergraph SDL
-         * This is done for us in the native composition library
-         * https://github.com/graphql-hive/federation-composition/blob/77d6b4ece2abacf94164beafb4e7f5961f726755/src/compose.ts#L228
-         */
-        const ast = parse(supergraph);
-        const publicAST = transformSupergraphToPublicSchema(ast);
-        sdl = print(publicAST);
-        sdlDocumentNode = publicAST;
-      } catch (e) {
-        // silently fail and revert to using the existing public sdl.
-        // This is the best option if the supergraph cannot be parsed.
-        // This is an extreme edge case because the supergraph should always be
-        // parseable.
-        sdlDocumentNode = parse(sdl);
-      }
+      /**
+       * Ensure the externally composed schema doesn't include supergraph SDL
+       * This is done for us in the native composition library
+       * https://github.com/graphql-hive/federation-composition/blob/77d6b4ece2abacf94164beafb4e7f5961f726755/src/compose.ts#L228
+       */
+      sdlDocumentNode = transformSupergraphToPublicSchema(supergraphDocumentNode);
+      sdl = print(sdlDocumentNode);
     } else {
       sdlDocumentNode = parse(sdl);
     }
@@ -296,7 +288,7 @@ export async function composeExternalFederation(args: {
       type: 'success',
       result: {
         supergraph,
-        supergraphDocumentNode: parse(supergraph),
+        supergraphDocumentNode,
         sdl,
         sdlDocumentNode,
       },

--- a/packages/services/schema/src/lib/compose.ts
+++ b/packages/services/schema/src/lib/compose.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'node:crypto';
 import got, { RequestError } from 'got';
-import { DocumentNode, GraphQLError, parse, print, printSchema } from 'graphql';
+import { ASTNode, DocumentNode, GraphQLError, parse, print, printSchema } from 'graphql';
 import { validateSDL } from 'graphql/validation/validate.js';
 import { z } from 'zod';
 import { composeAndValidate, compositionHasErrors } from '@apollo/federation';
@@ -10,6 +10,7 @@ import * as Sentry from '@sentry/node';
 import {
   composeServices as nativeComposeServices,
   compositionHasErrors as nativeCompositionHasErrors,
+  transformSupergraphToPublicSchema,
 } from '@theguild/federation-composition';
 import type { ExternalComposition } from '../types';
 import { toValidationError } from './errors';
@@ -176,6 +177,16 @@ export async function composeExternalFederation(args: {
   external: Exclude<ExternalComposition, null>;
   requestTimeoutMs: number;
   requestId: string;
+
+  /**
+   * Configuration option to use the supergraph SDL and transform it to the public
+   * SDL instead of taking the public SDL from the external composition result.
+   *
+   * This is used to support some existing implementations from customers that are
+   * incorrectly returning supergraph directives in their public SDL. This is intended
+   * to be deprecated in the future once all customers have addressed their implementation.
+   */
+  transformToPublicSdl?: boolean;
 }): Promise<ComposerMethodResult> {
   args.logger?.debug(
     'Using external composition service (url=%s, schemas=%s)',
@@ -258,14 +269,36 @@ export async function composeExternalFederation(args: {
     await checkExternalCompositionCompatibility(args.logger, parseResult.data.result.sdl);
 
     const supergraph = parseResult.data.result.supergraph;
-    const sdl = parseResult.data.result.sdl;
+    let sdl = parseResult.data.result.sdl;
+    let sdlDocumentNode: ASTNode;
+    if (args.transformToPublicSdl) {
+      try {
+        /**
+         * Ensure the externally composed schema doesn't include supergraph SDL
+         * This is done for us in the native composition library
+         * https://github.com/graphql-hive/federation-composition/blob/77d6b4ece2abacf94164beafb4e7f5961f726755/src/compose.ts#L228
+         */
+        const ast = parse(supergraph);
+        const publicAST = transformSupergraphToPublicSchema(ast);
+        sdl = print(publicAST);
+        sdlDocumentNode = publicAST;
+      } catch (e) {
+        // silently fail and revert to using the existing public sdl.
+        // This is the best option if the supergraph cannot be parsed.
+        // This is an extreme edge case because the supergraph should always be
+        // parseable.
+        sdlDocumentNode = parse(sdl);
+      }
+    } else {
+      sdlDocumentNode = parse(sdl);
+    }
     return {
       type: 'success',
       result: {
         supergraph,
         supergraphDocumentNode: parse(supergraph),
         sdl,
-        sdlDocumentNode: parse(sdl),
+        sdlDocumentNode,
       },
     };
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1594,6 +1594,9 @@ importers:
       ioredis-mock:
         specifier: 8.9.0
         version: 8.9.0(@types/ioredis-mock@8.2.5)(ioredis@5.10.1)
+      nock:
+        specifier: 14.0.10
+        version: 14.0.10
       pino-pretty:
         specifier: 11.3.0
         version: 11.3.0


### PR DESCRIPTION
### Background

An issue was reported where suddenly a team's public SDL included federated directives

### Description

I was able to identify the cause as this change: https://github.com/graphql-hive/console/pull/8319/changes#diff-f912a95c08d02dee17df2da852f56f215ec961506f1d50eb792971fc09cb5b5aL247

Because the composition library we use automatically make this calls, it was mistakenly assumed that the external composer would also call this. Since this composer is external by definition, I dont think it's safe to make that assumption.

Long term, we should remove this extra transform from all composition logic. Before doing this, we must ensure all existing systems are compatible or we have a plan to migrate.

For now, I've added back the transform based on an environment variable. This will transform the external supergraph SDL result to match the previous behavior.

### Checklist

- [X] Testing
