### PR TITLE
perf(usage): zstd instead of gzip and others

### DIFF
--- a/.changeset/kamil-usage-rep.md
+++ b/.changeset/kamil-usage-rep.md
@@ -1,0 +1,7 @@
+---
+'hive': patch
+---
+
+Improve usage-service performance: 
+- compression is now done with zstd instead of gzip
+- report processing is more efficient now, we cache things cross-requests and significantly reduced CPU usage (4x more throughput)

--- a/packages/services/api/src/modules/auth/providers/organization-access-token-validation-cache.ts
+++ b/packages/services/api/src/modules/auth/providers/organization-access-token-validation-cache.ts
@@ -2,7 +2,10 @@ import { BentoCache, bentostore } from 'bentocache';
 import { memoryDriver } from 'bentocache/build/src/drivers/memory';
 import { Injectable, Scope } from 'graphql-modules';
 import { prometheusPlugin } from '@bentocache/plugin-prometheus';
-import { PrometheusConfig } from '../../shared/providers/prometheus-config';
+import {
+  PROMETHEUS_CACHE_KEY_GROUPS,
+  PrometheusConfig,
+} from '../../shared/providers/prometheus-config';
 
 /**
  * Cache for performant OrganizationAccessToken lookups.
@@ -21,6 +24,7 @@ export class OrganizationAccessTokenValidationCache {
         ? [
             prometheusPlugin({
               prefix: 'bentocache_organization_access_token_validation',
+              keyGroups: PROMETHEUS_CACHE_KEY_GROUPS,
             }),
           ]
         : undefined,

--- a/packages/services/api/src/modules/operations/providers/clickhouse-client.ts
+++ b/packages/services/api/src/modules/operations/providers/clickhouse-client.ts
@@ -3,7 +3,7 @@ import Agent from 'agentkeepalive';
 import { Inject, Injectable } from 'graphql-modules';
 import { printWithValues, sql, SqlStatement, toQueryParams } from '@hive/clickhouse';
 import { SpanKind, trace } from '@hive/service-common';
-import { castValue, compress } from '@hive/usage-common';
+import { castValue, compressGzip } from '@hive/usage-common';
 import { atomic } from '../../../shared/helpers';
 import { HttpClient } from '../../shared/providers/http-client';
 import { Logger } from '../../shared/providers/logger';
@@ -429,7 +429,7 @@ export class ClickHouse {
       .post(
         this.endpoint,
         {
-          body: await compress(
+          body: await compressGzip(
             args.data.map(row => row.map(value => castValue(value)).join(',')).join('\n'),
           ),
           searchParams: {

--- a/packages/services/api/src/modules/organization/providers/organization-access-tokens-cache.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-access-tokens-cache.ts
@@ -6,7 +6,10 @@ import { prometheusPlugin } from '@bentocache/plugin-prometheus';
 import { PostgresDatabasePool } from '@hive/postgres';
 import { AuthorizationPolicyStatement } from '../../auth/lib/authz';
 import { Logger } from '../../shared/providers/logger';
-import { PrometheusConfig } from '../../shared/providers/prometheus-config';
+import {
+  PROMETHEUS_CACHE_KEY_GROUPS,
+  PrometheusConfig,
+} from '../../shared/providers/prometheus-config';
 import { REDIS_INSTANCE, type Redis } from '../../shared/providers/redis';
 import { Groups } from './groups';
 import {
@@ -51,6 +54,7 @@ export class OrganizationAccessTokensCache {
         ? [
             prometheusPlugin({
               prefix: 'bentocache_organization_access_tokens',
+              keyGroups: PROMETHEUS_CACHE_KEY_GROUPS,
             }),
           ]
         : undefined,

--- a/packages/services/api/src/modules/shared/providers/prometheus-config.ts
+++ b/packages/services/api/src/modules/shared/providers/prometheus-config.ts
@@ -1,5 +1,11 @@
 import { Injectable, Scope } from 'graphql-modules';
 
+/**
+ * Raw BentoCache keys create a permanent Prometheus series per key. Grouping 100k unique keys
+ * reduced series from 100k to 1, retained heap from 22.3MB to 0.05MB.
+ */
+export const PROMETHEUS_CACHE_KEY_GROUPS: Array<[RegExp, string]> = [[/^/, 'all']];
+
 @Injectable({
   scope: Scope.Singleton,
 })

--- a/packages/services/api/src/modules/target/providers/targets-by-id-cache.ts
+++ b/packages/services/api/src/modules/target/providers/targets-by-id-cache.ts
@@ -7,7 +7,10 @@ import { PostgresDatabasePool } from '@hive/postgres';
 import { findTargetById } from '@hive/storage';
 import type { Target } from '../../../shared/entities';
 import { isUUID } from '../../../shared/is-uuid';
-import { PrometheusConfig } from '../../shared/providers/prometheus-config';
+import {
+  PROMETHEUS_CACHE_KEY_GROUPS,
+  PrometheusConfig,
+} from '../../shared/providers/prometheus-config';
 import { REDIS_INSTANCE, type Redis } from '../../shared/providers/redis';
 
 /**
@@ -31,6 +34,7 @@ export class TargetsByIdCache {
         ? [
             prometheusPlugin({
               prefix: 'bentocache_targetsById',
+              keyGroups: PROMETHEUS_CACHE_KEY_GROUPS,
             }),
           ]
         : undefined,

--- a/packages/services/api/src/modules/target/providers/targets-by-slug-cache.ts
+++ b/packages/services/api/src/modules/target/providers/targets-by-slug-cache.ts
@@ -5,7 +5,10 @@ import { Inject, Injectable, Scope } from 'graphql-modules';
 import { prometheusPlugin } from '@bentocache/plugin-prometheus';
 import { PostgresDatabasePool } from '@hive/postgres';
 import { findTargetBySlug } from '@hive/storage';
-import { PrometheusConfig } from '../../shared/providers/prometheus-config';
+import {
+  PROMETHEUS_CACHE_KEY_GROUPS,
+  PrometheusConfig,
+} from '../../shared/providers/prometheus-config';
 import { REDIS_INSTANCE, type Redis } from '../../shared/providers/redis';
 
 /**
@@ -29,6 +32,7 @@ export class TargetsBySlugCache {
         ? [
             prometheusPlugin({
               prefix: 'bentocache_targetsBySlug',
+              keyGroups: PROMETHEUS_CACHE_KEY_GROUPS,
             }),
           ]
         : undefined,

--- a/packages/services/api/src/modules/token/providers/target-token-cache.ts
+++ b/packages/services/api/src/modules/token/providers/target-token-cache.ts
@@ -8,7 +8,10 @@ import { TaskScheduler } from '@hive/workflows/kit';
 import { PurgeTargetTokensTask } from '@hive/workflows/tasks/purge-target-tokens';
 import type { Token } from '../../../shared/entities';
 import { Logger } from '../../shared/providers/logger';
-import { PrometheusConfig } from '../../shared/providers/prometheus-config';
+import {
+  PROMETHEUS_CACHE_KEY_GROUPS,
+  PrometheusConfig,
+} from '../../shared/providers/prometheus-config';
 import { REDIS_INSTANCE, type Redis } from '../../shared/providers/redis';
 import { hashTargetToken, TargetTokenStorage } from './target-token-storage';
 
@@ -38,6 +41,7 @@ export class TargetTokenCache {
         ? [
             prometheusPlugin({
               prefix: 'bentocache_target_tokens',
+              keyGroups: PROMETHEUS_CACHE_KEY_GROUPS,
             }),
           ]
         : undefined,

--- a/packages/services/usage-common/src/compression.ts
+++ b/packages/services/usage-common/src/compression.ts
@@ -1,6 +1,6 @@
-import { gunzip, gzip } from 'node:zlib';
+import { constants, gunzip, gzip, zstdCompress, zstdDecompress } from 'node:zlib';
 
-export async function compress(data: string): Promise<Buffer> {
+export async function compressGzip(data: string): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     gzip(data, (error, buffer) => {
       if (error) {
@@ -12,9 +12,52 @@ export async function compress(data: string): Promise<Buffer> {
   });
 }
 
-export async function decompress(buffer: Buffer): Promise<Buffer> {
+export async function compressZstd(data: string): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    gunzip(buffer, (error, data) => {
+    zstdCompress(
+      data,
+      {
+        // Ran a bunch of benchmarks
+        // and found 1 to be the best compression level
+        // with minimal CPU overhead
+        // and minimal memory usage
+        // and good compressed size.
+        params: {
+          [constants.ZSTD_c_compressionLevel]: 1,
+          [constants.ZSTD_c_windowLog]: 23,
+        },
+      },
+      (error, buffer) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(buffer);
+        }
+      },
+    );
+  });
+}
+
+// Magic numbers, so decompress() can read either format.
+// The usage-service switched from gzip to zstd,
+// and the messages in both formats exist on the
+// topic for some time.
+export const ZSTD_MAGIC = [0x28, 0xb5, 0x2f, 0xfd];
+
+function isZstd(buffer: Buffer): boolean {
+  return (
+    buffer.length >= 4 &&
+    buffer[0] === ZSTD_MAGIC[0] &&
+    buffer[1] === ZSTD_MAGIC[1] &&
+    buffer[2] === ZSTD_MAGIC[2] &&
+    buffer[3] === ZSTD_MAGIC[3]
+  );
+}
+
+export async function decompress(buffer: Buffer): Promise<Buffer> {
+  const inflate = isZstd(buffer) ? zstdDecompress : gunzip;
+  return new Promise((resolve, reject) => {
+    inflate(buffer, (error, data) => {
       if (error) {
         reject(error);
       } else {

--- a/packages/services/usage-ingestor/__tests__/decompress.spec.ts
+++ b/packages/services/usage-ingestor/__tests__/decompress.spec.ts
@@ -6,7 +6,13 @@
  *
  */
 
-import { compressGzip, compressZstd, decompress, type RawReport, ZSTD_MAGIC } from '@hive/usage-common';
+import {
+  compressGzip,
+  compressZstd,
+  decompress,
+  ZSTD_MAGIC,
+  type RawReport,
+} from '@hive/usage-common';
 
 const reports: RawReport[] = Array.from({ length: 50 }, (_, i) => ({
   id: `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`,

--- a/packages/services/usage-ingestor/__tests__/decompress.spec.ts
+++ b/packages/services/usage-ingestor/__tests__/decompress.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * usage-service switched from gzip to zstd.
+ * The ingestor has to read both:
+ * - zstd for what the new producer writes
+ * - gzip for messages already on the topic and for anything a rollback produces
+ *
+ */
+
+import { compressGzip, compressZstd, decompress, type RawReport, ZSTD_MAGIC } from '@hive/usage-common';
+
+const reports: RawReport[] = Array.from({ length: 50 }, (_, i) => ({
+  id: `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`,
+  target: '00000000-0000-4000-8000-000000000001',
+  organization: '00000000-0000-4000-8000-000000000002',
+  size: 2,
+  map: {
+    [`key-${i}`]: {
+      key: `key-${i}`,
+      operation: `query op${i} { field${i} { id name } }`,
+      operationName: `op${i}`,
+      fields: [`Query.field${i}`, `Field${i}.id`, `Field${i}.name`],
+    },
+  },
+  operations: [
+    {
+      operationMapKey: `key-${i}`,
+      timestamp: Date.now() + i,
+      expiresAt: Date.now() + i + 86_400_000,
+      execution: { ok: true, duration: 1_000_000 + i, errorsTotal: 0 },
+      metadata: { client: { name: 'client', version: '1.0.0' } },
+    },
+  ],
+  subscriptionOperations: [],
+}));
+
+async function readAsIngestor(value: Buffer): Promise<RawReport[]> {
+  return JSON.parse((await decompress(value)).toString());
+}
+
+test('reads the zstd payload from usage-service', async () => {
+  const message = await compressZstd(JSON.stringify(reports));
+  await expect(readAsIngestor(message)).resolves.toEqual(reports);
+});
+
+test('reads the gzip payload from usage-service (legacy)', async () => {
+  const message = await compressGzip(JSON.stringify(reports));
+  await expect(readAsIngestor(message)).resolves.toEqual(reports);
+});
+
+test('assert the first bytes are correct for zstd and gzip', async () => {
+  const zstd = await compressZstd(JSON.stringify(reports));
+  const gzip = await compressGzip(JSON.stringify(reports));
+  expect([...zstd.subarray(0, 4)]).toEqual(ZSTD_MAGIC);
+  expect([...gzip.subarray(0, 2)]).toEqual([0x1f, 0x8b]);
+});

--- a/packages/services/usage-ingestor/src/writer.ts
+++ b/packages/services/usage-ingestor/src/writer.ts
@@ -1,7 +1,7 @@
 import Agent from 'agentkeepalive';
 import { got, Response as GotResponse } from 'got';
 import type { ServiceLogger } from '@hive/service-common';
-import { compress } from '@hive/usage-common';
+import { compressGzip } from '@hive/usage-common';
 import * as Sentry from '@sentry/node';
 import { writeDuration } from './metrics';
 import {
@@ -66,7 +66,7 @@ export function createWriter({
       }
 
       const csv = joinIntoSingleMessage(operations);
-      const compressed = await compress(csv);
+      const compressed = await compressGzip(csv);
 
       // Note that `SETTINGS input_format_with_names_use_header = 1` is enabled by default.
       // If migrating this table in the future, be sure to double check this via
@@ -87,7 +87,7 @@ export function createWriter({
       }
 
       const csv = joinIntoSingleMessage(operations);
-      const compressed = await compress(csv);
+      const compressed = await compressGzip(csv);
 
       await writeCsv(
         clickhouse,
@@ -104,7 +104,7 @@ export function createWriter({
       }
 
       const csv = joinIntoSingleMessage(records);
-      const compressed = await compress(csv);
+      const compressed = await compressGzip(csv);
 
       await writeCsv(
         clickhouse,
@@ -121,7 +121,7 @@ export function createWriter({
       }
 
       const csv = joinIntoSingleMessage(records);
-      const compressed = await compress(csv);
+      const compressed = await compressGzip(csv);
 
       await writeCsv(
         clickhouse,
@@ -138,7 +138,7 @@ export function createWriter({
       }
 
       const csv = joinIntoSingleMessage(records);
-      const compressed = await compress(csv);
+      const compressed = await compressGzip(csv);
       // create input structure schema
 
       await writeCsv(

--- a/packages/services/usage/__tests__/buffer.bench.ts
+++ b/packages/services/usage/__tests__/buffer.bench.ts
@@ -1,0 +1,42 @@
+import { bench, describe } from 'vitest';
+import { createKVBuffer } from '../src/buffer';
+
+const noop = () => {};
+const logger = { info: noop, error: noop } as any;
+const report = {
+  size: 28,
+  map: Object.fromEntries(Array.from({ length: 10 }, (_, i) => [`key-${i}`, i])),
+};
+
+function fillCurrent(count: number) {
+  const buffer = createKVBuffer({
+    logger,
+    size: count + 1,
+    interval: 60_000,
+    limitInBytes: 500_000,
+    useEstimator: true,
+    calculateReportSize: value => Object.keys(value.map).length,
+    split: value => [value],
+    onRetry: noop,
+    isTooLargePayloadError: () => false,
+    sender: async () => {},
+  });
+
+  for (let i = 0; i < count; i++) {
+    buffer.add(report);
+  }
+}
+
+for (const count of [100, 500, 1_000, 2_000]) {
+  // | Reports | Before     | After     | Speedup |
+  // | 100     | 0.0165 ms  | 0.0079 ms | 2.1x    |
+  // | 500     | 0.1897 ms  | 0.0190 ms | 10.0x   |
+  // | 1000    | 0.6847 ms  | 0.0331 ms | 20.7x   |
+  // | 2000    | 2.6089 ms  | 0.0616 ms | 42.4x   |
+  describe(`fill ${count} reports`, () => {
+    bench('buffer.add', () => fillCurrent(count), {
+      time: 1_000,
+      warmupTime: 100,
+    });
+  });
+}

--- a/packages/services/usage/__tests__/buffer.spec.ts
+++ b/packages/services/usage/__tests__/buffer.spec.ts
@@ -224,6 +224,34 @@ test('buffer should split the report into multiple reports when the estimated si
   await buffer.stop();
 });
 
+test('buffer should not recursively split a report that cannot get smaller', async () => {
+  const split = vi.fn((report: { size: number }) => [{ size: 0 }, report]);
+  const buffer = createKVBuffer<{ size: number }>({
+    logger: { info: vi.fn(), error: vi.fn() } as any,
+    size: 1,
+    interval: 60_000,
+    limitInBytes: 100,
+    useEstimator: true,
+    calculateReportSize: report => report.size,
+    split,
+    onRetry() {},
+    isTooLargePayloadError() {
+      return false;
+    },
+    async sender(reports, _bytes, _batchId, validateSize) {
+      validateSize(reports.reduce((sum, report) => sum + report.size, 0) * 200);
+    },
+  });
+
+  // The first flush teaches the estimator that one unit exceeds the byte limit.
+  buffer.add({ size: 1 });
+  await buffer.stop();
+
+  expect(() => buffer.add({ size: 1 })).not.toThrow();
+  await buffer.stop();
+  expect(split.mock.calls.length).toBeLessThan(10);
+});
+
 test('buffer create two chunks out of one buffer when actual buffer size is too big', async () => {
   const logger = {
     info: vi.fn(),

--- a/packages/services/usage/__tests__/codec.bench.ts
+++ b/packages/services/usage/__tests__/codec.bench.ts
@@ -7,7 +7,6 @@ import { usageProcessorV2 } from '../src/usage-processor-2';
 faker.seed(42);
 
 function createNameGenerator(): () => string {
-
   return () => `f${faker.string.alphanumeric(10)}`;
 }
 

--- a/packages/services/usage/__tests__/codec.bench.ts
+++ b/packages/services/usage/__tests__/codec.bench.ts
@@ -1,0 +1,250 @@
+import { constants, gunzipSync, gzipSync, zstdCompressSync, zstdDecompressSync } from 'node:zlib';
+import { bench, describe } from 'vitest';
+import { faker } from '@faker-js/faker';
+import { compressGzip, compressZstd } from '@hive/usage-common';
+import { usageProcessorV2 } from '../src/usage-processor-2';
+
+faker.seed(42);
+
+function createNameGenerator(): () => string {
+
+  return () => `f${faker.string.alphanumeric(10)}`;
+}
+
+function makeDocument(nextName: () => string, fieldCount: number) {
+  const fields = Array.from({ length: fieldCount }, nextName);
+  const operationName = nextName();
+  return {
+    operation: `query ${operationName} {\n${fields.map(f => `  ${f} { id name }`).join('\n')}\n}`,
+    operationName,
+    fields: fields.map(f => `Query.${f}`),
+  };
+}
+
+interface Shape {
+  name: string;
+  /** Operations per report */
+  operations: number;
+  /** Map records per report */
+  records: number;
+  /** Fields per document */
+  fields: number;
+  targets: number;
+  /** Documents in each target's map */
+  docs: number;
+  /** Subgraph fetches per operation */
+  subgraphs?: number;
+}
+
+const SHAPES: Shape[] = [
+  { name: 'tiny, heavy reuse', operations: 5, records: 3, fields: 10, targets: 5, docs: 5 },
+  { name: 'production typical', operations: 28, records: 10, fields: 20, targets: 20, docs: 30 },
+  { name: 'typical, low reuse', operations: 28, records: 10, fields: 20, targets: 200, docs: 200 },
+  { name: 'single target', operations: 28, records: 10, fields: 20, targets: 1, docs: 20 },
+  { name: 'wide field lists', operations: 28, records: 10, fields: 200, targets: 20, docs: 30 },
+  { name: 'huge documents', operations: 28, records: 10, fields: 500, targets: 10, docs: 15 },
+  { name: 'many ops, few docs', operations: 500, records: 5, fields: 20, targets: 10, docs: 8 },
+  {
+    name: 'many docs per report',
+    operations: 100,
+    records: 100,
+    fields: 20,
+    targets: 10,
+    docs: 300,
+  },
+  { name: 'high target count', operations: 28, records: 10, fields: 20, targets: 200, docs: 5 },
+  {
+    name: 'large client batches',
+    operations: 2000,
+    records: 100,
+    fields: 50,
+    targets: 5,
+    docs: 200,
+  },
+  {
+    name: 'federated (4 subgraphs)',
+    operations: 28,
+    records: 10,
+    fields: 20,
+    targets: 20,
+    docs: 30,
+    subgraphs: 4,
+  },
+];
+
+const noop = () => {};
+const logger = { child: () => logger, debug: noop, info: noop, warn: noop, error: noop } as any;
+
+function buildBatch(shape: Shape, targetBytes = 2_000_000): Buffer {
+  const nextName = createNameGenerator();
+  const catalogues = Array.from({ length: shape.targets }, () =>
+    Array.from({ length: shape.docs }, () => makeDocument(nextName, shape.fields)),
+  );
+
+  const reports: unknown[] = [];
+  let bytes = 0;
+  for (let r = 0; bytes < targetBytes; r++) {
+    const catalogue = catalogues[r % shape.targets];
+    const map: Record<string, unknown> = {};
+    for (let i = 0; i < shape.records; i++) {
+      map[`key${i}`] = catalogue[(r * 7 + i) % shape.docs];
+    }
+    const record = catalogue[r % shape.docs];
+    const result = usageProcessorV2(
+      logger,
+      {
+        size: shape.operations,
+        map,
+        operations: Array.from({ length: shape.operations }, (_, i) => ({
+          operationMapKey: `key${i % shape.records}`,
+          timestamp: 1756200000000 + i,
+          execution: {
+            ok: true,
+            duration: 1000 + i,
+            errorsTotal: 0,
+            ...(shape.subgraphs
+              ? {
+                  fetches: Array.from({ length: shape.subgraphs }, (_, s) => ({
+                    start: s * 10,
+                    duration: 100 + s,
+                    fields: Object.fromEntries(
+                      record.fields.slice(s, s + 8).map(f => [f, 1 + (i % 3)]),
+                    ),
+                    subgraph: `subgraph-${s}`,
+                    paths: 'Query',
+                    type: 'ROOT' as const,
+                    errors: [
+                      { coordinate: record.fields[s % record.fields.length], code: `E${s}` },
+                    ],
+                  })),
+                }
+              : {}),
+          },
+          metadata: { client: { name: `c${i % 3}`, version: '1.0.0' } },
+        })),
+      },
+      {
+        targetId: `target-${r % shape.targets}`,
+        projectId: 'project',
+        organizationId: 'organization',
+      },
+      365,
+    );
+    if (!result.success) {
+      throw new Error(`fixture "${shape.name}" is invalid: ${JSON.stringify(result.errors[0])}`);
+    }
+    reports.push(result.report);
+    bytes += JSON.stringify(result.report).length;
+  }
+  return Buffer.from(JSON.stringify(reports), 'utf8');
+}
+
+interface Codec {
+  name: string;
+  compress: (buffer: Buffer) => Buffer;
+  decompress: (buffer: Buffer) => Buffer;
+}
+
+function zstd(level: number, windowLog?: number): Codec {
+  const params: Record<number, number> = { [constants.ZSTD_c_compressionLevel]: level };
+  if (windowLog) {
+    params[constants.ZSTD_c_windowLog] = windowLog;
+  }
+  return {
+    name: `zstd L${level} ${windowLog ? `w${windowLog}` : 'w-default'}`,
+    compress: buffer => zstdCompressSync(buffer, { params }),
+    decompress: buffer => zstdDecompressSync(buffer),
+  };
+}
+
+function gzip(level: number): Codec {
+  return {
+    name: `gzip L${level}`,
+    compress: buffer => gzipSync(buffer, { level }),
+    decompress: buffer => gunzipSync(buffer),
+  };
+}
+
+const CODECS: Codec[] = [
+  gzip(1),
+  gzip(6), // what usage-service did before zstd
+  gzip(9),
+  zstd(1),
+  zstd(1, 21),
+  zstd(1, 23), // what usage-service does now
+  zstd(1, 25),
+  zstd(3, 23),
+  zstd(6, 23),
+];
+
+const batches = SHAPES.map(shape => ({ shape, buffer: buildBatch(shape) }));
+
+const compressionRatioOf = new Map<string, Map<string, number>>();
+for (const { shape, buffer } of batches) {
+  const byCodec = new Map<string, number>();
+  for (const codec of CODECS) {
+    const out = codec.compress(buffer);
+    if (!codec.decompress(out).equals(buffer)) {
+      throw new Error(
+        `${codec.name} does not yield the same payload when decompressing on "${shape.name}"`,
+      );
+    }
+    byCodec.set(codec.name, buffer.byteLength / out.byteLength);
+  }
+  compressionRatioOf.set(shape.name, byCodec);
+}
+
+const COMPRESS_TIMING = { time: 200, warmupTime: 50 } as const;
+const DECOMPRESS_TIMING = { time: 500, warmupTime: 100 } as const;
+
+for (const { shape, buffer } of batches) {
+  const megabytes = (buffer.byteLength / 1_000_000).toFixed(2);
+  const byCodec = compressionRatioOf.get(shape.name)!;
+  const label = (codec: Codec) =>
+    `${codec.name} - ${byCodec.get(codec.name)!.toFixed(1)}x compression`;
+
+  describe(`compress: ${shape.name} (${megabytes}MB batch)`, () => {
+    for (const codec of CODECS) {
+      bench(
+        label(codec),
+        () => {
+          codec.compress(buffer);
+        },
+        COMPRESS_TIMING,
+      );
+    }
+  });
+
+  describe(`decompress: ${shape.name} (${megabytes}MB batch)`, () => {
+    for (const codec of CODECS) {
+      const compressed = codec.compress(buffer);
+      bench(
+        label(codec),
+        () => {
+          codec.decompress(compressed);
+        },
+        DECOMPRESS_TIMING,
+      );
+    }
+  });
+}
+
+const typical = batches[1].buffer.toString('utf8');
+
+describe('as production compresses it', () => {
+  bench(
+    'compressZstd()',
+    async () => {
+      await compressZstd(typical);
+    },
+    COMPRESS_TIMING,
+  );
+
+  bench(
+    'compressGzip() - compression before',
+    async () => {
+      await compressGzip(typical);
+    },
+    COMPRESS_TIMING,
+  );
+});

--- a/packages/services/usage/package.json
+++ b/packages/services/usage/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@faker-js/faker": "9.9.0",
     "@hive/api": "workspace:*",
     "@hive/postgres": "workspace:*",
     "@hive/service-common": "workspace:*",

--- a/packages/services/usage/package.json
+++ b/packages/services/usage/package.json
@@ -26,6 +26,7 @@
     "p-limit": "6.2.0",
     "pino-pretty": "11.3.0",
     "reflect-metadata": "0.2.2",
+    "vitest": "4.1.3",
     "zod": "3.25.76"
   }
 }

--- a/packages/services/usage/src/buffer.ts
+++ b/packages/services/usage/src/buffer.ts
@@ -137,6 +137,17 @@ export function createKVBuffer<T>(config: {
 }) {
   const { logger } = config;
   let buffer: T[] = [];
+  let bufferedUnits = 0;
+  let bufferedOperations = 0;
+
+  function pushToBuffer(report: T, units = 0) {
+    buffer.push(report);
+    if (config.useEstimator) {
+      bufferedUnits += units;
+    } else {
+      bufferedOperations += (report as { size?: number }).size ?? 0;
+    }
+  }
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
   const estimator = createEstimator({
@@ -155,14 +166,6 @@ export function createKVBuffer<T>(config: {
 
   function calculateBufferSize(reports: readonly T[]) {
     return reports.reduce((sum, report) => sum + config.calculateReportSize(report), 0);
-  }
-
-  function calculateBufferSizeInBytes(reports: readonly T[]) {
-    return estimator.estimate(calculateBufferSize(reports));
-  }
-
-  function sumOfOperationsSizeInBuffer() {
-    return buffer.reduce((sum, report) => sum + (report as any).size, 0);
   }
 
   async function flushBuffer(
@@ -246,11 +249,13 @@ export function createKVBuffer<T>(config: {
 
     if (buffer.length !== 0) {
       const reports = buffer.slice();
-      const size = calculateBufferSize(reports);
+      const size = bufferedUnits;
       const batchId = randomUUID();
 
       try {
         buffer = [];
+        bufferedUnits = 0;
+        bufferedOperations = 0;
         await flushBuffer(reports, size, batchId);
       } catch (error) {
         logger.error(error);
@@ -283,8 +288,9 @@ export function createKVBuffer<T>(config: {
 
   function add(report: T) {
     if (config.useEstimator) {
-      const currentBufferSize = calculateBufferSizeInBytes(buffer);
-      const estimatedReportSize = estimator.estimate(config.calculateReportSize(report));
+      const reportSize = config.calculateReportSize(report);
+      const currentBufferSize = estimator.estimate(bufferedUnits);
+      const estimatedReportSize = estimator.estimate(reportSize);
       const estimatedBufferSize = currentBufferSize + estimatedReportSize;
 
       if (currentBufferSize >= config.limitInBytes || estimatedBufferSize >= config.limitInBytes) {
@@ -296,15 +302,20 @@ export function createKVBuffer<T>(config: {
       if (estimatedReportSize > config.limitInBytes) {
         const numOfChunks = Math.ceil(estimatedReportSize / config.limitInBytes);
         const reports = config.split(report, numOfChunks);
-        for (const report of reports) {
-          add(report);
+        for (const splitReport of reports) {
+          const splitReportSize = config.calculateReportSize(splitReport);
+          if (splitReportSize >= reportSize) {
+            pushToBuffer(splitReport, splitReportSize);
+          } else {
+            add(splitReport);
+          }
         }
       } else {
-        buffer.push(report);
+        pushToBuffer(report, reportSize);
       }
     } else {
-      buffer.push(report);
-      if (sumOfOperationsSizeInBuffer() >= config.size) {
+      pushToBuffer(report);
+      if (bufferedOperations >= config.size) {
         void send({
           scheduleNextSend: true,
         });

--- a/packages/services/usage/src/index.ts
+++ b/packages/services/usage/src/index.ts
@@ -90,10 +90,10 @@ async function main() {
   const authN = createAuthN({
     pgPool,
     redis,
-    isPrometheusEnabled: !!tracing,
+    isPrometheusEnabled: !!env.prometheus,
   });
 
-  const prometheusConfig = new PrometheusConfig(!!tracing);
+  const prometheusConfig = new PrometheusConfig(!!env.prometheus);
   const targetsByIdCache = new TargetsByIdCache(redis, pgPool, prometheusConfig);
   const targetsBySlugCache = new TargetsBySlugCache(redis, pgPool, prometheusConfig);
   const targetTokenCache = new TargetTokenCache(redis, pgPool, prometheusConfig);

--- a/packages/services/usage/src/usage-collection-legacy-route.ts
+++ b/packages/services/usage/src/usage-collection-legacy-route.ts
@@ -39,8 +39,12 @@ export function registerUsageCollectionLegacyRoute(args: {
   >({
     method: 'POST',
     url: '/',
-    onRequest(req, _, done) {
+    onRequest(req, reply, done) {
       req.onRequestHRTime = process.hrtime();
+      if (args.usage.readiness() === false) {
+        void reply.status(503).send();
+        return;
+      }
       done();
     },
     onResponse(req, _, done) {

--- a/packages/services/usage/src/usage-collection-route.ts
+++ b/packages/services/usage/src/usage-collection-route.ts
@@ -261,8 +261,12 @@ export function registerUsageCollectionRoute(args: {
   >({
     method: 'POST',
     url: '/:targetId',
-    onRequest(req, _, done) {
+    onRequest(req, reply, done) {
       req.onRequestHRTime = process.hrtime();
+      if (args.usage.readiness() === false) {
+        void reply.status(503).send();
+        return;
+      }
       done();
     },
     onResponse(req, _, done) {
@@ -283,8 +287,12 @@ export function registerUsageCollectionRoute(args: {
   >({
     method: 'POST',
     url: '/:organizationSlug/:projectSlug/:targetSlug',
-    onRequest(req, _, done) {
+    onRequest(req, reply, done) {
       req.onRequestHRTime = process.hrtime();
+      if (args.usage.readiness() === false) {
+        void reply.status(503).send();
+        return;
+      }
       done();
     },
     onResponse(req, _, done) {

--- a/packages/services/usage/src/usage-processor-1.ts
+++ b/packages/services/usage/src/usage-processor-1.ts
@@ -13,6 +13,7 @@ import {
   totalReports,
 } from './metrics';
 import type { TokensResponse } from './tokens';
+import { isUnixTimestamp } from './usage-processor-2';
 
 const DAY_IN_MS = 86_400_000;
 
@@ -207,12 +208,6 @@ function convertLegacyReport(legacy: IncomingLegacyReport): IncomingReport {
   }
 
   return report;
-}
-
-const unixTimestampRegex = /^\d{13,}$/;
-
-function isUnixTimestamp(x: number) {
-  return unixTimestampRegex.test(String(x));
 }
 
 // This is a custom format for positive integers (0 is allowed, decimals are not)

--- a/packages/services/usage/src/usage-processor-2.ts
+++ b/packages/services/usage/src/usage-processor-2.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { LRUCache } from 'lru-cache';
 import { ServiceLogger as Logger, traceInlineSync } from '@hive/service-common';
 import type {
   ClientMetadata,
@@ -12,6 +13,105 @@ import * as tc from '@sinclair/typebox/compiler';
 import * as tbe from '@sinclair/typebox/errors';
 import { invalidRawOperations, rawOperationsSize, totalOperations, totalReports } from './metrics';
 import { isValidOperationBody } from './usage-processor-1';
+
+interface OperationMapKeyEntry {
+  /** md5(targetId, document, operation name and the sorted fields) */
+  hash: string;
+  /** Sorted, so field order never affects identity. Also what Kafka carries. */
+  sortedFields: string[];
+}
+
+/**
+ * The idea here is to reuse operation map keys across requests,
+ * so we can skip sorting and stringifying the field list, and hashing the whole document.
+ */
+const operationMapKeyCache = new LRUCache<string, Map<string, OperationMapKeyEntry[]>>({
+  // We're using `maxSize` instead of `max`, because the stored Map can have 1 record or 1000s,
+  // and we want to cap the total memory used by the cache, not just the number of entries.
+  maxSize: 200 * 1024 * 1024, // 200MB
+  sizeCalculation: (byTarget, document) => {
+    // Yeah yeah, magic numbers, but I ran a bunch of different-sized reports to get those numbers
+    // and they roughtly represent 1:1 the memory footprint of the stored records in the cache.
+    let size = document.length + 1024; // The cost of Map, the LRU's own node, and the key
+    for (const entries of byTarget.values()) {
+      for (const entry of entries) {
+        size += 128; // md5 and stuff
+        for (const field of entry.sortedFields) {
+          size += field.length;
+        }
+      }
+    }
+    return size;
+  },
+});
+
+function sameFields(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function operationMapSlot(record: OperationMapRecord): Map<string, OperationMapKeyEntry[]> | null {
+  const cached = operationMapKeyCache.get(record.operation);
+  if (cached) {
+    return cached;
+  }
+  if (!isValidOperationBody(record.operation)) {
+    return null;
+  }
+  return new Map();
+}
+
+function buildOperationMapKeyEntry(
+  targetId: string,
+  record: OperationMapRecord,
+  sortedFields: string[],
+): OperationMapKeyEntry {
+  return {
+    sortedFields,
+    hash: createHash('md5')
+      .update(targetId)
+      .update(record.operation)
+      .update(record.operationName ?? '')
+      .update(JSON.stringify(sortedFields))
+      .digest('hex'),
+  };
+}
+
+function deriveOperationMapKey(
+  targetId: string,
+  record: OperationMapRecord,
+): OperationMapKeyEntry | null {
+  const byTarget = operationMapSlot(record);
+  if (byTarget === null) {
+    return null;
+  }
+
+  const sortedFields = record.fields.toSorted();
+
+  const entries = byTarget.get(targetId);
+  const cached = entries?.find(entry => sameFields(entry.sortedFields, sortedFields));
+  if (cached) {
+    return cached;
+  }
+
+  const entry = buildOperationMapKeyEntry(targetId, record, sortedFields);
+  if (entries) {
+    entries.push(entry);
+  } else {
+    byTarget.set(targetId, [entry]);
+  }
+
+  // Re-set so the LRU recalculates the size
+  operationMapKeyCache.set(record.operation, byTarget);
+  return entry;
+}
 
 export const usageProcessorV2 = traceInlineSync(
   'usageProcessorV2',
@@ -117,34 +217,30 @@ export const usageProcessorV2 = traceInlineSync(
 
       let newOperationMapKey = newKeyMappings.get(operationMapRecord);
 
-      if (!isValidOperationBody(operationMapRecord.operation)) {
-        logger.warn(
-          `Detected invalid operation (target=%s): %s`,
-          targetSelector.targetId,
-          operationMapKey,
-        );
-        invalidRawOperations
-          .labels({
-            reason: 'invalid_operation_body',
-          })
-          .inc(1);
-        return null;
-      }
-
       if (newOperationMapKey === undefined) {
-        const sortedFields = operationMapRecord.fields.sort();
-        newOperationMapKey = createHash('md5')
-          .update(targetSelector.targetId)
-          .update(operationMapRecord.operation)
-          .update(operationMapRecord.operationName ?? '')
-          .update(JSON.stringify(sortedFields))
-          .digest('hex');
+        const key = deriveOperationMapKey(targetSelector.targetId, operationMapRecord);
+
+        if (key === null) {
+          logger.warn(
+            `Detected invalid operation (target=%s): %s`,
+            targetSelector.targetId,
+            operationMapKey,
+          );
+          invalidRawOperations
+            .labels({
+              reason: 'invalid_operation_body',
+            })
+            .inc(1);
+          return null;
+        }
+
+        newOperationMapKey = key.hash;
 
         report.map[newOperationMapKey] = {
           key: newOperationMapKey,
           operation: operationMapRecord.operation,
           operationName: operationMapRecord.operationName,
-          fields: sortedFields,
+          fields: key.sortedFields,
         };
 
         newKeyMappings.set(operationMapRecord, newOperationMapKey);
@@ -388,9 +484,8 @@ const PersistedDocumentHash = tb.Type.String({
   pattern: '^[a-zA-Z0-9_-]{1,64}~[a-zA-Z0-9._-]{1,64}~([A-Za-z]|[0-9]|_){1,128}$',
 });
 
-const unixTimestampRegex = /^\d{13,}$/;
-function isUnixTimestamp(x: number) {
-  return unixTimestampRegex.test(String(x));
+export function isUnixTimestamp(x: number) {
+  return Number.isInteger(x) && x >= 1e12;
 }
 
 tbe.SetErrorFunction(param => {
@@ -462,17 +557,19 @@ interface ValueError {
 export function decodeReport(
   report: unknown,
 ): { success: true; report: ReportType } | { success: false; errors: Array<ValueError> } {
-  const errors = ReportModel.Errors(report);
-  if (ReportModel.Errors(report).First()) {
+  // Check() short-circuits on the first failure,
+  // where Errors() walk the whole document building error objects.
+  // We only pay for Errors() when it is invalid.
+  if (ReportModel.Check(report)) {
     return {
-      success: false,
-      errors: getTypeBoxErrors(errors),
+      success: true,
+      report: report as ReportType,
     };
   }
 
   return {
-    success: true,
-    report: report as ReportType,
+    success: false,
+    errors: getTypeBoxErrors(ReportModel.Errors(report)),
   };
 }
 

--- a/packages/services/usage/src/usage.ts
+++ b/packages/services/usage/src/usage.ts
@@ -14,7 +14,7 @@ import {
   type ServiceLogger,
 } from '@hive/service-common';
 import type { RawOperationMap, RawReport } from '@hive/usage-common';
-import { compress } from '@hive/usage-common';
+import { compressZstd } from '@hive/usage-common';
 import * as Sentry from '@sentry/node';
 import { calculateChunkSize, createKVBuffer } from './buffer';
 import type { KafkaEnvironment } from './environment';
@@ -216,7 +216,7 @@ export function createUsage(config: {
     async sender(reports, estimatedSizeInBytes, batchId, validateSize) {
       const numOfOperations = reports.reduce((sum, report) => report.size + sum, 0);
       const compressLatencyStop = compressDuration.startTimer();
-      const value = await compress(JSON.stringify(reports)).finally(() => {
+      const value = await compressZstd(JSON.stringify(reports)).finally(() => {
         compressLatencyStop();
       });
       estimationError.observe(Math.abs(estimatedSizeInBytes - value.byteLength) / value.byteLength);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1500,7 +1500,7 @@ importers:
     devDependencies:
       '@graphql-eslint/eslint-plugin':
         specifier: 3.20.1
-        version: 3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
+        version: 3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@24.13.3)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
       '@hive/service-common':
         specifier: workspace:*
         version: link:../service-common
@@ -1641,7 +1641,7 @@ importers:
         version: 8.0.2
       '@graphql-hive/plugin-opentelemetry':
         specifier: 1.4.35
-        version: 1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)
+        version: 1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)(ws@8.21.0)
       '@graphql-hive/yoga':
         specifier: workspace:*
         version: link:../../libraries/yoga/dist
@@ -1874,6 +1874,9 @@ importers:
 
   packages/services/usage:
     devDependencies:
+      '@faker-js/faker':
+        specifier: 9.9.0
+        version: 9.9.0
       '@hive/api':
         specifier: workspace:*
         version: link:../api
@@ -22289,29 +22292,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@graphql-eslint/eslint-plugin@3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.29.7)(graphql@16.9.0)
-      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.7)(graphql@16.9.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.9.0)
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      fast-glob: 3.3.3
-      graphql: 16.9.0
-      graphql-config: 4.5.0(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
-      graphql-depth-limit: 1.1.0(graphql@16.9.0)
-      lodash.lowercase: 4.3.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/node'
-      - bufferutil
-      - cosmiconfig-toml-loader
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   '@graphql-hive/core@0.21.1(graphql@16.14.2)(pino@10.3.0)':
     dependencies:
       '@graphql-hive/logger': 1.1.0(pino@10.3.0)
@@ -22626,7 +22606,7 @@ snapshots:
       - winston
       - ws
 
-  '@graphql-hive/plugin-opentelemetry@1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)':
+  '@graphql-hive/plugin-opentelemetry@1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)(ws@8.21.0)':
     dependencies:
       '@graphql-hive/core': 0.21.1(graphql@16.9.0)(pino@10.3.0)
       '@graphql-hive/gateway-runtime': 2.9.10(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)(ws@8.21.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1925,6 +1925,9 @@ importers:
       reflect-metadata:
         specifier: 0.2.2
         version: 0.2.2
+      vitest:
+        specifier: 4.1.3
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
       zod:
         specifier: 3.25.76
         version: 3.25.76


### PR DESCRIPTION
I profiled and benchmarked:
- compression and decompression of batched reports that we send and read from Kafka
- part where we decode and validate the report (v2)

This should be now 4x faster based on the benchmark I did.

The raw/compressed size ratio should also be better now, hard to say by how much, in some scenarios we're able to send 2x more data over the same-size kafka message than with gzip. It means EventHub can handle more at the same Throughput Unit.

Other changes I did:

`decodeReport` used TypeBox's `Errors()`, which walks the whole document building
error objects. `Check()` short-circuits, and errors are now only built when a report is actually invalid. I benchmarked it and it's 15-28x faster than before, depending on the report.

`isUnixTimestamp` compared `String(x)` against `/^\d{13,}$/`, allocating a string
per operation. The new check is ~4-7x faster. It's now shared with v2 and v1 report validations.

The GraphQL doc was parsed more than it should, we cache things more aggressively now.

We had this operationMapKeyCache or something, that was used to avoid doing the same work many times. Nothing there was request-specific, so I made the cache global, and reusable across requests. It made a big impact too.

<details>
<summary>Benchmark of compression/decompression</summary>

```
 ✓ packages/services/usage/__tests__/codec.bench.ts > compress: tiny, heavy reuse (2.00MB batch) 2310ms
     name                                         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · gzip L1 - 21.8x compression              555.25  1.7029  3.0545  1.8010  1.8135  2.0767  3.0545  3.0545  ±1.39%      112
   · gzip L6 - 51.4x compression              199.87  4.8678  6.2493  5.0032  5.0105  6.2493  6.2493  6.2493  ±1.36%       40
   · gzip L9 - 60.2x compression              200.69  4.8966  5.1228  4.9828  4.9982  5.1228  5.1228  5.1228  ±0.28%       41
   · zstd L1 w-default - 89.3x compression  2,726.15  0.3463  1.6872  0.3668  0.3692  0.4425  0.4755  1.6872  ±1.35%      546
   · zstd L1 w21 - 111.9x compression       3,143.32  0.2966  1.7523  0.3181  0.3228  0.3851  0.4217  1.7523  ±1.46%      629
   · zstd L1 w23 - 111.9x compression       3,120.89  0.2973  1.6322  0.3204  0.3235  0.3882  0.4185  1.6322  ±1.36%      625
   · zstd L1 w25 - 111.9x compression       3,082.31  0.2958  1.7933  0.3244  0.3281  0.4082  0.4253  1.7933  ±1.53%      617
   · zstd L3 w23 - 84.8x compression        2,110.48  0.4505  1.8377  0.4738  0.4730  0.6540  0.6691  1.8377  ±1.45%      423
   · zstd L6 w23 - 108.6x compression         976.90  0.9849  2.1505  1.0236  1.0226  1.2183  2.1505  2.1505  ±1.19%      196

 ✓ packages/services/usage/__tests__/codec.bench.ts > decompress: tiny, heavy reuse (2.00MB batch) 5436ms
     name                                         hz     min     max    mean     p75     p99    p995    p999      rme  samples
   · gzip L1 - 21.8x compression            1,218.43  0.6105  2.3448  0.8207  0.9049  2.0324  2.1038  2.3448   ±2.89%      610
   · gzip L6 - 51.4x compression            1,646.88  0.3733  6.6758  0.6072  0.7020  1.8712  1.9492  6.6758   ±4.81%      824
   · gzip L9 - 60.2x compression            1,646.15  0.3599  6.7930  0.6075  0.7321  1.9959  6.6397  6.7930   ±6.45%      824
   · zstd L1 w-default - 89.3x compression  1,932.51  0.2270  7.4297  0.5175  0.7762  2.0712  6.7938  7.4297   ±8.43%      967
   · zstd L1 w21 - 111.9x compression       1,969.73  0.2223  7.3419  0.5077  0.4865  6.9692  7.0936  7.3419  ±10.19%      986
   · zstd L1 w23 - 111.9x compression       1,851.54  0.2211  7.5097  0.5401  0.3144  7.2179  7.3712  7.5097  ±11.43%      926
   · zstd L1 w25 - 111.9x compression       1,968.86  0.2213  7.3576  0.5079  0.4818  7.1603  7.2230  7.3576  ±10.47%      985
   · zstd L3 w23 - 84.8x compression        1,777.12  0.2506  7.5140  0.5627  0.7318  7.2648  7.3545  7.5140  ±10.51%      889
   · zstd L6 w23 - 108.6x compression       1,825.95  0.2271  7.5541  0.5477  0.4936  7.2612  7.2975  7.5541  ±11.64%      913

 ✓ packages/services/usage/__tests__/codec.bench.ts > compress: production typical (2.01MB batch) 3240ms
     name                                       hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · gzip L1 - 5.0x compression             200.71   4.9065   5.0888   4.9824   5.0102   5.0888   5.0888   5.0888  ±0.30%       41
   · gzip L6 - 4.9x compression            52.3092  19.0720  19.1633  19.1171  19.1546  19.1633  19.1633  19.1633  ±0.12%       11
   · gzip L9 - 4.8x compression            15.7767  61.9248  65.0153  63.3847  64.0301  65.0153  65.0153  65.0153  ±1.32%       10
   · zstd L1 w-default - 6.4x compression   441.88   2.1587   3.8731   2.2631   2.2842   3.8731   3.8731   3.8731  ±1.76%       89
   · zstd L1 w21 - 9.7x compression         684.21   1.3937   2.8380   1.4615   1.4776   1.5876   2.8380   2.8380  ±1.47%      137
   · zstd L1 w23 - 9.7x compression         688.82   1.3936   2.6587   1.4518   1.4649   1.7486   2.6587   2.6587  ±1.34%      138
   · zstd L1 w25 - 9.7x compression         696.32   1.3871   1.5552   1.4361   1.4620   1.5497   1.5552   1.5552  ±0.48%      140
   · zstd L3 w23 - 11.6x compression        634.77   1.4465   3.4774   1.5754   1.5461   3.4333   3.4774   3.4774  ±3.62%      129
   · zstd L6 w23 - 11.7x compression        246.82   3.8906   5.1648   4.0516   4.1044   5.1648   5.1648   5.1648  ±1.45%       50

 ✓ packages/services/usage/__tests__/codec.bench.ts > decompress: production typical (2.01MB batch) 5452ms
     name                                        hz     min      max    mean     p75      p99     p995     p999     rme  samples
   · gzip L1 - 5.0x compression              381.83  1.8193  11.8389  2.6190  2.4695  11.2919  11.8389  11.8389  ±8.35%      191
   · gzip L6 - 4.9x compression              494.76  1.8205   4.7087  2.0212  2.0368   3.4959   4.6065   4.7087  ±2.35%      248
   · gzip L9 - 4.8x compression              489.54  1.8534   9.2684  2.0427  2.0161   3.2490   3.2575   9.2684  ±3.34%      245
   · zstd L1 w-default - 6.4x compression    754.32  1.0611   8.1384  1.3257  1.2988   7.9749   8.1097   8.1384  ±5.85%      378
   · zstd L1 w21 - 9.7x compression          981.95  0.7690   7.9446  1.0184  0.8808   2.3397   7.6924   7.9446  ±6.11%      491
   · zstd L1 w23 - 9.7x compression          845.89  0.7697  13.8457  1.1822  1.2337   4.4861   8.7393  13.8457  ±8.37%      424
   · zstd L1 w25 - 9.7x compression          881.80  0.7690   9.8855  1.1340  1.0115   8.4988   8.7178   9.8855  ±8.53%      441
   · zstd L3 w23 - 11.6x compression       1,095.23  0.6532   7.7703  0.9131  0.9065   2.4979   7.6210   7.7703  ±6.24%      548
   · zstd L6 w23 - 11.7x compression       1,123.21  0.6531   7.9546  0.8903  0.8913   2.3586   2.5208   7.9546  ±5.15%      562

 ✓ packages/services/usage/__tests__/codec.bench.ts > compress: typical, low reuse (2.01MB batch) 3250ms
     name                                       hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · gzip L1 - 5.0x compression             202.04   4.8581   6.3787   4.9496   4.9429   6.3787   6.3787   6.3787  ±1.55%       41
   · gzip L6 - 4.9x compression            52.9892  18.7729  19.1135  18.8718  19.0000  19.1135  19.1135  19.1135  ±0.42%       11
   · gzip L9 - 4.8x compression            16.0157  61.0927  64.8514  62.4389  62.8592  64.8514  64.8514  64.8514  ±1.40%       10
   · zstd L1 w-default - 6.4x compression   437.94   2.1791   3.5525   2.2834   2.2970   3.5525   3.5525   3.5525  ±1.52%       88
   · zstd L1 w21 - 6.4x compression         468.04   2.0163   3.6115   2.1366   2.1540   3.6115   3.6115   3.6115  ±1.75%       94
   · zstd L1 w23 - 6.4x compression         473.12   2.0109   2.4912   2.1136   2.1724   2.4912   2.4912   2.4912  ±0.86%       95
   · zstd L1 w25 - 6.4x compression         483.90   2.0097   3.4878   2.0666   2.0642   3.4878   3.4878   3.4878  ±1.48%       97
   · zstd L3 w23 - 5.8x compression         350.62   2.6745   6.2147   2.8521   2.7450   6.2147   6.2147   6.2147  ±4.19%       71
   · zstd L6 w23 - 5.9x compression         131.07   7.4470   8.9035   7.6294   7.6076   8.9035   8.9035   8.9035  ±1.51%       27

 ✓ packages/services/usage/__tests__/codec.bench.ts > decompress: typical, low reuse (2.01MB batch) 5454ms
     name                                      hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · gzip L1 - 5.0x compression            505.48  1.8105  8.5646  1.9783  1.9342  3.2749  3.6591  8.5646  ±3.18%      253
   · gzip L6 - 4.9x compression            504.87  1.8197  8.6426  1.9807  1.9596  3.2728  3.2765  8.6426  ±3.15%      253
   · gzip L9 - 4.8x compression            495.06  1.8521  3.5582  2.0200  2.0481  3.3088  3.3632  3.5582  ±1.77%      248
   · zstd L1 w-default - 6.4x compression  758.99  1.0711  8.1201  1.3175  1.2108  7.6741  8.1022  8.1201  ±5.72%      380
   · zstd L1 w21 - 6.4x compression        761.65  1.0678  8.5154  1.3129  1.2000  2.8610  8.3076  8.5154  ±5.42%      381
   · zstd L1 w23 - 6.4x compression        779.80  1.0720  8.5710  1.2824  1.1721  2.6884  7.9455  8.5710  ±4.62%      390
   · zstd L1 w25 - 6.4x compression        771.57  1.0704  8.0997  1.2961  1.1401  7.9410  8.0499  8.0997  ±5.81%      386
   · zstd L3 w23 - 5.8x compression        748.49  1.0720  8.1206  1.3360  1.1737  3.0066  8.0028  8.1206  ±5.35%      375
   · zstd L6 w23 - 5.9x compression        767.04  1.0760  8.0186  1.3037  1.1555  2.8438  5.4734  8.0186  ±4.23%      384

 ✓ packages/services/usage/__tests__/codec.bench.ts > compress: single target (2.01MB batch) 2860ms
     name                                          hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · gzip L1 - 6.5x compression                272.66   3.5468   4.8857   3.6676   3.6717   4.8857   4.8857   4.8857  ±1.29%       55
   · gzip L6 - 6.9x compression               68.1787  14.2808  15.3360  14.6673  14.8843  15.3360  15.3360  15.3360  ±1.22%       14
   · gzip L9 - 6.8x compression               22.2116  44.5700  46.0930  45.0215  45.2611  46.0930  46.0930  46.0930  ±0.82%       10
   · zstd L1 w-default - 154.3x compression  3,832.11   0.2505   0.4904   0.2610   0.2634   0.2942   0.3192   0.4904  ±0.38%      767
   · zstd L1 w21 - 154.3x compression        3,846.98   0.2493   0.4821   0.2599   0.2611   0.2965   0.3239   0.4821  ±0.37%      770
   · zstd L1 w23 - 154.3x compression        3,895.72   0.2506   0.4154   0.2567   0.2570   0.2819   0.2850   0.4154  ±0.21%      780
   · zstd L1 w25 - 154.3x compression        3,866.62   0.2512   0.4555   0.2586   0.2595   0.2815   0.2910   0.4555  ±0.24%      774
   · zstd L3 w23 - 140.6x compression        2,349.01   0.3466   3.6367   0.4257   0.3815   2.2956   2.4452   3.6367  ±6.54%      470
   · zstd L6 w23 - 185.5x compression        1,488.73   0.6575   0.8571   0.6717   0.6744   0.7513   0.7894   0.8571  ±0.35%      298

 ✓ packages/services/usage/__tests__/codec.bench.ts > decompress: single target (2.01MB batch) 5444ms
     name                                          hz     min      max    mean     p75     p99    p995     p999      rme  samples
   · gzip L1 - 6.5x compression                585.14  1.3936  11.5840  1.7090  1.6185  5.3940  5.7553  11.5840   ±5.66%      293
   · gzip L6 - 6.9x compression                688.95  1.2915   8.0744  1.4515  1.4490  2.5311  2.7860   8.0744   ±3.16%      345
   · gzip L9 - 6.8x compression                684.27  1.3037   2.7313  1.4614  1.5018  2.5648  2.6063   2.7313   ±1.89%      343
   · zstd L1 w-default - 154.3x compression  1,902.10  0.2184   7.4144  0.5257  0.7669  7.0783  7.2460   7.4144   ±9.79%      952
   · zstd L1 w21 - 154.3x compression        1,847.56  0.2235   7.3198  0.5413  0.3685  7.1915  7.2463   7.3198  ±11.34%      924
   · zstd L1 w23 - 154.3x compression        1,875.09  0.2246   7.7951  0.5333  0.3589  7.4853  7.5925   7.7951  ±12.01%      940
   · zstd L1 w25 - 154.3x compression        1,952.29  0.2236   7.5973  0.5122  0.5223  2.6917  7.4133   7.5973   ±9.00%      977
   · zstd L3 w23 - 140.6x compression        1,897.86  0.2328   7.5020  0.5269  0.8127  2.0064  7.3020   7.5020   ±8.83%      949
   · zstd L6 w23 - 185.5x compression        1,663.54  0.2288  19.5404  0.6011  0.6225  7.3743  7.5515  19.5404  ±13.61%      832

 ✓ packages/services/usage/__tests__/codec.bench.ts > compress: wide field lists (2.05MB batch) 5216ms
     name                                       hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · gzip L1 - 3.6x compression             133.87   7.1787   8.8315   7.4702   7.5367   8.8315   8.8315   8.8315  ±1.59%       27
   · gzip L6 - 3.6x compression            35.0072  28.1190  29.7508  28.5655  28.6190  29.7508  29.7508  29.7508  ±1.14%       10
   · gzip L9 - 3.5x compression             5.9352   166.04   180.04   168.49   168.04   180.04   180.04   180.04  ±1.75%       10
   · zstd L1 w-default - 4.5x compression   330.33   2.9471   3.3359   3.0273   3.0334   3.3359   3.3359   3.3359  ±0.68%       67
   · zstd L1 w21 - 4.5x compression         351.71   2.7597   3.3917   2.8432   2.8476   3.3917   3.3917   3.3917  ±0.76%       71
   · zstd L1 w23 - 4.5x compression         353.90   2.7382   3.8327   2.8256   2.8333   3.8327   3.8327   3.8327  ±1.17%       71
   · zstd L1 w25 - 4.5x compression         354.06   2.7608   3.1556   2.8244   2.8239   3.1556   3.1556   3.1556  ±0.58%       71
   · zstd L3 w23 - 4.1x compression         243.08   3.9576   4.4055   4.1139   4.1753   4.4055   4.4055   4.4055  ±0.76%       49
   · zstd L6 w23 - 4.1x compression        91.0133  10.4972  13.2231  10.9874  11.0640  13.2231  13.2231  13.2231  ±2.74%       19

 ✓ packages/services/usage/__tests__/codec.bench.ts > decompress: wide field lists (2.05MB batch) 5473ms
     name                                      hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · gzip L1 - 3.6x compression            357.10  2.5233  7.3533  2.8004  2.7854  6.8708  7.3533  7.3533  ±3.03%      179
   · gzip L6 - 3.6x compression            364.79  2.5411  3.9960  2.7413  2.7386  3.9149  3.9960  3.9960  ±1.52%      183
   · gzip L9 - 3.5x compression            351.35  2.6611  4.0680  2.8462  2.8487  4.0363  4.0680  4.0680  ±1.45%      176
   · zstd L1 w-default - 4.5x compression  572.55  1.4757  8.4707  1.7466  1.6728  7.9837  8.0190  8.4707  ±4.85%      287
   · zstd L1 w21 - 4.5x compression        594.75  1.4713  3.2155  1.6814  1.6308  3.1224  3.1341  3.2155  ±2.32%      298
   · zstd L1 w23 - 4.5x compression        583.47  1.4720  8.0060  1.7139  1.6190  3.1733  7.8047  8.0060  ±4.11%      292
   · zstd L1 w25 - 4.5x compression        581.87  1.4736  8.1071  1.7186  1.6127  3.1356  6.0688  8.1071  ±3.79%      291
   · zstd L3 w23 - 4.1x compression        555.86  1.4485  7.1369  1.7990  1.7345  3.9147  5.0632  7.1369  ±4.02%      279
   · zstd L6 w23 - 4.1x compression        549.40  1.5217  9.2291  1.8202  1.8355  3.4166  3.5666  9.2291  ±3.80%      275

 ✓ packages/services/usage/__tests__/codec.bench.ts > compress: huge documents (2.09MB batch) 5953ms
     name                                       hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · gzip L1 - 3.5x compression             126.93   7.5519   9.0140   7.8782   7.9544   9.0140   9.0140   9.0140  ±1.78%       26
   · gzip L6 - 3.5x compression            32.5248  30.2232  31.9376  30.7458  30.9617  31.9376  31.9376  31.9376  ±1.21%       10
   · gzip L9 - 3.4x compression             4.8633   196.73   241.15   205.62   199.48   241.15   241.15   241.15  ±5.43%       10
   · zstd L1 w-default - 4.3x compression   293.65   3.1900   4.5141   3.4054   3.4580   4.5141   4.5141   4.5141  ±1.65%       59
   · zstd L1 w21 - 4.3x compression         314.88   2.9446   4.8040   3.1758   3.2101   4.8040   4.8040   4.8040  ±2.29%       63
   · zstd L1 w23 - 4.3x compression         304.57   2.9478   7.6639   3.2833   3.1893   7.6639   7.6639   7.6639  ±6.00%       61
   · zstd L1 w25 - 4.3x compression         327.15   2.9481   4.4555   3.0567   3.0637   4.4555   4.4555   4.4555  ±1.51%       66
   · zstd L3 w23 - 3.9x compression         211.01   4.2229   7.3754   4.7391   4.6954   7.3754   7.3754   7.3754  ±4.53%       43
   · zstd L6 w23 - 3.9x compression        87.5624  11.0267  12.2783  11.4204  11.7067  12.2783  12.2783  12.2783  ±1.56%       18

 ✓ packages/services/usage/__tests__/codec.bench.ts > decompress: huge documents (2.09MB batch) 5471ms
     name                                      hz     min      max    mean     p75     p99     p995     p999     rme  samples
   · gzip L1 - 3.5x compression            345.49  2.6604   4.3610  2.8944  2.9137  4.1882   4.3610   4.3610  ±1.56%      173
   · gzip L6 - 3.5x compression            341.42  2.6806   9.9408  2.9290  2.9053  4.1394   9.9408   9.9408  ±3.12%      171
   · gzip L9 - 3.4x compression            318.24  2.8092   8.1060  3.1423  3.0779  5.7574   8.1060   8.1060  ±2.98%      160
   · zstd L1 w-default - 4.3x compression  560.88  1.5325   3.2947  1.7829  1.7456  3.1635   3.2501   3.2947  ±2.35%      281
   · zstd L1 w21 - 4.3x compression        557.43  1.5422   9.0094  1.7939  1.7253  3.0338   3.2059   9.0094  ±3.61%      279
   · zstd L1 w23 - 4.3x compression        524.93  1.5394  13.3215  1.9050  1.7658  8.7220  10.4360  13.3215  ±6.71%      263
   · zstd L1 w25 - 4.3x compression        545.31  1.5383   8.8164  1.8338  1.7166  8.4282   8.7449   8.8164  ±5.66%      273
   · zstd L3 w23 - 3.9x compression        528.60  1.5461   9.0946  1.8918  1.7712  8.5958   8.6534   9.0946  ±6.30%      265
   · zstd L6 w23 - 3.9x compression        528.99  1.5661  11.7248  1.8904  1.8162  7.3768   8.9015  11.7248  ±5.70%      265

 ✓ packages/services/usage/__tests__/codec.bench.ts > compress: many ops, few docs (2.05MB batch) 2343ms
     name                                         hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · gzip L1 - 13.0x compression              501.54   1.8792   2.1973   1.9939   2.0350   2.1757   2.1973   2.1973  ±0.77%      101
   · gzip L6 - 14.7x compression              132.61   7.1968   8.6506   7.5408   7.6569   8.6506   8.6506   8.6506  ±1.44%       27
   · gzip L9 - 16.5x compression             89.8692  10.9372  11.4650  11.1273  11.2157  11.4650  11.4650  11.4650  ±0.71%       18
   · zstd L1 w-default - 47.3x compression  1,332.04   0.7094   1.0656   0.7507   0.7513   0.9148   0.9184   1.0656  ±0.68%      267
   · zstd L1 w21 - 55.2x compression        1,414.19   0.6549   3.8045   0.7071   0.7067   0.8404   0.9881   3.8045  ±3.11%      283
   · zstd L1 w23 - 55.2x compression        1,454.36   0.6525   0.9172   0.6876   0.6892   0.8521   0.8522   0.9172  ±0.59%      291
   · zstd L1 w25 - 55.2x compression        1,299.57   0.6502   2.1658   0.7695   0.7423   1.9795   2.0687   2.1658  ±3.88%      260
   · zstd L3 w23 - 53.1x compression        1,371.28   0.6862   1.8753   0.7292   0.7386   0.9118   1.0442   1.8753  ±1.36%      275
   · zstd L6 w23 - 54.6x compression          691.77   1.3684   1.7270   1.4456   1.4775   1.6663   1.7270   1.7270  ±0.81%      139

 ✓ packages/services/usage/__tests__/codec.bench.ts > decompress: many ops, few docs (2.05MB batch) 5435ms
     name                                         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · gzip L1 - 13.0x compression            1,076.00  0.7446  2.2854  0.9294  1.0061  2.1436  2.2022  2.2854  ±2.57%      538
   · gzip L6 - 14.7x compression            1,133.39  0.6632  8.1359  0.8823  0.9441  2.2079  2.4728  8.1359  ±4.00%      567
   · gzip L9 - 16.5x compression            1,209.56  0.6320  7.1446  0.8267  0.9079  2.0292  2.0860  7.1446  ±3.66%      605
   · zstd L1 w-default - 47.3x compression  1,499.48  0.3768  6.9552  0.6669  0.7897  6.3643  6.6979  6.9552  ±7.55%      750
   · zstd L1 w21 - 55.2x compression        1,534.82  0.3726  7.2808  0.6515  0.4862  7.2081  7.2575  7.2808  ±9.30%      768
   · zstd L1 w23 - 55.2x compression        1,471.05  0.3774  7.4374  0.6798  0.8241  7.2211  7.3561  7.4374  ±9.44%      736
   · zstd L1 w25 - 55.2x compression        1,568.20  0.3720  7.4060  0.6377  0.4434  7.2532  7.3735  7.4060  ±8.70%      785
   · zstd L3 w23 - 53.1x compression        1,583.29  0.3811  7.5149  0.6316  0.4498  2.6854  7.3134  7.5149  ±7.93%      792
   · zstd L6 w23 - 54.6x compression        1,568.39  0.3697  7.4936  0.6376  0.4317  7.2880  7.3595  7.4936  ±9.13%      786

 ✓ packages/services/usage/__tests__/codec.bench.ts > compress: many docs per report (2.04MB batch) 4126ms
     name                                       hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · gzip L1 - 3.6x compression             130.76   7.6057   7.7183   7.6475   7.6665   7.7183   7.7183   7.7183  ±0.13%       27
   · gzip L6 - 3.6x compression            37.6913  25.7479  27.7268  26.5313  26.8887  27.7268  27.7268  27.7268  ±1.89%       10
   · gzip L9 - 3.6x compression             9.3474   106.70   107.08   106.98   107.04   107.08   107.08   107.08  ±0.07%       10
   · zstd L1 w-default - 5.0x compression   373.90   2.6022   4.0422   2.6745   2.6514   4.0422   4.0422   4.0422  ±1.49%       75
   · zstd L1 w21 - 5.0x compression         403.95   2.4348   3.6588   2.4756   2.4620   3.6588   3.6588   3.6588  ±1.22%       81
   · zstd L1 w23 - 5.0x compression         405.29   2.4196   3.5829   2.4674   2.4538   3.5829   3.5829   3.5829  ±1.13%       82
   · zstd L1 w25 - 5.0x compression         395.39   2.3951   6.2915   2.5292   2.4860   6.2915   6.2915   6.2915  ±3.92%       80
   · zstd L3 w23 - 5.1x compression         311.59   3.1195   3.5459   3.2094   3.2193   3.5459   3.5459   3.5459  ±0.68%       63
   · zstd L6 w23 - 5.2x compression         113.69   8.7150   8.8603   8.7960   8.8283   8.8603   8.8603   8.8603  ±0.20%       23

 ✓ packages/services/usage/__tests__/codec.bench.ts > decompress: many docs per report (2.04MB batch) 5473ms
     name                                      hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · gzip L1 - 3.6x compression            380.44  2.4642  3.9394  2.6285  2.6508  3.8619  3.9394  3.9394  ±1.61%      191
   · gzip L6 - 3.6x compression            381.37  2.4810  4.0126  2.6222  2.6421  3.8720  4.0126  4.0126  ±1.56%      192
   · gzip L9 - 3.6x compression            372.97  2.5338  3.9320  2.6812  2.6604  3.8724  3.9320  3.9320  ±1.50%      187
   · zstd L1 w-default - 5.0x compression  653.82  1.3046  7.8763  1.5295  1.4363  2.8818  2.9002  7.8763  ±3.54%      327
   · zstd L1 w21 - 5.0x compression        657.78  1.3036  8.1654  1.5203  1.3723  2.6066  2.7585  8.1654  ±3.48%      329
   · zstd L1 w23 - 5.0x compression        659.03  1.3074  3.1553  1.5174  1.4314  2.7097  2.7320  3.1553  ±2.48%      330
   · zstd L1 w25 - 5.0x compression        637.15  1.3045  8.1275  1.5695  1.3740  8.0047  8.1085  8.1275  ±5.61%      319
   · zstd L3 w23 - 5.1x compression        678.06  1.2407  8.1426  1.4748  1.3108  7.9284  8.0326  8.1426  ±5.60%      340
   · zstd L6 w23 - 5.2x compression        667.10  1.2380  8.1393  1.4990  1.3391  8.0863  8.1330  8.1393  ±6.11%      337

 ✓ packages/services/usage/__tests__/codec.bench.ts > compress: high target count (2.00MB batch) 2767ms
     name                                       hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · gzip L1 - 6.3x compression             257.27   3.8337   4.9352   3.8869   3.8724   4.9352   4.9352   4.9352  ±1.07%       52
   · gzip L6 - 6.3x compression            67.3475  14.7134  15.0337  14.8484  14.8900  15.0337  15.0337  15.0337  ±0.32%       14
   · gzip L9 - 6.3x compression            27.1977  36.7146  36.9265  36.7678  36.7627  36.9265  36.9265  36.9265  ±0.13%       10
   · zstd L1 w-default - 8.4x compression   534.01   1.8179   3.0561   1.8726   1.8547   2.9230   3.0561   3.0561  ±1.62%      107
   · zstd L1 w21 - 8.4x compression         573.75   1.6550   3.1009   1.7429   1.7233   2.4780   3.1009   3.1009  ±1.84%      115
   · zstd L1 w23 - 8.4x compression         591.23   1.6598   1.9558   1.6914   1.6912   1.7953   1.9558   1.9558  ±0.31%      119
   · zstd L1 w25 - 8.4x compression         584.06   1.6590   2.7753   1.7121   1.7035   1.9718   2.7753   2.7753  ±1.14%      117
   · zstd L3 w23 - 7.6x compression         455.46   2.1175   2.5380   2.1956   2.2080   2.5380   2.5380   2.5380  ±0.76%       92
   · zstd L6 w23 - 7.7x compression         171.41   5.8063   5.8848   5.8341   5.8516   5.8848   5.8848   5.8848  ±0.14%       35

 ✓ packages/services/usage/__tests__/codec.bench.ts > decompress: high target count (2.00MB batch) 5454ms
     name                                      hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · gzip L1 - 6.3x compression            633.14  1.4449  2.7332  1.5794  1.6089  2.6614  2.6946  2.7332  ±1.76%      317
   · gzip L6 - 6.3x compression            625.27  1.4273  7.3838  1.5993  1.6508  2.7411  3.1145  7.3838  ±2.88%      313
   · gzip L9 - 6.3x compression            616.67  1.4533  2.9760  1.6216  1.6819  2.8288  2.9052  2.9760  ±1.85%      309
   · zstd L1 w-default - 8.4x compression  907.33  0.8746  7.9311  1.1021  1.0056  2.4847  2.6448  7.9311  ±4.66%      455
   · zstd L1 w21 - 8.4x compression        883.02  0.8718  8.1141  1.1325  0.9707  7.8907  8.0498  8.1141  ±6.62%      442
   · zstd L1 w23 - 8.4x compression        902.75  0.8753  8.0217  1.1077  0.9877  2.5338  7.6770  8.0217  ±5.30%      452
   · zstd L1 w25 - 8.4x compression        888.44  0.8811  7.9073  1.1256  0.9950  4.3355  7.8243  7.9073  ±6.01%      445
   · zstd L3 w23 - 7.6x compression        814.96  0.8968  9.8259  1.2271  0.9778  8.1091  8.2310  9.8259  ±8.58%      408
   · zstd L6 w23 - 7.7x compression        869.88  0.8902  8.1019  1.1496  0.9760  2.6007  7.9816  8.1019  ±5.65%      435

 ✓ packages/services/usage/__tests__/codec.bench.ts > compress: large client batches (2.02MB batch) 3257ms
     name                                        hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · gzip L1 - 6.8x compression              252.73   3.9075   4.0721   3.9568   3.9756   4.0721   4.0721   4.0721  ±0.25%       51
   · gzip L6 - 6.6x compression             63.1361  15.3338  19.2007  15.8388  15.4452  19.2007  19.2007  19.2007  ±4.16%       13
   · gzip L9 - 6.7x compression             15.1978  64.6509  67.6542  65.7991  66.2810  67.6542  67.6542  67.6542  ±0.96%       10
   · zstd L1 w-default - 10.3x compression   522.68   1.8595   2.5110   1.9132   1.9152   1.9974   2.5110   2.5110  ±0.65%      105
   · zstd L1 w21 - 10.9x compression         666.27   1.4750   2.5990   1.5009   1.4929   1.6678   2.5990   2.5990  ±1.11%      134
   · zstd L1 w23 - 10.9x compression         669.76   1.4590   1.5769   1.4931   1.4950   1.5690   1.5769   1.5769  ±0.22%      134
   · zstd L1 w25 - 10.9x compression         669.43   1.4760   1.6045   1.4938   1.4929   1.5825   1.6045   1.6045  ±0.26%      134
   · zstd L3 w23 - 10.1x compression         542.69   1.8010   1.9189   1.8427   1.8470   1.9020   1.9189   1.9189  ±0.17%      109
   · zstd L6 w23 - 10.2x compression         181.68   5.3518   6.7724   5.5041   5.4801   6.7724   6.7724   6.7724  ±1.63%       37

 ✓ packages/services/usage/__tests__/codec.bench.ts > decompress: large client batches (2.02MB batch) 5449ms
     name                                       hz     min      max    mean     p75     p99    p995     p999     rme  samples
   · gzip L1 - 6.8x compression             643.00  1.3766   2.7615  1.5552  1.5860  2.6551  2.6884   2.7615  ±1.88%      322
   · gzip L6 - 6.6x compression             642.53  1.3935   2.8833  1.5564  1.6120  2.7441  2.7770   2.8833  ±1.90%      322
   · gzip L9 - 6.7x compression             628.44  1.4066   8.1353  1.5913  1.6253  2.7035  2.7420   8.1353  ±3.16%      315
   · zstd L1 w-default - 10.3x compression  886.39  0.8682  12.8910  1.1282  0.9852  7.4532  7.6058  12.8910  ±7.33%      449
   · zstd L1 w21 - 10.9x compression        994.97  0.7847   2.5519  1.0051  1.0308  2.3106  2.3591   2.5519  ±2.98%      498
   · zstd L1 w23 - 10.9x compression        991.77  0.7928   7.7131  1.0083  1.0222  2.4102  2.5444   7.7131  ±4.76%      496
   · zstd L1 w25 - 10.9x compression        942.91  0.7939   7.6889  1.0605  0.8769  7.4079  7.6718   7.6889  ±7.35%      472
   · zstd L3 w23 - 10.1x compression        971.87  0.8004   7.5580  1.0289  1.0230  2.4794  2.5442   7.5580  ±4.73%      486
   · zstd L6 w23 - 10.2x compression        943.74  0.8262   7.4615  1.0596  1.0701  2.3575  2.4163   7.4615  ±4.03%      472

 ✓ packages/services/usage/__tests__/codec.bench.ts > compress: federated (4 subgraphs) (2.01MB batch) 2678ms
     name                                       hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · gzip L1 - 7.5x compression             302.62   3.2573   3.6267   3.3045   3.3134   3.6267   3.6267   3.6267  ±0.47%       61
   · gzip L6 - 8.2x compression            80.1073  12.4275  12.5768  12.4833  12.5108  12.5768  12.5768  12.5768  ±0.20%       17
   · gzip L9 - 8.2x compression            30.9768  31.1351  34.9821  32.2822  32.5485  34.9821  34.9821  34.9821  ±3.13%       10
   · zstd L1 w-default - 9.5x compression   492.85   1.9519   2.5220   2.0290   2.0454   2.5220   2.5220   2.5220  ±0.87%       99
   · zstd L1 w21 - 9.5x compression         548.08   1.7480   3.1362   1.8246   1.8120   3.0664   3.1362   3.1362  ±1.97%      110
   · zstd L1 w23 - 9.5x compression         538.59   1.7271   2.6774   1.8567   1.9025   2.5726   2.6774   2.6774  ±1.46%      108
   · zstd L1 w25 - 9.5x compression         565.93   1.7455   2.8148   1.7670   1.7555   1.9967   2.8148   2.8148  ±1.09%      114
   · zstd L3 w23 - 9.2x compression         496.80   2.0087   2.0321   2.0129   2.0130   2.0316   2.0321   2.0321  ±0.04%      100
   · zstd L6 w23 - 10.0x compression        181.48   5.3475   7.2200   5.5101   5.4986   7.2200   7.2200   7.2200  ±1.90%       37

 ✓ packages/services/usage/__tests__/codec.bench.ts > decompress: federated (4 subgraphs) (2.01MB batch) 5453ms
     name                                      hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · gzip L1 - 7.5x compression            710.47  1.2508  2.7496  1.4075  1.4351  2.5818  2.6466  2.7496  ±1.95%      357
   · gzip L6 - 8.2x compression            747.55  1.1682  8.0416  1.3377  1.3571  2.5477  2.5531  8.0416  ±3.36%      374
   · gzip L9 - 8.2x compression            749.20  1.1841  2.7776  1.3348  1.3742  2.5207  2.6361  2.7776  ±2.10%      375
   · zstd L1 w-default - 9.5x compression  866.78  0.9472  7.6743  1.1537  1.0124  2.4138  2.6002  7.6743  ±3.86%      434
   · zstd L1 w21 - 9.5x compression        851.79  0.9484  8.0031  1.1740  0.9962  2.6097  7.7366  8.0031  ±5.39%      426
   · zstd L1 w23 - 9.5x compression        829.81  0.9529  8.0095  1.2051  1.0213  2.8330  7.8317  8.0095  ±6.01%      415
   · zstd L1 w25 - 9.5x compression        828.66  0.9464  8.1076  1.2068  0.9860  7.8914  7.9180  8.1076  ±7.38%      419
   · zstd L3 w23 - 9.2x compression        830.71  0.9317  8.0469  1.2038  0.9757  7.8705  7.9107  8.0469  ±7.46%      416
   · zstd L6 w23 - 10.0x compression       959.38  0.8353  7.8684  1.0423  0.8885  2.4626  2.6090  7.8684  ±4.81%      480

 ✓ packages/services/usage/__tests__/codec.bench.ts > as production compresses it 558ms
     name                                      hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · compressZstd()                        436.32   1.9446   8.6645   2.2919   2.1886   8.6645   8.6645   8.6645  ±7.71%       88
   · compressGzip() - compression before  49.9431  19.7568  21.3308  20.0228  19.9680  21.3308  21.3308  21.3308  ±1.66%       10

 BENCH  Summary

  zstd L1 w21 - 111.9x compression - packages/services/usage/__tests__/codec.bench.ts > compress: tiny, heavy reuse (2.00MB batch)
    1.01x faster than zstd L1 w23 - 111.9x compression
    1.02x faster than zstd L1 w25 - 111.9x compression
    1.15x faster than zstd L1 w-default - 89.3x compression
    1.49x faster than zstd L3 w23 - 84.8x compression
    3.22x faster than zstd L6 w23 - 108.6x compression
    5.66x faster than gzip L1 - 21.8x compression
    15.66x faster than gzip L9 - 60.2x compression
    15.73x faster than gzip L6 - 51.4x compression

  zstd L1 w21 - 111.9x compression - packages/services/usage/__tests__/codec.bench.ts > decompress: tiny, heavy reuse (2.00MB batch)
    1.00x faster than zstd L1 w25 - 111.9x compression
    1.02x faster than zstd L1 w-default - 89.3x compression
    1.06x faster than zstd L1 w23 - 111.9x compression
    1.08x faster than zstd L6 w23 - 108.6x compression
    1.11x faster than zstd L3 w23 - 84.8x compression
    1.20x faster than gzip L6 - 51.4x compression
    1.20x faster than gzip L9 - 60.2x compression
    1.62x faster than gzip L1 - 21.8x compression

  zstd L1 w25 - 9.7x compression - packages/services/usage/__tests__/codec.bench.ts > compress: production typical (2.01MB batch)
    1.01x faster than zstd L1 w23 - 9.7x compression
    1.02x faster than zstd L1 w21 - 9.7x compression
    1.10x faster than zstd L3 w23 - 11.6x compression
    1.58x faster than zstd L1 w-default - 6.4x compression
    2.82x faster than zstd L6 w23 - 11.7x compression
    3.47x faster than gzip L1 - 5.0x compression
    13.31x faster than gzip L6 - 4.9x compression
    44.14x faster than gzip L9 - 4.8x compression

  zstd L6 w23 - 11.7x compression - packages/services/usage/__tests__/codec.bench.ts > decompress: production typical (2.01MB batch)
    1.03x faster than zstd L3 w23 - 11.6x compression
    1.14x faster than zstd L1 w21 - 9.7x compression
    1.27x faster than zstd L1 w25 - 9.7x compression
    1.33x faster than zstd L1 w23 - 9.7x compression
    1.49x faster than zstd L1 w-default - 6.4x compression
    2.27x faster than gzip L6 - 4.9x compression
    2.29x faster than gzip L9 - 4.8x compression
    2.94x faster than gzip L1 - 5.0x compression

  zstd L1 w25 - 6.4x compression - packages/services/usage/__tests__/codec.bench.ts > compress: typical, low reuse (2.01MB batch)
    1.02x faster than zstd L1 w23 - 6.4x compression
    1.03x faster than zstd L1 w21 - 6.4x compression
    1.10x faster than zstd L1 w-default - 6.4x compression
    1.38x faster than zstd L3 w23 - 5.8x compression
    2.40x faster than gzip L1 - 5.0x compression
    3.69x faster than zstd L6 w23 - 5.9x compression
    9.13x faster than gzip L6 - 4.9x compression
    30.21x faster than gzip L9 - 4.8x compression

  zstd L1 w23 - 6.4x compression - packages/services/usage/__tests__/codec.bench.ts > decompress: typical, low reuse (2.01MB batch)
    1.01x faster than zstd L1 w25 - 6.4x compression
    1.02x faster than zstd L6 w23 - 5.9x compression
    1.02x faster than zstd L1 w21 - 6.4x compression
    1.03x faster than zstd L1 w-default - 6.4x compression
    1.04x faster than zstd L3 w23 - 5.8x compression
    1.54x faster than gzip L1 - 5.0x compression
    1.54x faster than gzip L6 - 4.9x compression
    1.58x faster than gzip L9 - 4.8x compression

  zstd L1 w23 - 154.3x compression - packages/services/usage/__tests__/codec.bench.ts > compress: single target (2.01MB batch)
    1.01x faster than zstd L1 w25 - 154.3x compression
    1.01x faster than zstd L1 w21 - 154.3x compression
    1.02x faster than zstd L1 w-default - 154.3x compression
    1.66x faster than zstd L3 w23 - 140.6x compression
    2.62x faster than zstd L6 w23 - 185.5x compression
    14.29x faster than gzip L1 - 6.5x compression
    57.14x faster than gzip L6 - 6.9x compression
    175.39x faster than gzip L9 - 6.8x compression

  zstd L1 w25 - 154.3x compression - packages/services/usage/__tests__/codec.bench.ts > decompress: single target (2.01MB batch)
    1.03x faster than zstd L1 w-default - 154.3x compression
    1.03x faster than zstd L3 w23 - 140.6x compression
    1.04x faster than zstd L1 w23 - 154.3x compression
    1.06x faster than zstd L1 w21 - 154.3x compression
    1.17x faster than zstd L6 w23 - 185.5x compression
    2.83x faster than gzip L6 - 6.9x compression
    2.85x faster than gzip L9 - 6.8x compression
    3.34x faster than gzip L1 - 6.5x compression

  zstd L1 w25 - 4.5x compression - packages/services/usage/__tests__/codec.bench.ts > compress: wide field lists (2.05MB batch)
    1.00x faster than zstd L1 w23 - 4.5x compression
    1.01x faster than zstd L1 w21 - 4.5x compression
    1.07x faster than zstd L1 w-default - 4.5x compression
    1.46x faster than zstd L3 w23 - 4.1x compression
    2.64x faster than gzip L1 - 3.6x compression
    3.89x faster than zstd L6 w23 - 4.1x compression
    10.11x faster than gzip L6 - 3.6x compression
    59.65x faster than gzip L9 - 3.5x compression

  zstd L1 w21 - 4.5x compression - packages/services/usage/__tests__/codec.bench.ts > decompress: wide field lists (2.05MB batch)
    1.02x faster than zstd L1 w23 - 4.5x compression
    1.02x faster than zstd L1 w25 - 4.5x compression
    1.04x faster than zstd L1 w-default - 4.5x compression
    1.07x faster than zstd L3 w23 - 4.1x compression
    1.08x faster than zstd L6 w23 - 4.1x compression
    1.63x faster than gzip L6 - 3.6x compression
    1.67x faster than gzip L1 - 3.6x compression
    1.69x faster than gzip L9 - 3.5x compression

  zstd L1 w25 - 4.3x compression - packages/services/usage/__tests__/codec.bench.ts > compress: huge documents (2.09MB batch)
    1.04x faster than zstd L1 w21 - 4.3x compression
    1.07x faster than zstd L1 w23 - 4.3x compression
    1.11x faster than zstd L1 w-default - 4.3x compression
    1.55x faster than zstd L3 w23 - 3.9x compression
    2.58x faster than gzip L1 - 3.5x compression
    3.74x faster than zstd L6 w23 - 3.9x compression
    10.06x faster than gzip L6 - 3.5x compression
    67.27x faster than gzip L9 - 3.4x compression

  zstd L1 w-default - 4.3x compression - packages/services/usage/__tests__/codec.bench.ts > decompress: huge documents (2.09MB batch)
    1.01x faster than zstd L1 w21 - 4.3x compression
    1.03x faster than zstd L1 w25 - 4.3x compression
    1.06x faster than zstd L6 w23 - 3.9x compression
    1.06x faster than zstd L3 w23 - 3.9x compression
    1.07x faster than zstd L1 w23 - 4.3x compression
    1.62x faster than gzip L1 - 3.5x compression
    1.64x faster than gzip L6 - 3.5x compression
    1.76x faster than gzip L9 - 3.4x compression

  zstd L1 w23 - 55.2x compression - packages/services/usage/__tests__/codec.bench.ts > compress: many ops, few docs (2.05MB batch)
    1.03x faster than zstd L1 w21 - 55.2x compression
    1.06x faster than zstd L3 w23 - 53.1x compression
    1.09x faster than zstd L1 w-default - 47.3x compression
    1.12x faster than zstd L1 w25 - 55.2x compression
    2.10x faster than zstd L6 w23 - 54.6x compression
    2.90x faster than gzip L1 - 13.0x compression
    10.97x faster than gzip L6 - 14.7x compression
    16.18x faster than gzip L9 - 16.5x compression

  zstd L3 w23 - 53.1x compression - packages/services/usage/__tests__/codec.bench.ts > decompress: many ops, few docs (2.05MB batch)
    1.01x faster than zstd L6 w23 - 54.6x compression
    1.01x faster than zstd L1 w25 - 55.2x compression
    1.03x faster than zstd L1 w21 - 55.2x compression
    1.06x faster than zstd L1 w-default - 47.3x compression
    1.08x faster than zstd L1 w23 - 55.2x compression
    1.31x faster than gzip L9 - 16.5x compression
    1.40x faster than gzip L6 - 14.7x compression
    1.47x faster than gzip L1 - 13.0x compression

  zstd L1 w23 - 5.0x compression - packages/services/usage/__tests__/codec.bench.ts > compress: many docs per report (2.04MB batch)
    1.00x faster than zstd L1 w21 - 5.0x compression
    1.03x faster than zstd L1 w25 - 5.0x compression
    1.08x faster than zstd L1 w-default - 5.0x compression
    1.30x faster than zstd L3 w23 - 5.1x compression
    3.10x faster than gzip L1 - 3.6x compression
    3.56x faster than zstd L6 w23 - 5.2x compression
    10.75x faster than gzip L6 - 3.6x compression
    43.36x faster than gzip L9 - 3.6x compression

  zstd L3 w23 - 5.1x compression - packages/services/usage/__tests__/codec.bench.ts > decompress: many docs per report (2.04MB batch)
    1.02x faster than zstd L6 w23 - 5.2x compression
    1.03x faster than zstd L1 w23 - 5.0x compression
    1.03x faster than zstd L1 w21 - 5.0x compression
    1.04x faster than zstd L1 w-default - 5.0x compression
    1.06x faster than zstd L1 w25 - 5.0x compression
    1.78x faster than gzip L6 - 3.6x compression
    1.78x faster than gzip L1 - 3.6x compression
    1.82x faster than gzip L9 - 3.6x compression

  zstd L1 w23 - 8.4x compression - packages/services/usage/__tests__/codec.bench.ts > compress: high target count (2.00MB batch)
    1.01x faster than zstd L1 w25 - 8.4x compression
    1.03x faster than zstd L1 w21 - 8.4x compression
    1.11x faster than zstd L1 w-default - 8.4x compression
    1.30x faster than zstd L3 w23 - 7.6x compression
    2.30x faster than gzip L1 - 6.3x compression
    3.45x faster than zstd L6 w23 - 7.7x compression
    8.78x faster than gzip L6 - 6.3x compression
    21.74x faster than gzip L9 - 6.3x compression

  zstd L1 w-default - 8.4x compression - packages/services/usage/__tests__/codec.bench.ts > decompress: high target count (2.00MB batch)
    1.01x faster than zstd L1 w23 - 8.4x compression
    1.02x faster than zstd L1 w25 - 8.4x compression
    1.03x faster than zstd L1 w21 - 8.4x compression
    1.04x faster than zstd L6 w23 - 7.7x compression
    1.11x faster than zstd L3 w23 - 7.6x compression
    1.43x faster than gzip L1 - 6.3x compression
    1.45x faster than gzip L6 - 6.3x compression
    1.47x faster than gzip L9 - 6.3x compression

  zstd L1 w23 - 10.9x compression - packages/services/usage/__tests__/codec.bench.ts > compress: large client batches (2.02MB batch)
    1.00x faster than zstd L1 w25 - 10.9x compression
    1.01x faster than zstd L1 w21 - 10.9x compression
    1.23x faster than zstd L3 w23 - 10.1x compression
    1.28x faster than zstd L1 w-default - 10.3x compression
    2.65x faster than gzip L1 - 6.8x compression
    3.69x faster than zstd L6 w23 - 10.2x compression
    10.61x faster than gzip L6 - 6.6x compression
    44.07x faster than gzip L9 - 6.7x compression

  zstd L1 w21 - 10.9x compression - packages/services/usage/__tests__/codec.bench.ts > decompress: large client batches (2.02MB batch)
    1.00x faster than zstd L1 w23 - 10.9x compression
    1.02x faster than zstd L3 w23 - 10.1x compression
    1.05x faster than zstd L6 w23 - 10.2x compression
    1.06x faster than zstd L1 w25 - 10.9x compression
    1.12x faster than zstd L1 w-default - 10.3x compression
    1.55x faster than gzip L1 - 6.8x compression
    1.55x faster than gzip L6 - 6.6x compression
    1.58x faster than gzip L9 - 6.7x compression

  zstd L1 w25 - 9.5x compression - packages/services/usage/__tests__/codec.bench.ts > compress: federated (4 subgraphs) (2.01MB batch)
    1.03x faster than zstd L1 w21 - 9.5x compression
    1.05x faster than zstd L1 w23 - 9.5x compression
    1.14x faster than zstd L3 w23 - 9.2x compression
    1.15x faster than zstd L1 w-default - 9.5x compression
    1.87x faster than gzip L1 - 7.5x compression
    3.12x faster than zstd L6 w23 - 10.0x compression
    7.06x faster than gzip L6 - 8.2x compression
    18.27x faster than gzip L9 - 8.2x compression

  zstd L6 w23 - 10.0x compression - packages/services/usage/__tests__/codec.bench.ts > decompress: federated (4 subgraphs) (2.01MB batch)
    1.11x faster than zstd L1 w-default - 9.5x compression
    1.13x faster than zstd L1 w21 - 9.5x compression
    1.15x faster than zstd L3 w23 - 9.2x compression
    1.16x faster than zstd L1 w23 - 9.5x compression
    1.16x faster than zstd L1 w25 - 9.5x compression
    1.28x faster than gzip L9 - 8.2x compression
    1.28x faster than gzip L6 - 8.2x compression
    1.35x faster than gzip L1 - 7.5x compression

  compressZstd() - packages/services/usage/__tests__/codec.bench.ts > as production compresses it
    8.74x faster than compressGzip() - compression before
```
</details>