### PR TITLE
feat: expose schema check, publish and promotion sources as prometheus metrics

### DIFF
--- a/deployment/grafana-dashboards/Registry-Operations.json
+++ b/deployment/grafana-dashboards/Registry-Operations.json
@@ -1,0 +1,824 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Volume, unexpected-error rate, and error sources for schema registry and app deployment operations. Expected domain errors such as invalid input or authorization failures are counted as successful handling; failures represent unexpected errors.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROM_DATASOURCE_UID"
+      },
+      "description": "Completed schema registry operations split by action.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"check\"}[$__range])) or vector(0)",
+          "instant": true,
+          "legendFormat": "Check",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"publish\"}[$__range])) or vector(0)",
+          "instant": true,
+          "legendFormat": "Publish",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"delete\"}[$__range])) or vector(0)",
+          "instant": true,
+          "legendFormat": "Delete",
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"promotion\"}[$__range])) or vector(0)",
+          "instant": true,
+          "legendFormat": "Promotion",
+          "range": false,
+          "refId": "D"
+        }
+      ],
+      "title": "Schema Registry operations",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROM_DATASOURCE_UID"
+      },
+      "description": "Completed app deployment operations split by action.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"app_deployment_create\"}[$__range])) or vector(0)",
+          "instant": true,
+          "legendFormat": "Create",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"persisted_document_upload\"}[$__range])) or vector(0)",
+          "instant": true,
+          "legendFormat": "Document upload",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"app_deployment_publish\"}[$__range])) or vector(0)",
+          "instant": true,
+          "legendFormat": "Publish",
+          "range": false,
+          "refId": "C"
+        }
+      ],
+      "title": "App Deployment operations",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROM_DATASOURCE_UID"
+      },
+      "description": "Percentage of completed operations that ended in an unexpected error.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "0%",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "100 * (sum(increase(registry_operation_outcome_count{conclusion=\"failure\"}[$__range])) or vector(0)) / clamp_min(sum(increase(registry_operation_outcome_count[$__range])) or vector(0), 1)",
+          "instant": true,
+          "legendFormat": "Unexpected error rate",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Unexpected error rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROM_DATASOURCE_UID"
+      },
+      "description": "Amount of completed actions.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 14,
+        "x": 0,
+        "y": 7
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["sum", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"check\"}[$__rate_interval]))",
+          "legendFormat": "Check",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"publish\"}[$__rate_interval]))",
+          "legendFormat": "Publish",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"delete\"}[$__rate_interval]))",
+          "legendFormat": "Delete",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"promotion\"}[$__rate_interval]))",
+          "legendFormat": "Promotion",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"app_deployment_create\"}[$__rate_interval]))",
+          "legendFormat": "Deployment create",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"persisted_document_upload\"}[$__rate_interval]))",
+          "legendFormat": "Document upload",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(registry_operation_outcome_count{operation=\"app_deployment_publish\"}[$__rate_interval]))",
+          "legendFormat": "Deployment publish",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "title": "Operations over time by action",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROM_DATASOURCE_UID"
+      },
+      "description": "Unexpected failures as a percentage of completed operations for each action in each chart interval. Expected domain errors are not failures.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "min": 0,
+          "noValue": "0%",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 10,
+        "x": 14,
+        "y": 7
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum(increase(registry_operation_outcome_count{operation=\"check\", conclusion=\"failure\"}[$__rate_interval])) / clamp_min(sum(increase(registry_operation_outcome_count{operation=\"check\"}[$__rate_interval])), 1e-9)",
+          "legendFormat": "Check",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum(increase(registry_operation_outcome_count{operation=\"publish\", conclusion=\"failure\"}[$__rate_interval])) / clamp_min(sum(increase(registry_operation_outcome_count{operation=\"publish\"}[$__rate_interval])), 1e-9)",
+          "legendFormat": "Publish",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum(increase(registry_operation_outcome_count{operation=\"delete\", conclusion=\"failure\"}[$__rate_interval])) / clamp_min(sum(increase(registry_operation_outcome_count{operation=\"delete\"}[$__rate_interval])), 1e-9)",
+          "legendFormat": "Delete",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum(increase(registry_operation_outcome_count{operation=\"promotion\", conclusion=\"failure\"}[$__rate_interval])) / clamp_min(sum(increase(registry_operation_outcome_count{operation=\"promotion\"}[$__rate_interval])), 1e-9)",
+          "legendFormat": "Promotion",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum(increase(registry_operation_outcome_count{operation=\"app_deployment_create\", conclusion=\"failure\"}[$__rate_interval])) / clamp_min(sum(increase(registry_operation_outcome_count{operation=\"app_deployment_create\"}[$__rate_interval])), 1e-9)",
+          "legendFormat": "Deployment create",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum(increase(registry_operation_outcome_count{operation=\"persisted_document_upload\", conclusion=\"failure\"}[$__rate_interval])) / clamp_min(sum(increase(registry_operation_outcome_count{operation=\"persisted_document_upload\"}[$__rate_interval])), 1e-9)",
+          "legendFormat": "Document upload",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum(increase(registry_operation_outcome_count{operation=\"app_deployment_publish\", conclusion=\"failure\"}[$__rate_interval])) / clamp_min(sum(increase(registry_operation_outcome_count{operation=\"app_deployment_publish\"}[$__rate_interval])), 1e-9)",
+          "legendFormat": "Deployment publish",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "title": "Unexpected error rate by action",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROM_DATASOURCE_UID"
+      },
+      "description": "Unexpected errors grouped by operation and error source.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 70,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "0",
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 15,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum by (source) (rate(registry_operation_unexpected_error_count{operation=\"check\"}[$__rate_interval])) * $__interval_s",
+          "legendFormat": "Check / {{source}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum by (source) (rate(registry_operation_unexpected_error_count{operation=\"publish\"}[$__rate_interval])) * $__interval_s",
+          "legendFormat": "Publish / {{source}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum by (source) (rate(registry_operation_unexpected_error_count{operation=\"delete\"}[$__rate_interval])) * $__interval_s",
+          "legendFormat": "Delete / {{source}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum by (source) (rate(registry_operation_unexpected_error_count{operation=\"promotion\"}[$__rate_interval])) * $__interval_s",
+          "legendFormat": "Promotion / {{source}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum by (source) (rate(registry_operation_unexpected_error_count{operation=\"app_deployment_create\"}[$__rate_interval])) * $__interval_s",
+          "legendFormat": "Deployment create / {{source}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum by (source) (rate(registry_operation_unexpected_error_count{operation=\"persisted_document_upload\"}[$__rate_interval])) * $__interval_s",
+          "legendFormat": "Document upload / {{source}}",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum by (source) (rate(registry_operation_unexpected_error_count{operation=\"app_deployment_publish\"}[$__rate_interval])) * $__interval_s",
+          "legendFormat": "Deployment publish / {{source}}",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "title": "Unexpected errors over time by source",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROM_DATASOURCE_UID"
+      },
+      "description": "Overall share of unexpected errors by source.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "No errors",
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 15,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "displayLabels": ["name", "percent"],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": ["value", "percent"]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PROM_DATASOURCE_UID"
+          },
+          "editorMode": "code",
+          "expr": "sum by (source) (increase(registry_operation_unexpected_error_count[$__range] offset $__rate_interval)) + sum by (source) (increase(registry_operation_unexpected_error_count[$__rate_interval]))",
+          "instant": true,
+          "legendFormat": "{{source}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Unexpected errors by source",
+      "type": "piechart"
+    }
+  ],
+  "refresh": "30s",
+  "revision": 1,
+  "schemaVersion": 38,
+  "tags": ["hive", "api", "schema-registry", "app-deployments"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "API Operations",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/configs/prometheus/prometheus.yml
+++ b/docker/configs/prometheus/prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: 15s
+  scrape_interval: 5s
 
 scrape_configs:
   - job_name: 'otel-collector'

--- a/packages/internal/postgres/package.json
+++ b/packages/internal/postgres/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
+    "@hive/service-common": "workspace:*",
     "@standard-schema/spec": "1.0.0",
     "slonik": "48.13.2",
     "slonik-interceptor-query-logging": "48.13.2",
@@ -14,7 +15,6 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
-    "@hive/service-common": "workspace:*",
     "vitest": "4.1.3"
   }
 }

--- a/packages/internal/postgres/package.json
+++ b/packages/internal/postgres/package.json
@@ -7,7 +7,6 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@hive/service-common": "workspace:*",
     "@standard-schema/spec": "1.0.0",
     "slonik": "48.13.2",
     "slonik-interceptor-query-logging": "48.13.2",
@@ -15,6 +14,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "@hive/service-common": "workspace:*",
     "vitest": "4.1.3"
   }
 }

--- a/packages/internal/postgres/src/postgres-database-pool.ts
+++ b/packages/internal/postgres/src/postgres-database-pool.ts
@@ -9,7 +9,7 @@ import {
   type CommonQueryMethods as SlonikCommonQueryMethods,
 } from 'slonik';
 import { createQueryLoggingInterceptor } from 'slonik-interceptor-query-logging';
-import { context, SpanKind, SpanStatusCode, trace } from '@hive/service-common';
+import { context, SpanKind, SpanStatusCode, trace, withErrorSource } from '@hive/service-common';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import {
   createConnectionString,
@@ -72,46 +72,46 @@ export class PostgresDatabasePool implements CommonQueryMethods {
     sql: QuerySqlToken<T>,
     values?: PrimitiveValueExpression[],
   ): Promise<boolean> {
-    return this.pool.exists(sql, values);
+    return withErrorSource(this.pool.exists(sql, values), 'pg');
   }
 
   async any<T extends StandardSchemaV1>(
     sql: QuerySqlToken<T>,
     values?: PrimitiveValueExpression[],
   ): Promise<ReadonlyArray<StandardSchemaV1.InferOutput<T>>> {
-    return this.pool.any(sql, values);
+    return withErrorSource(this.pool.any(sql, values), 'pg');
   }
 
   async maybeOne<T extends StandardSchemaV1>(
     sql: QuerySqlToken<T>,
     values?: PrimitiveValueExpression[],
   ): Promise<null | StandardSchemaV1.InferOutput<T>> {
-    return this.pool.maybeOne(sql, values);
+    return withErrorSource(this.pool.maybeOne(sql, values), 'pg');
   }
 
   async query(sql: QuerySqlToken<any>, values?: PrimitiveValueExpression[]): Promise<void> {
-    await this.pool.query(sql, values);
+    await withErrorSource(this.pool.query(sql, values), 'pg');
   }
 
   async oneFirst<T extends StandardSchemaV1>(
     sql: QuerySqlToken<T>,
     values?: PrimitiveValueExpression[],
   ): Promise<StandardSchemaV1.InferOutput<T>[keyof StandardSchemaV1.InferOutput<T>]> {
-    return await this.pool.oneFirst(sql, values);
+    return await withErrorSource(this.pool.oneFirst(sql, values), 'pg');
   }
 
   async maybeOneFirst<T extends StandardSchemaV1>(
     sql: QuerySqlToken<T>,
     values?: PrimitiveValueExpression[],
   ): Promise<null | StandardSchemaV1.InferOutput<T>[keyof StandardSchemaV1.InferOutput<T>]> {
-    return await this.pool.maybeOneFirst(sql, values);
+    return await withErrorSource(this.pool.maybeOneFirst(sql, values), 'pg');
   }
 
   async one<T extends StandardSchemaV1>(
     sql: QuerySqlToken<T>,
     values?: PrimitiveValueExpression[],
   ): Promise<StandardSchemaV1.InferOutput<T>> {
-    return await this.pool.one(sql, values);
+    return await withErrorSource(this.pool.one(sql, values), 'pg');
   }
 
   async anyFirst<T extends StandardSchemaV1>(
@@ -120,7 +120,7 @@ export class PostgresDatabasePool implements CommonQueryMethods {
   ): Promise<
     ReadonlyArray<StandardSchemaV1.InferOutput<T>[keyof StandardSchemaV1.InferOutput<T>]>
   > {
-    return await this.pool.anyFirst(sql, values);
+    return await withErrorSource(this.pool.anyFirst(sql, values), 'pg');
   }
 
   async transaction<T = void>(
@@ -131,67 +131,70 @@ export class PostgresDatabasePool implements CommonQueryMethods {
       kind: SpanKind.INTERNAL,
     });
 
-    return context.with(trace.setSpan(context.active(), span), async () => {
-      return await this.pool.transaction(async methods => {
-        try {
-          return await handler({
-            exists: methods.exists,
-            any: methods.any,
-            maybeOne: methods.maybeOne,
-            async query(
-              sql: QuerySqlToken<any>,
-              values?: PrimitiveValueExpression[],
-            ): Promise<void> {
-              await methods.query(sql, values);
-            },
-            oneFirst: methods.oneFirst,
-            maybeOneFirst: methods.maybeOneFirst,
-            anyFirst: methods.anyFirst,
-            one: methods.one,
-            transaction<T>(name: string, handler: (methods: CommonQueryMethods) => Promise<T>) {
-              // We just mark this as a virtual transaction, it still runs as part of the current one.
-              const span = tracer.startSpan(`Virtual PG Transaction: ${name}`, {
-                kind: SpanKind.INTERNAL,
-              });
-
-              try {
-                return context.with(trace.setSpan(context.active(), span), async () => {
-                  return handler(this);
+    return withErrorSource(
+      context.with(trace.setSpan(context.active(), span), async () => {
+        return await this.pool.transaction(async methods => {
+          try {
+            return await handler({
+              exists: methods.exists,
+              any: methods.any,
+              maybeOne: methods.maybeOne,
+              async query(
+                sql: QuerySqlToken<any>,
+                values?: PrimitiveValueExpression[],
+              ): Promise<void> {
+                await methods.query(sql, values);
+              },
+              oneFirst: methods.oneFirst,
+              maybeOneFirst: methods.maybeOneFirst,
+              anyFirst: methods.anyFirst,
+              one: methods.one,
+              transaction<T>(name: string, handler: (methods: CommonQueryMethods) => Promise<T>) {
+                // We just mark this as a virtual transaction, it still runs as part of the current one.
+                const span = tracer.startSpan(`Virtual PG Transaction: ${name}`, {
+                  kind: SpanKind.INTERNAL,
                 });
-              } catch (err) {
-                span.setAttribute('error', 'true');
 
-                if (err instanceof Error) {
-                  span.setAttribute('error.type', err.name);
-                  span.setAttribute('error.message', err.message);
-                  span.setStatus({
-                    code: SpanStatusCode.ERROR,
-                    message: err.message,
+                try {
+                  return context.with(trace.setSpan(context.active(), span), async () => {
+                    return handler(this);
                   });
+                } catch (err) {
+                  span.setAttribute('error', 'true');
+
+                  if (err instanceof Error) {
+                    span.setAttribute('error.type', err.name);
+                    span.setAttribute('error.message', err.message);
+                    span.setStatus({
+                      code: SpanStatusCode.ERROR,
+                      message: err.message,
+                    });
+                  }
+
+                  throw err;
                 }
-
-                throw err;
-              }
-            },
-          });
-        } catch (err) {
-          span.setAttribute('error', 'true');
-
-          if (err instanceof Error) {
-            span.setAttribute('error.type', err.name);
-            span.setAttribute('error.message', err.message);
-            span.setStatus({
-              code: SpanStatusCode.ERROR,
-              message: err.message,
+              },
             });
-          }
+          } catch (err) {
+            span.setAttribute('error', 'true');
 
-          throw err;
-        } finally {
-          span.end();
-        }
-      });
-    });
+            if (err instanceof Error) {
+              span.setAttribute('error.type', err.name);
+              span.setAttribute('error.message', err.message);
+              span.setStatus({
+                code: SpanStatusCode.ERROR,
+                message: err.message,
+              });
+            }
+
+            throw err;
+          } finally {
+            span.end();
+          }
+        });
+      }),
+      'pg',
+    );
   }
 
   end(): Promise<void> {

--- a/packages/services/api/src/modules/app-deployments/providers/app-deployments-manager.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/app-deployments-manager.ts
@@ -1,6 +1,4 @@
 import { Injectable, Scope } from 'graphql-modules';
-import promClient from 'prom-client';
-import { getErrorSource } from '@hive/service-common';
 import * as GraphQLSchema from '../../../__generated__/types';
 import { Target } from '../../../shared/entities';
 import { HiveError } from '../../../shared/errors';
@@ -8,44 +6,13 @@ import { batch } from '../../../shared/helpers';
 import { Session } from '../../auth/lib/authz';
 import { IdTranslator } from '../../shared/providers/id-translator';
 import { Logger } from '../../shared/providers/logger';
+import {
+  registryOperationOutcomeCount,
+  registryOperationUnexpectedErrorCount,
+  unexpectedErrorMetricLabels,
+} from '../../shared/providers/registry-operation-metrics';
 import { TargetManager } from '../../target/providers/target-manager';
 import { AppDeployments, type AppDeploymentRecord } from './app-deployments';
-
-const appDeploymentCreateOutcomeCount = new promClient.Counter({
-  name: 'app_deployment_create_outcome_count',
-  help: 'Number of completed app deployment create operations by outcome. Only unexpected errors are treated as failures.',
-  labelNames: ['conclusion'],
-});
-
-const appDeploymentCreateUnexpectedErrorCount = new promClient.Counter({
-  name: 'app_deployment_create_unexpected_error_count',
-  help: 'Unexpected, not gracefully handled app deployment create errors.',
-  labelNames: ['source'],
-});
-
-const appDeploymentDocumentUploadOutcomeCount = new promClient.Counter({
-  name: 'app_deployment_document_upload_outcome_count',
-  help: 'Number of completed app deployment document upload operations by outcome. Only unexpected errors are treated as failures.',
-  labelNames: ['conclusion'],
-});
-
-const appDeploymentDocumentUploadUnexpectedErrorCount = new promClient.Counter({
-  name: 'app_deployment_document_upload_unexpected_error_count',
-  help: 'Unexpected, not gracefully handled app deployment document upload errors.',
-  labelNames: ['source'],
-});
-
-const appDeploymentPublishOutcomeCount = new promClient.Counter({
-  name: 'app_deployment_publish_outcome_count',
-  help: 'Number of completed app deployment publish operations by outcome. Only unexpected errors are treated as failures.',
-  labelNames: ['conclusion'],
-});
-
-const appDeploymentPublishUnexpectedErrorCount = new promClient.Counter({
-  name: 'app_deployment_publish_unexpected_error_count',
-  help: 'Unexpected, not gracefully handled app deployment publish errors.',
-  labelNames: ['source'],
-});
 
 export type AppDeploymentStatus = 'pending' | 'active' | 'retired';
 
@@ -109,17 +76,26 @@ export class AppDeploymentsManager {
   }) {
     return this.internalCreateAppDeployment(args).then(
       result => {
-        appDeploymentCreateOutcomeCount.inc({ conclusion: 'success' });
+        registryOperationOutcomeCount.inc({
+          operation: 'app_deployment_create',
+          conclusion: 'success',
+        });
         return result;
       },
       error => {
         if (error instanceof HiveError) {
-          appDeploymentCreateOutcomeCount.inc({ conclusion: 'success' });
-        } else {
-          appDeploymentCreateOutcomeCount.inc({ conclusion: 'failure' });
-          appDeploymentCreateUnexpectedErrorCount.inc({
-            source: getErrorSource(error) ?? 'unknown',
+          registryOperationOutcomeCount.inc({
+            operation: 'app_deployment_create',
+            conclusion: 'success',
           });
+        } else {
+          registryOperationOutcomeCount.inc({
+            operation: 'app_deployment_create',
+            conclusion: 'failure',
+          });
+          registryOperationUnexpectedErrorCount.inc(
+            unexpectedErrorMetricLabels('app_deployment_create', error),
+          );
         }
         throw error;
       },
@@ -172,17 +148,26 @@ export class AppDeploymentsManager {
   }) {
     return this.internalAddDocumentsToAppDeployment(args).then(
       result => {
-        appDeploymentDocumentUploadOutcomeCount.inc({ conclusion: 'success' });
+        registryOperationOutcomeCount.inc({
+          operation: 'persisted_document_upload',
+          conclusion: 'success',
+        });
         return result;
       },
       error => {
         if (error instanceof HiveError) {
-          appDeploymentDocumentUploadOutcomeCount.inc({ conclusion: 'success' });
-        } else {
-          appDeploymentDocumentUploadOutcomeCount.inc({ conclusion: 'failure' });
-          appDeploymentDocumentUploadUnexpectedErrorCount.inc({
-            source: getErrorSource(error) ?? 'unknown',
+          registryOperationOutcomeCount.inc({
+            operation: 'persisted_document_upload',
+            conclusion: 'success',
           });
+        } else {
+          registryOperationOutcomeCount.inc({
+            operation: 'persisted_document_upload',
+            conclusion: 'failure',
+          });
+          registryOperationUnexpectedErrorCount.inc(
+            unexpectedErrorMetricLabels('persisted_document_upload', error),
+          );
         }
         throw error;
       },
@@ -237,17 +222,26 @@ export class AppDeploymentsManager {
   }) {
     return this.internalActivateAppDeployment(args).then(
       result => {
-        appDeploymentPublishOutcomeCount.inc({ conclusion: 'success' });
+        registryOperationOutcomeCount.inc({
+          operation: 'app_deployment_publish',
+          conclusion: 'success',
+        });
         return result;
       },
       error => {
         if (error instanceof HiveError) {
-          appDeploymentPublishOutcomeCount.inc({ conclusion: 'success' });
-        } else {
-          appDeploymentPublishOutcomeCount.inc({ conclusion: 'failure' });
-          appDeploymentPublishUnexpectedErrorCount.inc({
-            source: getErrorSource(error) ?? 'unknown',
+          registryOperationOutcomeCount.inc({
+            operation: 'app_deployment_publish',
+            conclusion: 'success',
           });
+        } else {
+          registryOperationOutcomeCount.inc({
+            operation: 'app_deployment_publish',
+            conclusion: 'failure',
+          });
+          registryOperationUnexpectedErrorCount.inc(
+            unexpectedErrorMetricLabels('app_deployment_publish', error),
+          );
         }
         throw error;
       },

--- a/packages/services/api/src/modules/app-deployments/providers/app-deployments-manager.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/app-deployments-manager.ts
@@ -1,12 +1,51 @@
 import { Injectable, Scope } from 'graphql-modules';
+import promClient from 'prom-client';
+import { getErrorSource } from '@hive/service-common';
 import * as GraphQLSchema from '../../../__generated__/types';
 import { Target } from '../../../shared/entities';
+import { HiveError } from '../../../shared/errors';
 import { batch } from '../../../shared/helpers';
 import { Session } from '../../auth/lib/authz';
 import { IdTranslator } from '../../shared/providers/id-translator';
 import { Logger } from '../../shared/providers/logger';
 import { TargetManager } from '../../target/providers/target-manager';
 import { AppDeployments, type AppDeploymentRecord } from './app-deployments';
+
+const appDeploymentCreateOutcomeCount = new promClient.Counter({
+  name: 'app_deployment_create_outcome_count',
+  help: 'Number of completed app deployment create operations by outcome. Only unexpected errors are treated as failures.',
+  labelNames: ['conclusion'],
+});
+
+const appDeploymentCreateUnexpectedErrorCount = new promClient.Counter({
+  name: 'app_deployment_create_unexpected_error_count',
+  help: 'Unexpected, not gracefully handled app deployment create errors.',
+  labelNames: ['source'],
+});
+
+const appDeploymentDocumentUploadOutcomeCount = new promClient.Counter({
+  name: 'app_deployment_document_upload_outcome_count',
+  help: 'Number of completed app deployment document upload operations by outcome. Only unexpected errors are treated as failures.',
+  labelNames: ['conclusion'],
+});
+
+const appDeploymentDocumentUploadUnexpectedErrorCount = new promClient.Counter({
+  name: 'app_deployment_document_upload_unexpected_error_count',
+  help: 'Unexpected, not gracefully handled app deployment document upload errors.',
+  labelNames: ['source'],
+});
+
+const appDeploymentPublishOutcomeCount = new promClient.Counter({
+  name: 'app_deployment_publish_outcome_count',
+  help: 'Number of completed app deployment publish operations by outcome. Only unexpected errors are treated as failures.',
+  labelNames: ['conclusion'],
+});
+
+const appDeploymentPublishUnexpectedErrorCount = new promClient.Counter({
+  name: 'app_deployment_publish_unexpected_error_count',
+  help: 'Unexpected, not gracefully handled app deployment publish errors.',
+  labelNames: ['source'],
+});
 
 export type AppDeploymentStatus = 'pending' | 'active' | 'retired';
 
@@ -68,6 +107,32 @@ export class AppDeploymentsManager {
       version: string;
     };
   }) {
+    return this.internalCreateAppDeployment(args).then(
+      result => {
+        appDeploymentCreateOutcomeCount.inc({ conclusion: 'success' });
+        return result;
+      },
+      error => {
+        if (error instanceof HiveError) {
+          appDeploymentCreateOutcomeCount.inc({ conclusion: 'success' });
+        } else {
+          appDeploymentCreateOutcomeCount.inc({ conclusion: 'failure' });
+          appDeploymentCreateUnexpectedErrorCount.inc({
+            source: getErrorSource(error) ?? 'unknown',
+          });
+        }
+        throw error;
+      },
+    );
+  }
+
+  private async internalCreateAppDeployment(args: {
+    reference: GraphQLSchema.TargetReferenceInput | null;
+    appDeployment: {
+      name: string;
+      version: string;
+    };
+  }) {
     const selector = await this.idTranslator.resolveTargetReference({
       reference: args.reference,
     });
@@ -95,6 +160,36 @@ export class AppDeploymentsManager {
   }
 
   async addDocumentsToAppDeployment(args: {
+    reference: GraphQLSchema.TargetReferenceInput | null;
+    appDeployment: {
+      name: string;
+      version: string;
+    };
+    documents: ReadonlyArray<{
+      hash: string;
+      body: string;
+    }>;
+  }) {
+    return this.internalAddDocumentsToAppDeployment(args).then(
+      result => {
+        appDeploymentDocumentUploadOutcomeCount.inc({ conclusion: 'success' });
+        return result;
+      },
+      error => {
+        if (error instanceof HiveError) {
+          appDeploymentDocumentUploadOutcomeCount.inc({ conclusion: 'success' });
+        } else {
+          appDeploymentDocumentUploadOutcomeCount.inc({ conclusion: 'failure' });
+          appDeploymentDocumentUploadUnexpectedErrorCount.inc({
+            source: getErrorSource(error) ?? 'unknown',
+          });
+        }
+        throw error;
+      },
+    );
+  }
+
+  private async internalAddDocumentsToAppDeployment(args: {
     reference: GraphQLSchema.TargetReferenceInput | null;
     appDeployment: {
       name: string;
@@ -134,6 +229,32 @@ export class AppDeploymentsManager {
   }
 
   async activateAppDeployment(args: {
+    reference: GraphQLSchema.TargetReferenceInput | null;
+    appDeployment: {
+      name: string;
+      version: string;
+    };
+  }) {
+    return this.internalActivateAppDeployment(args).then(
+      result => {
+        appDeploymentPublishOutcomeCount.inc({ conclusion: 'success' });
+        return result;
+      },
+      error => {
+        if (error instanceof HiveError) {
+          appDeploymentPublishOutcomeCount.inc({ conclusion: 'success' });
+        } else {
+          appDeploymentPublishOutcomeCount.inc({ conclusion: 'failure' });
+          appDeploymentPublishUnexpectedErrorCount.inc({
+            source: getErrorSource(error) ?? 'unknown',
+          });
+        }
+        throw error;
+      },
+    );
+  }
+
+  private async internalActivateAppDeployment(args: {
     reference: GraphQLSchema.TargetReferenceInput | null;
     appDeployment: {
       name: string;

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
@@ -410,7 +410,7 @@ export class PersistedDocumentIngester {
 
             if (response.statusCode !== 200) {
               throw new Error(
-                `Failed to upload operation to S3: [${response.statusCode}] ${response.statusMessage}`,
+                `Failed to upload operation to S3 object storage (${s3.endpoint}/${s3.bucket}): [${response.statusCode}] ${response.statusMessage}`,
               );
             }
           }

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
@@ -14,7 +14,7 @@ import PromiseQueue from 'p-queue';
 import { z } from 'zod';
 import { collectSchemaCoordinates, preprocessOperation } from '@graphql-hive/core';
 import { buildOperationS3BucketKey } from '@hive/cdn-script/artifact-storage-reader';
-import { ServiceLogger } from '@hive/service-common';
+import { ServiceLogger, setErrorSource } from '@hive/service-common';
 import { sql as c_sql, ClickHouse } from '../../operations/providers/clickhouse-client';
 import { S3Config } from '../../shared/providers/s3-config';
 
@@ -409,8 +409,11 @@ export class PersistedDocumentIngester {
             });
 
             if (response.statusCode !== 200) {
-              throw new Error(
-                `Failed to upload operation to S3 object storage (${s3.endpoint}/${s3.bucket}): [${response.statusCode}] ${response.statusMessage}`,
+              throw setErrorSource(
+                new Error(
+                  `Failed to upload operation to S3 object storage (${s3.endpoint}/${s3.bucket}): [${response.statusCode}] ${response.statusMessage}`,
+                ),
+                `s3 ${s3.endpoint}`,
               );
             }
           }

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-scheduler.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-scheduler.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { Worker } from 'node:worker_threads';
 import { fileURLToPath } from 'url';
 import { Injectable, Scope } from 'graphql-modules';
+import { getErrorSource, setErrorSource } from '@hive/service-common';
 import { Logger, registerWorkerLogging } from '../../shared/providers/logger';
 import { BatchProcessedEvent, BatchProcessEvent } from './persisted-document-ingester';
 
@@ -11,6 +12,30 @@ type PendingTaskRecord = {
   resolve: (data: BatchProcessedEvent) => void;
   reject: (err: unknown) => void;
 };
+
+export type SerializedWorkerError = {
+  name: string;
+  message: string;
+  stack: string | undefined;
+  source: string | null;
+};
+
+export function serializeWorkerError(error: unknown): SerializedWorkerError {
+  const normalizedError = error instanceof Error ? error : new Error(String(error));
+  return {
+    name: normalizedError.name,
+    message: normalizedError.message,
+    stack: normalizedError.stack,
+    source: getErrorSource(normalizedError),
+  };
+}
+
+export function deserializeWorkerError(error: SerializedWorkerError): Error {
+  const deserializedError = new Error(error.message);
+  deserializedError.name = error.name;
+  deserializedError.stack = error.stack;
+  return error.source ? setErrorSource(deserializedError, error.source) : deserializedError;
+}
 
 @Injectable({
   scope: Scope.Singleton,
@@ -56,7 +81,7 @@ export class PersistedDocumentScheduler {
 
       this.logger.debug('Cancel pending tasks %s', index);
       for (const [, task] of tasks) {
-        task.reject(new Error('Worker stopped.'));
+        task.reject(setErrorSource(new Error('Worker stopped.'), 'persisted-documents-worker'));
       }
     });
 
@@ -64,9 +89,11 @@ export class PersistedDocumentScheduler {
 
     worker.on(
       'message',
-      (data: BatchProcessedEvent | { event: 'error'; id: string; err: Error }) => {
+      (
+        data: BatchProcessedEvent | { event: 'error'; id: string; error: SerializedWorkerError },
+      ) => {
         if (data.event === 'error') {
-          tasks.get(data.id)?.reject(data.err);
+          tasks.get(data.id)?.reject(deserializeWorkerError(data.error));
         }
 
         if (data.event === 'processedBatch') {
@@ -81,7 +108,12 @@ export class PersistedDocumentScheduler {
       const id = crypto.randomUUID();
       const d = Promise.withResolvers<BatchProcessedEvent>();
       const timeout = setTimeout(() => {
-        task.reject(new Error('Timeout, worker did not respond within time.'));
+        task.reject(
+          setErrorSource(
+            new Error('Timeout, worker did not respond within time.'),
+            'persisted-documents-worker',
+          ),
+        );
       }, 20_000);
 
       const task: PendingTaskRecord = {

--- a/packages/services/api/src/modules/app-deployments/worker/persisted-documents-worker.ts
+++ b/packages/services/api/src/modules/app-deployments/worker/persisted-documents-worker.ts
@@ -10,6 +10,7 @@ import {
   PersistedDocumentIngester,
   type BatchProcessEvent,
 } from '../providers/persisted-document-ingester';
+import { serializeWorkerError } from '../providers/persisted-document-scheduler';
 
 /**
  * Create a worker for processing incoming persisted operations.
@@ -110,7 +111,7 @@ export function createWorker(
       port.postMessage({
         event: 'error',
         id: message.id,
-        err,
+        error: serializeWorkerError(err),
       });
     }
   });

--- a/packages/services/api/src/modules/cdn/providers/aws.ts
+++ b/packages/services/api/src/modules/cdn/providers/aws.ts
@@ -1,5 +1,6 @@
 import { got, type Method, type OptionsInit } from 'got';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { withErrorSource } from '@hive/service-common';
 
 /**
  * AWS credential provider chain + custom SigV4 signer (ported from aws4fetch).
@@ -199,9 +200,10 @@ export class AwsClient {
     console.log(`Calling ${init.method} ${url}`);
     const startedAt = Date.now();
 
-    const signed = await this.sign(url, init);
+    const errorSource = `s3 ${new URL(url).origin}` as const;
+    const signed = await withErrorSource(this.sign(url, init), errorSource);
 
-    return got(signed.url, {
+    const request = got(signed.url, {
       method: signed.init.method,
       body: signed.init.body,
       headers: signed.init.headers,
@@ -244,6 +246,8 @@ export class AwsClient {
     }).finally(() => {
       console.log(`Finished ${init.method} ${url} in ${Date.now() - startedAt}ms`);
     });
+
+    return withErrorSource(request, errorSource);
   }
 
   private async sign(url: string, init?: AwsRequestInit) {

--- a/packages/services/api/src/modules/commerce/providers/commerce-client.ts
+++ b/packages/services/api/src/modules/commerce/providers/commerce-client.ts
@@ -1,5 +1,6 @@
 import { FactoryProvider, InjectionToken, Scope, ValueProvider } from 'graphql-modules';
 import type { CommerceRouter } from '@hive/commerce';
+import { errorSourceLink } from '@hive/service-common';
 import { createTRPCProxyClient, httpLink, type CreateTRPCProxyClient } from '@trpc/client';
 import type { inferRouterInputs } from '@trpc/server';
 
@@ -32,7 +33,10 @@ export function provideCommerceClient(): FactoryProvider<CommerceTrpcClient> {
       }
 
       return createTRPCProxyClient<CommerceRouter>({
-        links: [httpLink({ url: `${config.endpoint}/trpc`, fetch })],
+        links: [
+          errorSourceLink('commerce-service'),
+          httpLink({ url: `${config.endpoint}/trpc`, fetch }),
+        ],
       });
     },
   };

--- a/packages/services/api/src/modules/integrations/providers/github-integration-manager.ts
+++ b/packages/services/api/src/modules/integrations/providers/github-integration-manager.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable, InjectionToken, Scope } from 'graphql-modules';
+import { setErrorSource, withErrorSource } from '@hive/service-common';
 import { App } from '@octokit/app';
 import { Octokit } from '@octokit/core';
 import { retry } from '@octokit/plugin-retry';
@@ -185,7 +186,7 @@ export class GitHubIntegrationManager {
     if (!this.app) {
       throw new Error('GitHub Integration not found. Please provide GITHUB_APP_CONFIG.');
     }
-    return await this.app.getInstallationOctokit(installationId);
+    return await withErrorSource(this.app.getInstallationOctokit(installationId), 'github');
   }
 
   /**
@@ -353,7 +354,7 @@ export class GitHubIntegrationManager {
         };
       }
 
-      throw error;
+      throw setErrorSource(error, 'github');
     }
   }
 
@@ -390,14 +391,17 @@ export class GitHubIntegrationManager {
       );
     }
 
-    const result = await octokit.request('PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}', {
-      owner: args.githubCheckRun.owner,
-      repo: args.githubCheckRun.repository,
-      check_run_id: args.githubCheckRun.id,
-      conclusion: args.conclusion,
-      output: this.limitOutput(args.output),
-      details_url: args.detailsUrl ?? undefined,
-    });
+    const result = await withErrorSource(
+      octokit.request('PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}', {
+        owner: args.githubCheckRun.owner,
+        repo: args.githubCheckRun.repository,
+        check_run_id: args.githubCheckRun.id,
+        conclusion: args.conclusion,
+        output: this.limitOutput(args.output),
+        details_url: args.detailsUrl ?? undefined,
+      }),
+      'github',
+    );
 
     this.logger.debug('Check-run updated (link=%s)', result.data.url);
 

--- a/packages/services/api/src/modules/operations/providers/clickhouse-client.ts
+++ b/packages/services/api/src/modules/operations/providers/clickhouse-client.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import Agent from 'agentkeepalive';
 import { Inject, Injectable } from 'graphql-modules';
 import { printWithValues, sql, SqlStatement, toQueryParams } from '@hive/clickhouse';
-import { SpanKind, trace } from '@hive/service-common';
+import { setErrorSource, SpanKind, trace } from '@hive/service-common';
 import { castValue, compressGzip } from '@hive/usage-common';
 import { atomic } from '../../../shared/helpers';
 import { HttpClient } from '../../shared/providers/http-client';
@@ -221,7 +221,7 @@ export class ClickHouse {
           error.name,
           error.message,
         );
-        return Promise.reject(error);
+        return Promise.reject(setErrorSource(error, 'clickhouse'));
       })
       .finally(() => {
         this.logger.debug(
@@ -381,7 +381,7 @@ export class ClickHouse {
           error.name,
           error.message,
         );
-        return Promise.reject(error);
+        return Promise.reject(setErrorSource(error, 'clickhouse'));
       })
       .finally(() => {
         this.logger.debug(
@@ -482,7 +482,7 @@ export class ClickHouse {
           error.name,
           error.message,
         );
-        return Promise.reject(error);
+        return Promise.reject(setErrorSource(error, 'clickhouse'));
       })
       .finally(() => {
         this.logger.debug(

--- a/packages/services/api/src/modules/policy/providers/schema-policy-api.provider.ts
+++ b/packages/services/api/src/modules/policy/providers/schema-policy-api.provider.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import type { AvailableRulesResponse, SchemaPolicyApi, SchemaPolicyApiInput } from '@hive/policy';
-import { traceFn } from '@hive/service-common';
+import { errorSourceLink, traceFn } from '@hive/service-common';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
 import { Logger } from '../../shared/providers/logger';
 import type { SchemaPolicyServiceConfig } from './tokens';
@@ -24,6 +24,7 @@ export class SchemaPolicyApiProvider {
     this.schemaPolicy = config.endpoint
       ? createTRPCProxyClient<SchemaPolicyApi>({
           links: [
+            errorSourceLink('schema-policy-service'),
             httpLink({
               url: `${config.endpoint}/trpc`,
               fetch,

--- a/packages/services/api/src/modules/schema/providers/artifact-storage-writer.ts
+++ b/packages/services/api/src/modules/schema/providers/artifact-storage-writer.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { Inject } from 'graphql-modules';
 import { buildArtifactStorageKey } from '@hive/cdn-script/artifact-storage-reader';
-import { traceFn } from '@hive/service-common';
+import { setErrorSource, traceFn } from '@hive/service-common';
 import { Logger } from '../../shared/providers/logger';
 import { S3_CONFIG, type S3Config } from '../../shared/providers/s3-config';
 
@@ -98,8 +98,11 @@ export class ArtifactStorageWriter {
             versionedKey,
             versionedResult.statusCode,
           );
-          throw new Error(
-            `Unexpected status code ${versionedResult.statusCode} when writing versioned artifact (targetId=${args.targetId}, artifactType=${args.artifactType}, versionId=${args.versionId}, key=${versionedKey})`,
+          throw setErrorSource(
+            new Error(
+              `Unexpected status code ${versionedResult.statusCode} when writing versioned artifact (targetId=${args.targetId}, artifactType=${args.artifactType}, versionId=${args.versionId}, key=${versionedKey})`,
+            ),
+            `s3 ${s3.endpoint}`,
           );
         }
       }
@@ -128,8 +131,11 @@ export class ArtifactStorageWriter {
           versionedKey,
           latestKey,
         );
-        throw new Error(
-          `Unexpected status code ${latestResult.statusCode} when writing latest artifact (targetId=${args.targetId}, artifactType=${args.artifactType}, contractName=${args.contractName}, key=${latestKey}). Note: versioned artifact was already written.`,
+        throw setErrorSource(
+          new Error(
+            `Unexpected status code ${latestResult.statusCode} when writing latest artifact (targetId=${args.targetId}, artifactType=${args.artifactType}, contractName=${args.contractName}, key=${latestKey}). Note: versioned artifact was already written.`,
+          ),
+          `s3 ${new URL(s3.endpoint).origin}`,
         );
       }
     }

--- a/packages/services/api/src/modules/schema/providers/orchestrator/composition-orchestrator.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrator/composition-orchestrator.ts
@@ -1,7 +1,7 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
 import { abortSignalAny } from '@graphql-hive/signal';
 import type { ContractsInputType, SchemaBuilderApi } from '@hive/schema';
-import { trace, traceFn } from '@hive/service-common';
+import { errorSourceLink, trace, traceFn } from '@hive/service-common';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
 import {
   ComposeAndValidateResult,
@@ -52,6 +52,7 @@ export class CompositionOrchestrator {
     this.logger = logger.child({ service: 'FederationOrchestrator' });
     this.schemaService = createTRPCProxyClient<SchemaBuilderApi>({
       links: [
+        errorSourceLink('schema-service'),
         httpLink({
           url: `${serviceConfig.endpoint}/trpc`,
           fetch,

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -6,7 +6,7 @@ import lodash from 'lodash';
 import promClient from 'prom-client';
 import { z } from 'zod';
 import { CriticalityLevel } from '@graphql-inspector/core';
-import { invariant, trace, traceFn } from '@hive/service-common';
+import { getErrorSource, invariant, trace, traceFn } from '@hive/service-common';
 import type {
   ConditionalBreakingChangeMetadata,
   SchemaChangeType,
@@ -87,20 +87,32 @@ const schemaCheckCount = new promClient.Counter({
 
 const schemaPublishCount = new promClient.Counter({
   name: 'registry_publish_count',
-  help: 'Number of schema publishes',
+  help: 'Number of performed schema publishes',
   labelNames: ['model', 'projectType', 'conclusion'],
+});
+
+const schemaPublishOutcomeCount = new promClient.Counter({
+  name: 'registry_publish_outcome_count',
+  help: 'Number of completed schema publish attempts by outcome. Only unexpected errors are treated as failures, invalid input or insufficient auth is treated as a success.',
+  labelNames: ['conclusion'],
 });
 
 const schemaPublishUnexpectedErrorCount = new promClient.Counter({
   name: 'registry_publish_unexpected_error_count',
-  help: 'Unexpected, not gracefully handled errors. E.g. from GitHub or other third-party services.',
-  labelNames: ['errorName'],
+  help: 'Unexpected, not gracefully handled schema publish errors.',
+  labelNames: ['source'],
 });
 
 const schemaCheckUnexpectedErrorCount = new promClient.Counter({
   name: 'registry_check_unexpected_error_count',
   help: 'Unexpected, not gracefully handled errors. E.g. from GitHub or other third-party services.',
-  labelNames: ['errorName'],
+  labelNames: ['source'],
+});
+
+const schemaCheckOutcomeCount = new promClient.Counter({
+  name: 'registry_check_outcome_count',
+  help: 'Number of completed schema check attempts by outcome. Only unexpected errors are treated as failures.',
+  labelNames: ['conclusion'],
 });
 
 const schemaDeleteCount = new promClient.Counter({
@@ -108,6 +120,36 @@ const schemaDeleteCount = new promClient.Counter({
   help: 'Number of schema deletes',
   labelNames: ['model', 'projectType'],
 });
+
+const schemaDeleteOutcomeCount = new promClient.Counter({
+  name: 'registry_delete_outcome_count',
+  help: 'Number of completed schema delete attempts by outcome. Only unexpected errors are treated as failures.',
+  labelNames: ['conclusion'],
+});
+
+const schemaDeleteUnexpectedErrorCount = new promClient.Counter({
+  name: 'registry_delete_unexpected_error_count',
+  help: 'Unexpected, not gracefully handled schema delete errors.',
+  labelNames: ['source'],
+});
+
+const schemaPromotionOutcomeCount = new promClient.Counter({
+  name: 'registry_promotion_outcome_count',
+  help: 'Number of completed schema promotion attempts by outcome. Only unexpected errors are treated as failures.',
+  labelNames: ['conclusion'],
+});
+
+const schemaPromotionUnexpectedErrorCount = new promClient.Counter({
+  name: 'registry_promotion_unexpected_error_count',
+  help: 'Unexpected, not gracefully handled schema promotion errors.',
+  labelNames: ['source'],
+});
+
+function unexpectedErrorMetricLabels(error: unknown) {
+  return {
+    source: getErrorSource(error) ?? 'unknown',
+  };
+}
 
 export type CheckInput = Types.SchemaCheckInput & {
   schemaProposalId?: string | null;
@@ -1250,15 +1292,19 @@ export class SchemaPublisher {
   }
 
   async check(input: CheckInput) {
-    return await this.internalCheck(input).catch(error => {
-      if (error instanceof HiveError === false) {
-        schemaCheckUnexpectedErrorCount.inc({
-          errorName: (error instanceof Error && error.name) || 'unknown',
-        });
-      }
-
-      throw error;
-    });
+    return await this.internalCheck(input).then(
+      result => {
+        schemaCheckOutcomeCount.inc({ conclusion: 'success' });
+        return result;
+      },
+      error => {
+        if (error instanceof HiveError === false) {
+          schemaCheckOutcomeCount.inc({ conclusion: 'failure' });
+          schemaCheckUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
+        }
+        throw error;
+      },
+    );
   }
 
   @traceFn('SchemaPublisher.publish', {
@@ -1273,6 +1319,26 @@ export class SchemaPublisher {
     }),
   })
   async publish(input: PublishInput, signal: AbortSignal): Promise<PublishResult> {
+    return this.internalPublishRequest(input, signal).then(
+      result => {
+        schemaPublishOutcomeCount.inc({
+          conclusion: 'success',
+        });
+        return result;
+      },
+      error => {
+        if (!(error instanceof HiveError)) {
+          schemaPublishOutcomeCount.inc({ conclusion: 'failure' });
+        }
+        throw error;
+      },
+    );
+  }
+
+  private async internalPublishRequest(
+    input: PublishInput,
+    signal: AbortSignal,
+  ): Promise<PublishResult> {
     this.logger.debug('Start schema publication.');
 
     const selector = await this.idTranslator.resolveTargetReference({
@@ -1438,9 +1504,7 @@ export class SchemaPublisher {
         }
 
         if (error instanceof HiveError === false) {
-          schemaPublishUnexpectedErrorCount.inc({
-            errorName: (error instanceof Error && error.name) || 'unknown',
-          });
+          schemaPublishUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
         }
 
         throw error;
@@ -1459,6 +1523,24 @@ export class SchemaPublisher {
     }),
   })
   async delete(input: DeleteInput, signal: AbortSignal) {
+    return this.internalDeleteRequest(input, signal).then(
+      result => {
+        schemaDeleteOutcomeCount.inc({
+          conclusion: 'success',
+        });
+        return result;
+      },
+      error => {
+        if (error instanceof HiveError === false) {
+          schemaDeleteOutcomeCount.inc({ conclusion: 'failure' });
+          schemaDeleteUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
+        }
+        throw error;
+      },
+    );
+  }
+
+  private async internalDeleteRequest(input: DeleteInput, signal: AbortSignal) {
     this.logger.info('Deleting schema (input=%o)', input);
 
     const selector = await this.idTranslator.resolveTargetReference({
@@ -2340,6 +2422,28 @@ export class SchemaPublisher {
       /** Where the schema version is promoted to. */
       target: Types.TargetReferenceInput;
       /** Which schema version is promoted. This can be either a target or specific schema version by id. */
+      source: Types.SchemaVersionPromoteSourceInput;
+    },
+    signal: AbortSignal,
+  ) {
+    return this.internalPromoteSchemaVersionRequest(args, signal).then(
+      result => {
+        schemaPromotionOutcomeCount.inc({ conclusion: 'success' });
+        return result;
+      },
+      error => {
+        if (error instanceof HiveError === false) {
+          schemaPromotionOutcomeCount.inc({ conclusion: 'failure' });
+          schemaPromotionUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
+        }
+        throw error;
+      },
+    );
+  }
+
+  private async internalPromoteSchemaVersionRequest(
+    args: {
+      target: Types.TargetReferenceInput;
       source: Types.SchemaVersionPromoteSourceInput;
     },
     signal: AbortSignal,

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -1298,7 +1298,9 @@ export class SchemaPublisher {
         return result;
       },
       error => {
-        if (error instanceof HiveError === false) {
+        if (error instanceof HiveError) {
+          schemaCheckOutcomeCount.inc({ conclusion: 'success' });
+        } else {
           schemaCheckOutcomeCount.inc({ conclusion: 'failure' });
           schemaCheckUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
         }
@@ -1327,8 +1329,11 @@ export class SchemaPublisher {
         return result;
       },
       error => {
-        if (!(error instanceof HiveError)) {
+        if (error instanceof HiveError) {
+          schemaPublishOutcomeCount.inc({ conclusion: 'success' });
+        } else {
           schemaPublishOutcomeCount.inc({ conclusion: 'failure' });
+          schemaPublishUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
         }
         throw error;
       },
@@ -1503,10 +1508,6 @@ export class SchemaPublisher {
           } satisfies PublishResult;
         }
 
-        if (error instanceof HiveError === false) {
-          schemaPublishUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
-        }
-
         throw error;
       });
   }
@@ -1531,7 +1532,11 @@ export class SchemaPublisher {
         return result;
       },
       error => {
-        if (error instanceof HiveError === false) {
+        if (error instanceof HiveError) {
+          schemaDeleteOutcomeCount.inc({
+            conclusion: 'success',
+          });
+        } else {
           schemaDeleteOutcomeCount.inc({ conclusion: 'failure' });
           schemaDeleteUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
         }
@@ -2432,7 +2437,9 @@ export class SchemaPublisher {
         return result;
       },
       error => {
-        if (error instanceof HiveError === false) {
+        if (error instanceof HiveError) {
+          schemaPromotionOutcomeCount.inc({ conclusion: 'success' });
+        } else {
           schemaPromotionOutcomeCount.inc({ conclusion: 'failure' });
           schemaPromotionUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
         }

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -6,7 +6,7 @@ import lodash from 'lodash';
 import promClient from 'prom-client';
 import { z } from 'zod';
 import { CriticalityLevel } from '@graphql-inspector/core';
-import { getErrorSource, invariant, trace, traceFn } from '@hive/service-common';
+import { invariant, trace, traceFn } from '@hive/service-common';
 import type {
   ConditionalBreakingChangeMetadata,
   SchemaChangeType,
@@ -33,6 +33,11 @@ import { DistributedCache } from '../../shared/providers/distributed-cache';
 import { IdTranslator } from '../../shared/providers/id-translator';
 import { Logger } from '../../shared/providers/logger';
 import { Mutex, MutexResourceLockedError } from '../../shared/providers/mutex';
+import {
+  registryOperationOutcomeCount,
+  registryOperationUnexpectedErrorCount,
+  unexpectedErrorMetricLabels,
+} from '../../shared/providers/registry-operation-metrics';
 import { Storage, type TargetSelector } from '../../shared/providers/storage';
 import { TargetManager } from '../../target/providers/target-manager';
 import { toGraphQLSchemaCheck } from '../to-graphql-schema-check';
@@ -91,65 +96,11 @@ const schemaPublishCount = new promClient.Counter({
   labelNames: ['model', 'projectType', 'conclusion'],
 });
 
-const schemaPublishOutcomeCount = new promClient.Counter({
-  name: 'registry_publish_outcome_count',
-  help: 'Number of completed schema publish attempts by outcome. Only unexpected errors are treated as failures, invalid input or insufficient auth is treated as a success.',
-  labelNames: ['conclusion'],
-});
-
-const schemaPublishUnexpectedErrorCount = new promClient.Counter({
-  name: 'registry_publish_unexpected_error_count',
-  help: 'Unexpected, not gracefully handled schema publish errors.',
-  labelNames: ['source'],
-});
-
-const schemaCheckUnexpectedErrorCount = new promClient.Counter({
-  name: 'registry_check_unexpected_error_count',
-  help: 'Unexpected, not gracefully handled errors. E.g. from GitHub or other third-party services.',
-  labelNames: ['source'],
-});
-
-const schemaCheckOutcomeCount = new promClient.Counter({
-  name: 'registry_check_outcome_count',
-  help: 'Number of completed schema check attempts by outcome. Only unexpected errors are treated as failures.',
-  labelNames: ['conclusion'],
-});
-
 const schemaDeleteCount = new promClient.Counter({
   name: 'registry_delete_count',
   help: 'Number of schema deletes',
   labelNames: ['model', 'projectType'],
 });
-
-const schemaDeleteOutcomeCount = new promClient.Counter({
-  name: 'registry_delete_outcome_count',
-  help: 'Number of completed schema delete attempts by outcome. Only unexpected errors are treated as failures.',
-  labelNames: ['conclusion'],
-});
-
-const schemaDeleteUnexpectedErrorCount = new promClient.Counter({
-  name: 'registry_delete_unexpected_error_count',
-  help: 'Unexpected, not gracefully handled schema delete errors.',
-  labelNames: ['source'],
-});
-
-const schemaPromotionOutcomeCount = new promClient.Counter({
-  name: 'registry_promotion_outcome_count',
-  help: 'Number of completed schema promotion attempts by outcome. Only unexpected errors are treated as failures.',
-  labelNames: ['conclusion'],
-});
-
-const schemaPromotionUnexpectedErrorCount = new promClient.Counter({
-  name: 'registry_promotion_unexpected_error_count',
-  help: 'Unexpected, not gracefully handled schema promotion errors.',
-  labelNames: ['source'],
-});
-
-function unexpectedErrorMetricLabels(error: unknown) {
-  return {
-    source: getErrorSource(error) ?? 'unknown',
-  };
-}
 
 export type CheckInput = Types.SchemaCheckInput & {
   schemaProposalId?: string | null;
@@ -1294,15 +1245,15 @@ export class SchemaPublisher {
   async check(input: CheckInput) {
     return await this.internalCheck(input).then(
       result => {
-        schemaCheckOutcomeCount.inc({ conclusion: 'success' });
+        registryOperationOutcomeCount.inc({ operation: 'check', conclusion: 'success' });
         return result;
       },
       error => {
         if (error instanceof HiveError) {
-          schemaCheckOutcomeCount.inc({ conclusion: 'success' });
+          registryOperationOutcomeCount.inc({ operation: 'check', conclusion: 'success' });
         } else {
-          schemaCheckOutcomeCount.inc({ conclusion: 'failure' });
-          schemaCheckUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
+          registryOperationOutcomeCount.inc({ operation: 'check', conclusion: 'failure' });
+          registryOperationUnexpectedErrorCount.inc(unexpectedErrorMetricLabels('check', error));
         }
         throw error;
       },
@@ -1323,17 +1274,18 @@ export class SchemaPublisher {
   async publish(input: PublishInput, signal: AbortSignal): Promise<PublishResult> {
     return this.internalPublishRequest(input, signal).then(
       result => {
-        schemaPublishOutcomeCount.inc({
+        registryOperationOutcomeCount.inc({
+          operation: 'publish',
           conclusion: 'success',
         });
         return result;
       },
       error => {
         if (error instanceof HiveError) {
-          schemaPublishOutcomeCount.inc({ conclusion: 'success' });
+          registryOperationOutcomeCount.inc({ operation: 'publish', conclusion: 'success' });
         } else {
-          schemaPublishOutcomeCount.inc({ conclusion: 'failure' });
-          schemaPublishUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
+          registryOperationOutcomeCount.inc({ operation: 'publish', conclusion: 'failure' });
+          registryOperationUnexpectedErrorCount.inc(unexpectedErrorMetricLabels('publish', error));
         }
         throw error;
       },
@@ -1526,19 +1478,21 @@ export class SchemaPublisher {
   async delete(input: DeleteInput, signal: AbortSignal) {
     return this.internalDeleteRequest(input, signal).then(
       result => {
-        schemaDeleteOutcomeCount.inc({
+        registryOperationOutcomeCount.inc({
+          operation: 'delete',
           conclusion: 'success',
         });
         return result;
       },
       error => {
         if (error instanceof HiveError) {
-          schemaDeleteOutcomeCount.inc({
+          registryOperationOutcomeCount.inc({
+            operation: 'delete',
             conclusion: 'success',
           });
         } else {
-          schemaDeleteOutcomeCount.inc({ conclusion: 'failure' });
-          schemaDeleteUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
+          registryOperationOutcomeCount.inc({ operation: 'delete', conclusion: 'failure' });
+          registryOperationUnexpectedErrorCount.inc(unexpectedErrorMetricLabels('delete', error));
         }
         throw error;
       },
@@ -2433,15 +2387,17 @@ export class SchemaPublisher {
   ) {
     return this.internalPromoteSchemaVersionRequest(args, signal).then(
       result => {
-        schemaPromotionOutcomeCount.inc({ conclusion: 'success' });
+        registryOperationOutcomeCount.inc({ operation: 'promotion', conclusion: 'success' });
         return result;
       },
       error => {
         if (error instanceof HiveError) {
-          schemaPromotionOutcomeCount.inc({ conclusion: 'success' });
+          registryOperationOutcomeCount.inc({ operation: 'promotion', conclusion: 'success' });
         } else {
-          schemaPromotionOutcomeCount.inc({ conclusion: 'failure' });
-          schemaPromotionUnexpectedErrorCount.inc(unexpectedErrorMetricLabels(error));
+          registryOperationOutcomeCount.inc({ operation: 'promotion', conclusion: 'failure' });
+          registryOperationUnexpectedErrorCount.inc(
+            unexpectedErrorMetricLabels('promotion', error),
+          );
         }
         throw error;
       },

--- a/packages/services/api/src/modules/shared/providers/registry-operation-metrics.ts
+++ b/packages/services/api/src/modules/shared/providers/registry-operation-metrics.ts
@@ -1,0 +1,21 @@
+import promClient from 'prom-client';
+import { getErrorSource } from '@hive/service-common';
+
+export const registryOperationOutcomeCount = new promClient.Counter({
+  name: 'registry_operation_outcome_count',
+  help: 'Number of completed registry operations by outcome. Only unexpected errors are treated as failures.',
+  labelNames: ['operation', 'conclusion'],
+});
+
+export const registryOperationUnexpectedErrorCount = new promClient.Counter({
+  name: 'registry_operation_unexpected_error_count',
+  help: 'Unexpected, not gracefully handled registry operation errors.',
+  labelNames: ['operation', 'source'],
+});
+
+export function unexpectedErrorMetricLabels(operation: string, error: unknown) {
+  return {
+    operation,
+    source: getErrorSource(error) ?? 'unknown',
+  };
+}

--- a/packages/services/service-common/src/errors.ts
+++ b/packages/services/service-common/src/errors.ts
@@ -1,6 +1,53 @@
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify';
 import * as Sentry from '@sentry/node';
 
+export type ErrorSource = string;
+
+const errorSourceProperty = 'hiveErrorSource';
+
+export type ErrorWithSource = Error & {
+  errorSource: ErrorSource;
+};
+
+const unexpectedErrorCounted = Symbol('unexpectedErrorCounted');
+
+export function markUnexpectedErrorCounted(error: unknown): void {
+  if (error instanceof Error) {
+    Object.defineProperty(error, unexpectedErrorCounted, { value: true });
+  }
+}
+
+export function isUnexpectedErrorCounted(error: unknown): boolean {
+  return error instanceof Error && unexpectedErrorCounted in error;
+}
+
+export function withErrorSource<T>(promise: Promise<T>, errorSource: ErrorSource): Promise<T> {
+  return promise.catch(error => {
+    throw setErrorSource(error, errorSource);
+  });
+}
+
+export function setErrorSource(error: unknown, errorSource: ErrorSource): ErrorWithSource {
+  const sourcedError = error instanceof Error ? error : new Error(String(error));
+
+  if (!('errorSource' in sourcedError)) {
+    Object.defineProperty(sourcedError, errorSourceProperty, {
+      value: errorSource,
+      enumerable: true,
+    });
+  }
+
+  return sourcedError as ErrorWithSource;
+}
+
+export function getErrorSource(error: unknown): ErrorSource | null {
+  if (error instanceof Error && errorSourceProperty in error) {
+    return String(error[errorSourceProperty]);
+  }
+
+  return null;
+}
+
 export function createErrorHandler(server: FastifyInstance) {
   return function errorHandler(message: string, error: Error, logger?: FastifyBaseLogger) {
     Sentry.captureException(error);

--- a/packages/services/service-common/src/errors.ts
+++ b/packages/services/service-common/src/errors.ts
@@ -9,18 +9,6 @@ export type ErrorWithSource = Error & {
   errorSource: ErrorSource;
 };
 
-const unexpectedErrorCounted = Symbol('unexpectedErrorCounted');
-
-export function markUnexpectedErrorCounted(error: unknown): void {
-  if (error instanceof Error) {
-    Object.defineProperty(error, unexpectedErrorCounted, { value: true });
-  }
-}
-
-export function isUnexpectedErrorCounted(error: unknown): boolean {
-  return error instanceof Error && unexpectedErrorCounted in error;
-}
-
 export function withErrorSource<T>(promise: Promise<T>, errorSource: ErrorSource): Promise<T> {
   return promise.catch(error => {
     throw setErrorSource(error, errorSource);

--- a/packages/services/service-common/src/errors.ts
+++ b/packages/services/service-common/src/errors.ts
@@ -18,7 +18,7 @@ export function withErrorSource<T>(promise: Promise<T>, errorSource: ErrorSource
 export function setErrorSource(error: unknown, errorSource: ErrorSource): ErrorWithSource {
   const sourcedError = error instanceof Error ? error : new Error(String(error));
 
-  if (!('errorSource' in sourcedError)) {
+  if (!(errorSourceProperty in sourcedError)) {
     Object.defineProperty(sourcedError, errorSourceProperty, {
       value: errorSource,
       enumerable: true,

--- a/packages/services/service-common/src/trpc.ts
+++ b/packages/services/service-common/src/trpc.ts
@@ -1,9 +1,25 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { ZodError } from 'zod';
 import * as Sentry from '@sentry/node';
+import type { TRPCLink } from '@trpc/client';
 import { experimental_standaloneMiddleware, type AnyRouter } from '@trpc/server';
 import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import type { CreateFastifyContextOptions } from '@trpc/server/adapters/fastify';
+import { observable } from '@trpc/server/observable';
+import { setErrorSource } from './errors';
+
+export function errorSourceLink<TRouter extends AnyRouter>(errorSource: string): TRPCLink<TRouter> {
+  return () =>
+    ({ op, next }) =>
+      observable(observer =>
+        next(op).subscribe({
+          next: value => observer.next(value),
+          complete: () => observer.complete(),
+          error: error =>
+            observer.error(setErrorSource(error, errorSource) as unknown as typeof error),
+        }),
+      );
+}
 
 export function registerTRPC<
   TRouter extends AnyRouter,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,6 +439,9 @@ importers:
 
   packages/internal/postgres:
     dependencies:
+      '@hive/service-common':
+        specifier: workspace:*
+        version: link:../../services/service-common
       '@standard-schema/spec':
         specifier: 1.0.0
         version: 1.0.0
@@ -455,9 +458,6 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
     devDependencies:
-      '@hive/service-common':
-        specifier: workspace:*
-        version: link:../../services/service-common
       vitest:
         specifier: 4.1.3
         version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
@@ -31377,8 +31377,8 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3)
       eslint: 8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)
       eslint-config-prettier: 9.1.2(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
       eslint-plugin-jsonc: 2.19.1(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
       eslint-plugin-mdx: 3.2.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
@@ -34237,7 +34237,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -34248,7 +34248,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
     transitivePeerDependencies:
       - supports-color
 
@@ -34276,14 +34276,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3)
       eslint: 8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
     transitivePeerDependencies:
       - supports-color
 
@@ -34310,7 +34310,7 @@ snapshots:
       eslint: 8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)
       eslint-compat-utils: 0.5.1(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -34321,7 +34321,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0)))(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))
       hasown: 2.0.4
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,9 +439,6 @@ importers:
 
   packages/internal/postgres:
     dependencies:
-      '@hive/service-common':
-        specifier: workspace:*
-        version: link:../../services/service-common
       '@standard-schema/spec':
         specifier: 1.0.0
         version: 1.0.0
@@ -458,6 +455,9 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
     devDependencies:
+      '@hive/service-common':
+        specifier: workspace:*
+        version: link:../../services/service-common
       vitest:
         specifier: 4.1.3
         version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.12.7(@types/node@25.5.0)(typescript@5.7.3))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))

--- a/scripts/seed-schemas.ts
+++ b/scripts/seed-schemas.ts
@@ -86,6 +86,62 @@ const publishMutationDocument =
     }
   `;
 
+const checkMutationDocument =
+  /* GraphQL */
+  `
+    mutation schemaCheck($input: SchemaCheckInput!) {
+      schemaCheck(input: $input) {
+        __typename
+        ... on SchemaCheckSuccess {
+          valid
+          schemaCheck {
+            webUrl
+          }
+        }
+        ... on SchemaCheckError {
+          valid
+          schemaCheck {
+            webUrl
+          }
+          errors {
+            nodes {
+              message
+            }
+          }
+        }
+      }
+    }
+  `;
+
+async function checkSchema(args: { sdl: string; service?: string; target?: string }) {
+  const response = await fetch(graphqlEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      query: checkMutationDocument,
+      variables: {
+        input: {
+          sdl: args.sdl,
+          service: args.service,
+          target: args.target ? { byId: args.target } : null,
+        },
+      },
+    }),
+  }).then(res => res.json());
+  return response as {
+    data: {
+      schemaCheck: {
+        schemaCheck: { webUrl: string } | null;
+        valid: boolean;
+      } | null;
+    } | null;
+    errors?: any[];
+  };
+}
+
 async function publishSchema(args: { sdl: string; service?: string; target?: string }) {
   const commit = `${Date.now()}`;
   const response = await fetch(graphqlEndpoint, {
@@ -123,11 +179,25 @@ function minifySchema(schema: string): string {
   return schema.replace(/\s+/g, ' ').trim();
 }
 
+function createCheckSdl(sdl: string, variant: string): string {
+  const field = `seedCheck${variant.replace(/[^a-zA-Z0-9_]/g, '_')}`;
+  return `${sdl} extend type Query { ${field}: String }`;
+}
+
 async function single() {
   const schema = await loadSchema('scripts/seed-schemas/mono.graphql', {
     loaders: [new GraphQLFileLoader()],
   });
   const sdl = minifySchema(printSchema(schema));
+  const checkResult = await checkSchema({
+    sdl: createCheckSdl(sdl, 'Single'),
+    target,
+  });
+  if (checkResult?.errors || checkResult?.data?.schemaCheck?.valid !== true) {
+    console.error(`Schema check is invalid.`);
+  } else {
+    console.log(`Schema check succeeded (${checkResult.data.schemaCheck.schemaCheck?.webUrl})`);
+  }
   const result = await publishSchema({
     sdl,
     target,
@@ -151,9 +221,21 @@ async function federation() {
         return null;
       }
       const service = d.location ? parsePath(d.location).name.replaceAll('.', '-') : undefined;
+      const sdl = minifySchema(d.rawSDL);
+
+      const checkResult = await checkSchema({
+        sdl: createCheckSdl(sdl, service ?? 'Federated'),
+        service,
+        target,
+      });
+      if (checkResult?.errors || checkResult?.data?.schemaCheck?.valid !== true) {
+        console.error(`Schema check is invalid for "${service}".`);
+      } else {
+        console.log(`Schema check for "${service}" succeeded.`);
+      }
 
       const result = await publishSchema({
-        sdl: minifySchema(d.rawSDL),
+        sdl,
         service,
         target,
       });


### PR DESCRIPTION
Exposes total amount and error source for critical schema registry operations:
- schema publish
- schema check
- schema promotion
- app deployment create
- app deployment document upload
- app deployment publish

This will allow us overseeing the total amount of times each operation is performed and the source on why operation fails.

It can be used as a source for alerts so we are informed when object storage (r2/s3), clickhouse, pg, clickhouse or an internal service is causing issues.