### PR TITLE
Check schema validity after removing unaccessible types

### DIFF
--- a/.changeset/old-cups-smile.md
+++ b/.changeset/old-cups-smile.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Verify that adding inaccessible to unreachable types doesn't create an invalid supergraph schema.

--- a/packages/services/schema/__tests__/federation.spec.ts
+++ b/packages/services/schema/__tests__/federation.spec.ts
@@ -1,5 +1,6 @@
 import { parse } from 'graphql';
 import { composeAndValidate } from '@apollo/federation';
+import { createComposeFederation } from '../src/composition/federation';
 import { composeFederationV2 } from '../src/lib/compose';
 
 test('patch', () => {
@@ -134,4 +135,80 @@ test('native federation formats the composed supergraph', ({ expect }) => {
       product: Product
     }
   `);
+});
+
+test('contract composition fails instead of producing an invalid schema when removing unreachable types marks a type referenced by a custom directive as @inaccessible', async ({
+  expect,
+}) => {
+  const composeFederation = createComposeFederation({
+    decrypt: value => value,
+    requestTimeoutMs: 30_000,
+  });
+
+  const result = await composeFederation({
+    schemas: [
+      {
+        raw: /* GraphQL */ `
+          extend schema
+            @link(
+              url: "https://specs.apollo.dev/federation/v2.5"
+              import: ["@key", "@tag", "@composeDirective"]
+            )
+            @link(url: "https://myspecs.dev/meta/v1.0", import: ["@meta"])
+            @composeDirective(name: "@meta")
+
+          directive @meta(options: MetaOptions) repeatable on FIELD_DEFINITION
+
+          scalar MetaOptions
+
+          type Product @key(fields: "id") {
+            id: ID!
+            name: String @meta(options: {}) @tag(name: "internal")
+            secret: String @tag(name: "internal")
+          }
+
+          type Query {
+            product: Product
+          }
+        `,
+        source: 'products',
+        url: 'https://products.example.com/graphql',
+      },
+    ],
+    external: null,
+    native: true,
+    requestId: 'test',
+    contracts: [
+      {
+        id: 'contract-1',
+        filter: {
+          include: null,
+          exclude: ['internal'],
+          removeUnreachableTypesFromPublicApiSchema: true,
+        },
+      },
+    ],
+  });
+
+  expect(result.type).toBe('success');
+  if (result.type !== 'success') {
+    throw new Error('unreachable');
+  }
+
+  const contractResult = result.result.contracts?.[0];
+  expect(contractResult?.result.type).toBe('failure');
+  if (contractResult?.result.type !== 'failure') {
+    throw new Error('unreachable');
+  }
+
+  expect(contractResult.result.result.supergraph).toBeNull();
+  expect(contractResult.result.result.sdl).toBeNull();
+  expect(contractResult.result.result.errors).toContainEqual(
+    expect.objectContaining({
+      source: 'composition',
+      message: expect.stringContaining(
+        'Type "MetaOptions" is @inaccessible but is referenced by "@meta(options:)"',
+      ),
+    }),
+  );
 });

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@apollo/federation": "0.38.1",
+    "@apollo/federation-internals": "2.14.0",
     "@graphql-tools/merge": "9.2.3",
     "@graphql-tools/stitch": "10.2.2",
     "@graphql-tools/stitching-directives": "4.0.27",

--- a/packages/services/schema/src/composition/federation.ts
+++ b/packages/services/schema/src/composition/federation.ts
@@ -6,6 +6,7 @@ import {
   type FieldDefinitionNode,
   type NameNode,
 } from 'graphql';
+import { Supergraph } from '@apollo/federation-internals';
 import type { ServiceLogger } from '@hive/service-common';
 import {
   addInaccessibleToUnreachableTypes,
@@ -271,6 +272,33 @@ export const createComposeFederation = (deps: ComposeFederationDeps) =>
             supergraphDocumentNode,
             publicDocumentNode,
           });
+
+          // Marking unreachable types as @inaccessible can produce an invalid supergraph.
+          // This verifies that the supergraph generated is valid.
+          try {
+            Supergraph.build(result.supergraphSdl).apiSchema();
+          } catch (error) {
+            return {
+              id: contract.id,
+              result: {
+                type: 'failure',
+                result: {
+                  supergraph: null,
+                  sdl: null,
+                  errors: [
+                    {
+                      message: `Removing unreachable types from the public API schema produced an invalid schema: ${
+                        error instanceof Error ? error.message : String(error)
+                      }`,
+                      source: 'composition',
+                    },
+                  ],
+                  includesNetworkError: false,
+                  includesException: false,
+                },
+              },
+            } satisfies ContractResultFailure;
+          }
 
           return {
             id: contract.id,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1501,7 +1501,7 @@ importers:
     devDependencies:
       '@graphql-eslint/eslint-plugin':
         specifier: 3.20.1
-        version: 3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
+        version: 3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@24.13.3)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
       '@hive/service-common':
         specifier: workspace:*
         version: link:../service-common
@@ -1544,6 +1544,9 @@ importers:
       '@apollo/federation':
         specifier: 0.38.1
         version: 0.38.1(patch_hash=cb592719b35ac58f48c97dd557e19223b45b2c5544bec4f6f2e741c58b7f1de9)(encoding@0.1.13)(graphql@16.9.0)
+      '@apollo/federation-internals':
+        specifier: 2.14.0
+        version: 2.14.0(graphql@16.9.0)
       '@graphql-tools/merge':
         specifier: 9.2.3
         version: 9.2.3(graphql@16.9.0)
@@ -1642,7 +1645,7 @@ importers:
         version: 8.0.2
       '@graphql-hive/plugin-opentelemetry':
         specifier: 1.4.35
-        version: 1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)
+        version: 1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)(ws@8.21.0)
       '@graphql-hive/yoga':
         specifier: workspace:*
         version: link:../../libraries/yoga/dist
@@ -11976,10 +11979,6 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
-
-  chalk@5.3.0:
-    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -22358,29 +22357,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@graphql-eslint/eslint-plugin@3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.29.7)(graphql@16.9.0)
-      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.7)(graphql@16.9.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.9.0)
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      fast-glob: 3.3.3
-      graphql: 16.9.0
-      graphql-config: 4.5.0(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
-      graphql-depth-limit: 1.1.0(graphql@16.9.0)
-      lodash.lowercase: 4.3.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/node'
-      - bufferutil
-      - cosmiconfig-toml-loader
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   '@graphql-hive/core@0.21.1(graphql@16.14.2)(pino@10.3.0)':
     dependencies:
       '@graphql-hive/logger': 1.1.0(pino@10.3.0)
@@ -22695,7 +22671,7 @@ snapshots:
       - winston
       - ws
 
-  '@graphql-hive/plugin-opentelemetry@1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)':
+  '@graphql-hive/plugin-opentelemetry@1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)(ws@8.21.0)':
     dependencies:
       '@graphql-hive/core': 0.21.1(graphql@16.9.0)(pino@10.3.0)
       '@graphql-hive/gateway-runtime': 2.9.10(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)(ws@8.21.0)
@@ -33109,8 +33085,6 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.3.0: {}
-
   chalk@5.6.2: {}
 
   change-case-all@1.0.15:
@@ -36015,7 +35989,7 @@ snapshots:
       ansi-escapes: 7.1.1
       ansi-styles: 6.2.1
       auto-bind: 5.0.1
-      chalk: 5.3.0
+      chalk: 5.6.2
       cli-boxes: 3.0.0
       cli-cursor: 4.0.0
       cli-truncate: 4.0.0


### PR DESCRIPTION
### Background

https://github.com/graphql-hive/router/issues/1487

### Description

Our composition also validates the schema, but when we add inaccessible to unreachable types afterwards, it can cause the supergraph to become invalid.

We should determine if a supergraph is valid in the registry so that we don't expose an invalid graph to the gateways.

### Checklist

- [X] Error handling and logging
- [X] Testing
