### PR TITLE
feat: `hive app:check` command

### DIFF
--- a/integration-tests/testkit/cli.ts
+++ b/integration-tests/testkit/cli.ts
@@ -99,6 +99,14 @@ export async function appCreate(args: string[]) {
   );
 }
 
+export async function appCheck(args: string[]) {
+  const registryAddress = await getServiceHost('server', 8082);
+
+  return await exec(
+    ['app:check', `--registry.endpoint`, `http://${registryAddress}/graphql`, ...args].join(' '),
+  );
+}
+
 export async function appPublish(args: string[]) {
   const registryAddress = await getServiceHost('server', 8082);
 

--- a/integration-tests/tests/cli/app.spec.ts
+++ b/integration-tests/tests/cli/app.spec.ts
@@ -6,7 +6,7 @@ import { buildASTSchema, parse } from 'graphql';
 import { createLogger } from 'graphql-yoga';
 import { getServiceHost } from 'testkit/utils';
 import { createHive } from '@graphql-hive/core';
-import { appCreate, appPublish, appRetire } from '../../testkit/cli';
+import { appCheck, appCreate, appPublish, appRetire } from '../../testkit/cli';
 import { graphql } from '../../testkit/gql';
 import { execute } from '../../testkit/graphql';
 import { initSeed } from '../../testkit/seed';
@@ -134,6 +134,69 @@ test('app:create --version is optional and auto-generates a version', async () =
 
   expect(output).toContain('No version provided, using generated version:');
   expect(output).toContain('created');
+});
+
+test('app:check validates an Apollo manifest against the latest schema', async () => {
+  const { createOrg } = await initSeed().createOwner();
+  const { createProject } = await createOrg();
+  const { createTargetAccessToken } = await createProject();
+  const token = await createTargetAccessToken({});
+
+  await token.publishSchema({
+    sdl: /* GraphQL */ `
+      type Query {
+        hello: String
+      }
+    `,
+  });
+
+  const operationsFile = join(tmpdir(), `operations-${Date.now()}.json`);
+  await writeFile(
+    operationsFile,
+    JSON.stringify({
+      format: 'apollo-persisted-query-manifest',
+      version: 1,
+      operations: [{ id: 'op-hash-1', body: 'query { hello }' }],
+    }),
+    'utf-8',
+  );
+
+  const output = await appCheck(['--registry.accessToken', token.secret, operationsFile]);
+
+  expect(output).toContain('All operations are valid (1)');
+
+  await writeFile(
+    operationsFile,
+    JSON.stringify({
+      format: 'apollo-persisted-query-manifest',
+      version: 1,
+      operations: [{ id: 'op-hash-1', body: 'query { goodbye }' }],
+    }),
+    'utf-8',
+  );
+
+  await expect(appCheck(['--registry.accessToken', token.secret, operationsFile])).rejects.toThrow(
+    /op-hash-1[\s\S]*Cannot query field "goodbye" on type "Query"\./,
+  );
+
+  await writeFile(
+    operationsFile,
+    JSON.stringify({
+      format: 'apollo-persisted-query-manifest',
+      version: 1,
+      operations: [
+        {
+          id: 'multi-operation-hash',
+          body: 'query First { hello } query Second { hello }',
+        },
+      ],
+    }),
+    'utf-8',
+  );
+
+  await expect(appCheck(['--registry.accessToken', token.secret, operationsFile])).rejects.toThrow(
+    /multi-operation-hash[\s\S]*Multiple operation definitions found\. Only one executable operation definition is allowed per document\./,
+  );
 });
 
 test('app:create --publish creates and immediately activates the deployment', async () => {

--- a/packages/libraries/cli/src/commands/app/check.ts
+++ b/packages/libraries/cli/src/commands/app/check.ts
@@ -1,0 +1,174 @@
+import { buildSchema, GraphQLError, Kind, parse, Source, specifiedRules, validate } from 'graphql';
+import type { DocumentNode, ValidationContext } from 'graphql';
+import { Args, Errors, Flags } from '@oclif/core';
+import Command from '../../base-command';
+import * as GraphQLSchema from '../../gql/graphql';
+import { FetchLatestVersionDocument } from '../../gql/graphql';
+import { loadAppOperations } from '../../helpers/app-operations';
+import { graphqlEndpoint } from '../../helpers/config';
+import {
+  InvalidDocumentsError,
+  InvalidTargetError,
+  MissingEndpointError,
+  MissingRegistryTokenError,
+  SchemaNotFoundError,
+  UnexpectedError,
+} from '../../helpers/errors';
+import * as TargetInput from '../../helpers/target-input';
+import { Texture } from '../../helpers/texture/texture';
+
+function SingleOperationDefinitionRule(context: ValidationContext) {
+  return {
+    Document(node: DocumentNode) {
+      const operations = node.definitions.filter(
+        definition => definition.kind === Kind.OPERATION_DEFINITION && definition.name,
+      );
+
+      if (operations.length > 1) {
+        context.reportError(
+          new GraphQLError(
+            'Multiple operation definitions found. Only one executable operation definition is allowed per document.',
+            { nodes: operations },
+          ),
+        );
+      }
+    },
+  };
+}
+
+export default class AppCheck extends Command<typeof AppCheck> {
+  static description = 'checks app operations against the latest published schema';
+
+  static flags = {
+    'registry.endpoint': Flags.string({
+      description: 'registry endpoint',
+    }),
+    'registry.accessToken': Flags.string({
+      description: 'registry access token',
+    }),
+    target: Flags.string({
+      description:
+        'The target against which the app operations are checked.' +
+        ' This can either be a slug following the format "$organizationSlug/$projectSlug/$targetSlug" (e.g "the-guild/graphql-hive/staging")' +
+        ' or an UUID (e.g. "a0f4c605-6541-4350-8cfe-b31f21a4bf80").',
+    }),
+  };
+
+  static args = {
+    operations: Args.string({
+      name: 'operations',
+      required: true,
+      description:
+        'Path to the persisted operations manifest (GraphQL Code Generator, Relay or Apollo persisted query manifest JSON file), a directory containing .graphql files, or a glob pattern matching .graphql files.',
+      hidden: false,
+    }),
+  };
+
+  async run() {
+    try {
+      const { flags, args } = await this.parse(AppCheck);
+      let endpoint: string, accessToken: string;
+
+      try {
+        endpoint = this.ensure({
+          key: 'registry.endpoint',
+          args: flags,
+          defaultValue: graphqlEndpoint,
+          env: 'HIVE_REGISTRY',
+          description: AppCheck.flags['registry.endpoint'].description!,
+        });
+      } catch (error) {
+        this.logDebug(error);
+        throw new MissingEndpointError();
+      }
+
+      try {
+        accessToken = this.ensure({
+          key: 'registry.accessToken',
+          args: flags,
+          env: 'HIVE_TOKEN',
+          description: AppCheck.flags['registry.accessToken'].description!,
+        });
+      } catch (error) {
+        this.logDebug(error);
+        throw new MissingRegistryTokenError();
+      }
+
+      let target: GraphQLSchema.TargetReferenceInput | null = null;
+      if (flags.target) {
+        const result = TargetInput.parse(flags.target);
+        if (result.type === 'error') {
+          throw new InvalidTargetError();
+        }
+        target = result.data;
+      }
+
+      const { operations, warnings } = await loadAppOperations(args.operations);
+      for (const warning of warnings) {
+        this.warn(warning);
+      }
+
+      if (operations.length === 0) {
+        this.logInfo('No operations found');
+        return;
+      }
+
+      const result = await this.registryApi(endpoint, accessToken).request({
+        operation: FetchLatestVersionDocument,
+        variables: { target },
+      });
+      const sdl = result.latestValidVersion?.sdl;
+      if (!sdl) {
+        throw new SchemaNotFoundError();
+      }
+
+      const schema = buildSchema(sdl, {
+        assumeValidSDL: true,
+        assumeValid: true,
+      });
+
+      const invalidOperations = operations.flatMap(operation => {
+        const source = operation.location
+          ? `${operation.location} (${operation.operationHash})`
+          : operation.operationHash;
+        try {
+          const document = parse(new Source(operation.content, source));
+          const errors = validate(schema, document, [
+            ...specifiedRules,
+            SingleOperationDefinitionRule,
+          ]);
+          return errors.length > 0 ? [{ source, errors }] : [];
+        } catch (error) {
+          if (error instanceof GraphQLError) {
+            return [{ source, errors: [error] }];
+          }
+          throw error;
+        }
+      });
+
+      if (invalidOperations.length === 0) {
+        this.logSuccess(`All operations are valid (${operations.length})`);
+        return;
+      }
+
+      this.log(Texture.header('Summary'));
+      this.log(
+        [
+          `Total: ${operations.length}`,
+          `Invalid: ${invalidOperations.length} (${Math.floor(
+            (invalidOperations.length / operations.length) * 100,
+          )}%)`,
+          '',
+        ].join('\n'),
+      );
+      this.log(Texture.header('Details'));
+      throw new InvalidDocumentsError(invalidOperations);
+    } catch (error) {
+      if (error instanceof Errors.CLIError) {
+        throw error;
+      }
+      this.logFailure('Failed to validate operations');
+      throw new UnexpectedError(error);
+    }
+  }
+}

--- a/packages/libraries/cli/src/commands/app/create.ts
+++ b/packages/libraries/cli/src/commands/app/create.ts
@@ -1,22 +1,15 @@
-import { createHash } from 'node:crypto';
-import { statSync } from 'node:fs';
-import { relative, resolve } from 'node:path';
-import { print } from 'graphql';
-import { z } from 'zod';
-import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
-import { loadDocuments } from '@graphql-tools/load';
 import { Args, Flags } from '@oclif/core';
 import Command from '../../base-command';
 import { graphql } from '../../gql';
 import { AppDeploymentStatus } from '../../gql/graphql';
 import * as GraphQLSchema from '../../gql/graphql';
+import { loadAppOperations } from '../../helpers/app-operations';
 import { graphqlEndpoint } from '../../helpers/config';
 import {
   APIError,
   InvalidTargetError,
   MissingEndpointError,
   MissingRegistryTokenError,
-  PersistedOperationsMalformedError,
 } from '../../helpers/errors';
 import * as TargetInput from '../../helpers/target-input';
 import { ActivateAppDeploymentMutation } from './publish';
@@ -102,99 +95,13 @@ export default class AppCreate extends Command<typeof AppCreate> {
       this.log(`No version provided, using generated version: ${version}`);
     }
 
-    const file: string = args.operations;
-
-    let manifest: Record<string, string>;
-
-    const isFile = (() => {
-      try {
-        return statSync(file).isFile();
-      } catch {
-        return false;
-      }
-    })();
-
-    if (isFile) {
-      const contents = this.readJSON(file);
-      const operations: unknown = JSON.parse(contents);
-      let entries: Array<[string, string]>;
-      const manifestValidationResult = ManifestModel.safeParse(operations);
-
-      if (manifestValidationResult.success) {
-        entries = Object.entries(manifestValidationResult.data);
-      } else {
-        const apolloValidationResult = ApolloManifestModel.safeParse(operations);
-        if (apolloValidationResult.success) {
-          entries = apolloValidationResult.data.operations.map(operation => [
-            operation.id,
-            operation.body,
-          ]);
-        } else {
-          throw new PersistedOperationsMalformedError(file);
-        }
-      }
-
-      manifest = Object.fromEntries(entries);
-    } else {
-      // file is a glob or directory - generate the manifest in-memory
-      const globPattern = (() => {
-        try {
-          if (statSync(file).isDirectory()) {
-            return `${resolve(file)}/**/*.graphql`;
-          }
-        } catch {
-          // not a directory, treat as a glob pattern as-is
-        }
-        return file;
-      })();
-
-      let sources;
-      try {
-        sources = await loadDocuments(globPattern, {
-          loaders: [new GraphQLFileLoader()],
-        });
-      } catch (err) {
-        this.error(
-          `Failed to load GraphQL files from "${relative(process.cwd(), file)}": ${String(err)}`,
-        );
-      }
-
-      if (sources.length === 0) {
-        this.error(`No .graphql files found in "${relative(process.cwd(), file)}".`);
-      }
-
-      // sort by location to make the output deterministic
-      sources.sort((a, b) => (a.location ?? '').localeCompare(b.location ?? ''));
-
-      manifest = {};
-
-      for (const source of sources) {
-        const sourceFile = source.location ?? '<unknown>';
-        if (!source.document) {
-          this.warn(`Skipping empty operation in file "${relative(process.cwd(), sourceFile)}".`);
-          continue;
-        }
-        const operation = print(source.document).replace('\n', ' ').replace(/\s+/g, ' ').trim();
-        if (!operation) {
-          this.warn(`Skipping empty operation in file "${relative(process.cwd(), sourceFile)}".`);
-          continue;
-        }
-        const hash = createHash('sha256').update(operation).digest('hex');
-        if (hash in manifest) {
-          this.warn(
-            `Hash collision detected for file "${relative(process.cwd(), sourceFile)}". The operation is identical to another operation already in the manifest. Skipping.`,
-          );
-          continue;
-        }
-        manifest[hash] = operation;
-      }
-
-      if (Object.keys(manifest).length === 0) {
-        this.error(`No valid GraphQL operations found in "${relative(process.cwd(), file)}".`);
-      }
-
+    const { manifest, generatedFrom, warnings } = await loadAppOperations(args.operations);
+    for (const warning of warnings) {
+      this.warn(warning);
+    }
+    if (generatedFrom) {
       this.log(
-        `Persisted documents manifest generated in-memory from discovered GraphQL operations under "${globPattern}".`,
+        `Persisted documents manifest generated in-memory from discovered GraphQL operations under "${generatedFrom}".`,
       );
       this.log(JSON.stringify(manifest, null, 2));
     }
@@ -322,19 +229,6 @@ export default class AppCreate extends Command<typeof AppCreate> {
     }
   }
 }
-
-const ManifestModel = z.record(z.string());
-
-const ApolloManifestModel = z.object({
-  format: z.literal('apollo-persisted-query-manifest'),
-  version: z.literal(1),
-  operations: z.array(
-    z.object({
-      id: z.string(),
-      body: z.string(),
-    }),
-  ),
-});
 
 const CreateAppDeploymentMutation = graphql(/* GraphQL */ `
   mutation CreateAppDeployment($input: CreateAppDeploymentInput!) {

--- a/packages/libraries/cli/src/helpers/app-operations.ts
+++ b/packages/libraries/cli/src/helpers/app-operations.ts
@@ -1,0 +1,139 @@
+import { createHash } from 'node:crypto';
+import { promises as fs, statSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import { print } from 'graphql';
+import { z } from 'zod';
+import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
+import { loadDocuments } from '@graphql-tools/load';
+import { Errors } from '@oclif/core';
+import { PersistedOperationsMalformedError } from './errors';
+
+const ManifestModel = z.record(z.string());
+
+const ApolloManifestModel = z.object({
+  format: z.literal('apollo-persisted-query-manifest'),
+  version: z.literal(1),
+  operations: z.array(
+    z.object({
+      id: z.string(),
+      body: z.string(),
+    }),
+  ),
+});
+
+export async function loadAppOperations(file: string): Promise<{
+  manifest: Record<string, string>;
+  operations: Array<{ operationHash: string; content: string; location?: string }>;
+  generatedFrom?: string;
+  warnings: string[];
+}> {
+  const isFile = (() => {
+    try {
+      return statSync(file).isFile();
+    } catch {
+      return false;
+    }
+  })();
+
+  if (isFile) {
+    const input: unknown = JSON.parse(await fs.readFile(file, 'utf8'));
+    const manifestValidationResult = ManifestModel.safeParse(input);
+    let entries: Array<[string, string]>;
+
+    if (manifestValidationResult.success) {
+      entries = Object.entries(manifestValidationResult.data);
+    } else {
+      const apolloValidationResult = ApolloManifestModel.safeParse(input);
+      if (!apolloValidationResult.success) {
+        throw new PersistedOperationsMalformedError(file);
+      }
+      entries = apolloValidationResult.data.operations.map(operation => [
+        operation.id,
+        operation.body,
+      ]);
+    }
+
+    const location = relative(process.cwd(), file);
+    return {
+      manifest: Object.fromEntries(entries),
+      operations: entries.map(([operationHash, content]) => ({
+        operationHash,
+        content,
+        location,
+      })),
+      warnings: [],
+    };
+  }
+
+  const globPattern = (() => {
+    try {
+      if (statSync(file).isDirectory()) {
+        return `${resolve(file)}/**/*.graphql`;
+      }
+    } catch {
+      // Not a directory, treat it as a glob pattern.
+    }
+    return file;
+  })();
+
+  let sources;
+  try {
+    sources = await loadDocuments(globPattern, {
+      loaders: [new GraphQLFileLoader()],
+    });
+  } catch (error) {
+    throw new Errors.CLIError(
+      `Failed to load GraphQL files from "${relative(process.cwd(), file)}": ${String(error)}`,
+    );
+  }
+
+  if (sources.length === 0) {
+    throw new Errors.CLIError(`No .graphql files found in "${relative(process.cwd(), file)}".`);
+  }
+
+  sources.sort((a, b) => (a.location ?? '').localeCompare(b.location ?? ''));
+
+  const manifest: Record<string, string> = {};
+  const locations = new Map<string, string>();
+  const warnings: string[] = [];
+
+  for (const source of sources) {
+    const sourceFile = source.location ?? '<unknown>';
+    const location = relative(process.cwd(), sourceFile);
+    if (!source.document) {
+      warnings.push(`Skipping empty operation in file "${location}".`);
+      continue;
+    }
+    const operation = print(source.document).replace('\n', ' ').replace(/\s+/g, ' ').trim();
+    if (!operation) {
+      warnings.push(`Skipping empty operation in file "${location}".`);
+      continue;
+    }
+    const hash = createHash('sha256').update(operation).digest('hex');
+    if (hash in manifest) {
+      warnings.push(
+        `Hash collision detected for file "${location}". The operation is identical to another operation already in the manifest. Skipping.`,
+      );
+      continue;
+    }
+    manifest[hash] = operation;
+    locations.set(hash, location);
+  }
+
+  if (Object.keys(manifest).length === 0) {
+    throw new Errors.CLIError(
+      `No valid GraphQL operations found in "${relative(process.cwd(), file)}".`,
+    );
+  }
+
+  return {
+    manifest,
+    operations: Object.entries(manifest).map(([operationHash, content]) => ({
+      operationHash,
+      content,
+      location: locations.get(operationHash),
+    })),
+    generatedFrom: globPattern,
+    warnings,
+  };
+}

--- a/packages/libraries/cli/src/helpers/errors.ts
+++ b/packages/libraries/cli/src/helpers/errors.ts
@@ -1,7 +1,6 @@
 import { extname } from 'node:path';
 import { env } from 'node:process';
-import { GraphQLError } from 'graphql';
-import { InvalidDocument } from '@graphql-inspector/core';
+import { GraphQLError, Source } from 'graphql';
 import { CLIError } from '@oclif/core/lib/errors';
 import { CompositionFailure } from '@theguild/federation-composition';
 import { FragmentType, makeFragmentData } from '../gql/index';
@@ -286,7 +285,12 @@ export class SchemaPublishMissingUrlError extends HiveCLIError {
 }
 
 export class InvalidDocumentsError extends HiveCLIError {
-  constructor(invalidDocuments: InvalidDocument[]) {
+  constructor(
+    invalidDocuments: Array<{
+      source: string | Source;
+      errors: ReadonlyArray<GraphQLError>;
+    }>,
+  ) {
     const message = invalidDocuments
       .map(doc => {
         return `${Texture.failure(doc.source)}\n${doc.errors.map(e => ` - ${Texture.boldQuotedWords(e.message)}`).join('\n')}`;

--- a/packages/libraries/cli/src/helpers/operations.ts
+++ b/packages/libraries/cli/src/helpers/operations.ts
@@ -67,6 +67,7 @@ export async function loadOperations(
       }),
       new GraphQLFileLoader(),
     ],
+    skipGraphQLImport: true,
   });
 
   return sources.map(source => ({

--- a/packages/libraries/cli/src/helpers/operations.ts
+++ b/packages/libraries/cli/src/helpers/operations.ts
@@ -67,7 +67,6 @@ export async function loadOperations(
       }),
       new GraphQLFileLoader(),
     ],
-    skipGraphQLImport: true,
   });
 
   return sources.map(source => ({


### PR DESCRIPTION
Adds `hive app:check` to validate persisted app operations against the target’s latest valid GraphQL schema without creating or publishing an app deployment.

The `app:check` commands extract and validates the operations the same way the schema registry is validating the documents before storing them.

**NOTE**: The existing `operations:check` command is more general purpose and already has different loading behaviour compared to how we load the persisted documents manifest (around `#import`), thus it is more straight forward to introduce this new command that shares the expected behaviour with how other app deployment related commands work.

## Example Command Usages

**Manifest File**

```
hive app:check persisted-documents.json \
  --registry.accessToken "$HIVE_TOKEN" \
  --target my-org/my-project/production
```

**Directory with GraphQL Files**

```
hive app:check ./src/operations \
  --registry.accessToken "$HIVE_TOKEN" \
  --target my-org/my-project/production
```

**Glob**

```
hive app:check "src/**/*.graphql" \
  --registry.accessToken "$HIVE_TOKEN" \
  --target my-org/my-project/production
```

## Example Command Output

```bash
> hive app:check ../../web/app/src/gql/persisted-documents.json

=== Summary
Total: 212
Invalid: 212 (100%)

=== Details
Error: Invalid operation syntax:
✖ ../../web/app/src/gql/persisted-documents.json (sha256:bc2faab99e07f170ab859f2f6a2626af7b95af74f84fb50f5b02e090b5053679)
 - Unknown type AdminOperationPoint.
 - Unknown type DateRangeInput.
 - Cannot query field admin on type Query.
✖ ../../web/app/src/gql/persisted-documents.json (sha256:cf7758fb01e287fe99182d4d8fbcf38bb004d3f11befa7869a8efb9552f87d59)
 - Unknown type OrganizationGetStarted.
 - Unknown type OrganizationConnection.
 - Unknown type Organization.
 - Unknown type Organization.
 - Unknown type User.
 - Unknown type OrganizationConnection.
 - Unknown type Organization.
 - Cannot query field me on type Query.
 - Cannot query field organizationBySlug on type Query.
 - Cannot query field organizations on type Query.
✖ ../../web/app/src/gql/persisted-documents.json (sha256:bbc76ec4af947b9cb434dd4106cf4cac40319cdc6e658ee4a0dc9379d16b83cb)
 - Unknown type CreateProjectInput.
 ```