### PR TITLE
Fix SSO discovery endpoint request headers

### DIFF
--- a/.changeset/many-turtles-sin.md
+++ b/.changeset/many-turtles-sin.md
@@ -1,0 +1,7 @@
+---
+'hive': patch
+---
+
+Remove content-type header from sso discovery doc request. Since no payload is sent with this
+request, the header can cause the request to fail. This header is specifically not required by the
+configuration request

--- a/packages/web/app/src/components/organization/settings/single-sign-on/connect-single-sign-on-provider-sheet.tsx
+++ b/packages/web/app/src/components/organization/settings/single-sign-on/connect-single-sign-on-provider-sheet.tsx
@@ -448,7 +448,6 @@ async function fetchOIDCMetadata(url: string) {
   const res = await fetch(url, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json',
       Accept: 'application/json',
     },
   });


### PR DESCRIPTION
### Background

Exploring SSO configuration for google, I found their discovery endpoint: `https://accounts.google.com/.well-known/openid-configuration` and populated this option. However, fetching fails.

### Description

Removes the unnecessary header that was causing issues. This now correctly populates the fields.