### PR TITLE
Fix cli graphql request error handling edge case and log order

### DIFF
--- a/.changeset/long-ants-worry.md
+++ b/.changeset/long-ants-worry.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/cli': patch
+---
+
+Improve error handling for graphql requests
+
+Fixes an edge case where if the graphql error response doesn't include the extension, then an unexpected error was thrown. Additionally, if this error was thrown, then the error response was not logged even if the debug logs are enabled. This moves the debug log to before these conditions so that it is possible to always see the response in the logs.

--- a/packages/libraries/cli/src/helpers/graphql-request.ts
+++ b/packages/libraries/cli/src/helpers/graphql-request.ts
@@ -83,6 +83,8 @@ export function graphqlRequest(config: {
       }
 
       if (jsonData.errors && jsonData.errors.length > 0) {
+        config.logger?.debug?.(jsonData.errors.map(String).join('\n'));
+
         if (jsonData.errors[0].extensions?.code === 'ERR_MISSING_TARGET') {
           throw new MissingArgumentsError([
             'target',
@@ -98,7 +100,6 @@ export function graphqlRequest(config: {
           throw new IntrospectionError();
         }
 
-        config.logger?.debug?.(jsonData.errors.map(String).join('\n'));
         throw new APIError(
           jsonData.errors.map(e => e.message).join('\n'),
           cleanRequestId(response?.headers?.get('x-request-id')),
@@ -119,16 +120,16 @@ export function isIntrospectionDisabledError(error: GraphQLError): boolean {
   // Default implementation - this is the string used by graphql-js and thus the majority of all other implementations
   // as they use graphql-js as a reference.
   // https://github.com/graphql/graphql-js/blob/8eb6383ae7447514343457abb2063c40e5dc81bc/src/validation/rules/custom/NoSchemaIntrospectionCustomRule.ts#L30
-  if (error.message.includes('GraphQL introspection has been disabled')) {
+  if (error.message?.includes('GraphQL introspection has been disabled')) {
     return true;
   }
   // Apollo Server
   // https://github.com/apollographql/apollo-server/blob/19d0ffca703f85f0184532393aa3fff687f30bca/packages/server/src/validationRules/NoIntrospection.ts#L20
-  if (error.extensions['validationErrorCode'] === 'INTROSPECTION_DISABLED') {
+  if (error.extensions?.['validationErrorCode'] === 'INTROSPECTION_DISABLED') {
     return true;
   }
   // https://github.com/apollographql/apollo-server/blob/19d0ffca703f85f0184532393aa3fff687f30bca/packages/server/src/validationRules/NoIntrospection.ts#L15
-  if (error.message.includes('GraphQL introspection is not allowed')) {
+  if (error.message?.includes('GraphQL introspection is not allowed')) {
     return true;
   }
   return false;


### PR DESCRIPTION
### Background

Noticed when testing the `--github` option locally using `act`.

### Description

If the graphql error response doesn't include the extension, then an unexpected error is thrown. If this error is thrown, then the error response json isnt logged even if the debug logs are enabled.

This PR moves the error debug logs ahead of the checks and adds an optional check to the extensions object in case it isnt returned.

### Checklist

- [X] Error handling and logging
