### PR TITLE
add `SchemaVersion.date` to the public GraphQL API schema

### DIFF
--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -1011,9 +1011,9 @@ export default gql`
     """
     hasSchemaChanges: Boolean!
     """
-    The data on which this schema version was published.
+    The date on which this schema version was published.
     """
-    date: DateTime!
+    date: DateTime! @tag(name: "public")
     """
     The log that initiated this schema version.
     For a federation schema this is the published or removed subgraph/service.


### PR DESCRIPTION
Can be useful. Internal context: https://guild-oss.slack.com/archives/C013PFF4T1U/p1788271679722649?thread_ts=1787723331.399249&cid=C013PFF4T1U