### PR TITLE
Laboratory: improve local dev setup and small bug fixes

### DIFF
--- a/.changeset/brave-jars-shave.md
+++ b/.changeset/brave-jars-shave.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/laboratory': patch
+---
+
+Make Stop cancel a running subscription on every transport. Cancellation relied on the executor honouring `request.signal`, which `@graphql-tools/executor-legacy-ws` does not, so stopping a `LEGACY_WS` subscription did nothing and the run kept rendering events until the server completed on its own. The stream is now ended from the laboratory side as well.

--- a/packages/libraries/laboratory/dev/legacy-ws-server.ts
+++ b/packages/libraries/laboratory/dev/legacy-ws-server.ts
@@ -1,0 +1,127 @@
+/**
+ * The pre-2020 subscription protocol, whose subprotocol string is confusingly the
+ * literal `graphql-ws` (the modern one is `graphql-transport-ws`). Apollo Server 2
+ * era endpoints still speak it, and the laboratory offers it as LEGACY_WS.
+ *
+ * Hand-rolled rather than pulled from `subscriptions-transport-ws`: that package is
+ * deprecated, CJS-only, declares a `ws` peer range the workspace no longer satisfies,
+ * and runs its own parse/validate outside envelop.
+ *
+ * Two client-side quirks show up when driving this from a browser, both in
+ * @graphql-tools/executor-legacy-ws and neither fixable from here:
+ *  - its teardown calls the node `ws` API `terminate()`, which the browser WebSocket
+ *    does not have, so it throws after the stream has already completed. See
+ *    dev/legacy-ws-shim.ts.
+ *  - it ignores `request.signal`, so the laboratory's Stop button cannot cancel a run.
+ */
+import type { IncomingMessage } from 'node:http';
+import type { WebSocket, WebSocketServer } from 'ws';
+import {
+  buildExecutionArgs,
+  isSubscription,
+  type EnvelopedRoot,
+  type MockYoga,
+  type SubscribePayload,
+} from './yoga-enveloped';
+
+const KEEP_ALIVE_MS = 12_000;
+
+export const attachLegacyWSServer = (wss: WebSocketServer, yoga: MockYoga) => {
+  wss.on('connection', (socket: WebSocket, request: IncomingMessage) => {
+    const running = new Map<string, AsyncIterator<unknown>>();
+    let keepAlive: ReturnType<typeof setInterval> | undefined;
+
+    const send = (message: Record<string, unknown>) => {
+      if (socket.readyState === socket.OPEN) {
+        socket.send(JSON.stringify(message));
+      }
+    };
+
+    const stop = (id: string) => {
+      void running.get(id)?.return?.(undefined);
+      running.delete(id);
+    };
+
+    const run = async (id: string, payload: SubscribePayload) => {
+      try {
+        const args = await buildExecutionArgs(yoga, payload, { request, socket });
+
+        if (Array.isArray(args)) {
+          send({ type: 'error', id, payload: args });
+          return;
+        }
+
+        const root = args.rootValue as EnvelopedRoot;
+        const result = isSubscription(args.document, payload.operationName)
+          ? await root.subscribe(args)
+          : await root.execute(args);
+
+        if (!(Symbol.asyncIterator in Object(result))) {
+          send({ type: 'data', id, payload: result });
+          send({ type: 'complete', id });
+          return;
+        }
+
+        const iterator = (result as AsyncIterable<unknown>)[Symbol.asyncIterator]();
+        running.set(id, iterator);
+
+        try {
+          // A `stop` calls return() on the iterator, which ends this loop and reports
+          // the operation complete, as the protocol expects.
+          for (let next = await iterator.next(); !next.done; next = await iterator.next()) {
+            send({ type: 'data', id, payload: next.value });
+          }
+
+          send({ type: 'complete', id });
+        } finally {
+          running.delete(id);
+        }
+      } catch (error: unknown) {
+        send({
+          type: 'error',
+          id,
+          payload: { message: error instanceof Error ? error.message : 'Unknown error' },
+        });
+      }
+    };
+
+    socket.on('message', (raw: unknown) => {
+      let message: { type?: string; id?: string; payload?: SubscribePayload };
+
+      try {
+        message = JSON.parse(String(raw));
+      } catch {
+        send({ type: 'connection_error', payload: { message: 'Invalid message' } });
+        return;
+      }
+
+      switch (message.type) {
+        case 'connection_init':
+          send({ type: 'connection_ack' });
+          keepAlive ??= setInterval(() => send({ type: 'ka' }), KEEP_ALIVE_MS);
+          break;
+        case 'start':
+          if (message.id && message.payload) {
+            void run(message.id, message.payload);
+          }
+          break;
+        case 'stop':
+          if (message.id) {
+            stop(message.id);
+          }
+          break;
+        case 'connection_terminate':
+          socket.close(1000);
+          break;
+      }
+    });
+
+    socket.on('close', () => {
+      clearInterval(keepAlive);
+
+      for (const id of [...running.keys()]) {
+        stop(id);
+      }
+    });
+  });
+};

--- a/packages/libraries/laboratory/dev/legacy-ws-shim.ts
+++ b/packages/libraries/laboratory/dev/legacy-ws-shim.ts
@@ -1,0 +1,15 @@
+/**
+ * Dev harness only, never shipped.
+ *
+ * @graphql-tools/executor-legacy-ws tears a connection down with `terminate()`, an API
+ * that exists on node's `ws` sockets but not on the browser WebSocket, so LEGACY_WS
+ * runs end with an uncaught TypeError after the stream has already completed. Aliasing
+ * it to close() keeps the console readable while testing the transport locally; what
+ * an embedder sees is unchanged.
+ */
+if (typeof WebSocket !== 'undefined' && !('terminate' in WebSocket.prototype)) {
+  (WebSocket.prototype as WebSocket & { terminate: () => void }).terminate =
+    WebSocket.prototype.close;
+}
+
+export {};

--- a/packages/libraries/laboratory/dev/mock-graphql.spec.ts
+++ b/packages/libraries/laboratory/dev/mock-graphql.spec.ts
@@ -1,0 +1,99 @@
+import { createMockYoga } from './mock-graphql';
+
+/**
+ * Frames are parsed rather than snapshotted: schema.graphql is regenerated regularly,
+ * so a whole-body snapshot would rot on changes that have nothing to do with the mock.
+ */
+const parseFrames = (body: string) => {
+  const frames = body
+    .split('\n\n')
+    .map(frame => frame.trim())
+    .filter(Boolean);
+
+  const events = frames
+    .filter(frame => frame.startsWith('event: next'))
+    .map(frame => {
+      const data = frame
+        .split('\n')
+        .find(line => line.startsWith('data:'))!
+        .slice('data:'.length);
+
+      return JSON.parse(data) as {
+        data: Record<string, Record<string, string>>;
+        extensions?: Record<string, unknown>;
+      };
+    });
+
+  return { events, completed: frames.some(frame => frame.startsWith('event: complete')) };
+};
+
+const runSubscription = async (query: string, headers: Record<string, string> = {}) => {
+  // intervalMs 0 keeps the whole stream inside one await; the generator still ends on
+  // its own, which is what lets us read the body to completion.
+  const yoga = createMockYoga({ subscriptions: { eventCount: 3, intervalMs: 0 } });
+  const url = new URL('http://localhost/graphql');
+  url.searchParams.set('query', query);
+
+  const response = await yoga.fetch(url, {
+    method: 'GET',
+    headers: { accept: 'text/event-stream', ...headers },
+  });
+
+  return { response, ...parseFrames(await response.text()) };
+};
+
+const OIDC_LOG = /* GraphQL */ `
+  subscription OidcLog {
+    oidcIntegrationLog(input: { oidcIntegrationId: "dev" }) {
+      message
+      timestamp
+    }
+  }
+`;
+
+describe('mock subscriptions', () => {
+  it('streams over SSE and completes', async () => {
+    const { response, events, completed } = await runSubscription(OIDC_LOG);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    expect(events).toHaveLength(3);
+    expect(completed).toBe(true);
+  });
+
+  it('gives each event a distinct payload', async () => {
+    const { events } = await runSubscription(OIDC_LOG);
+    const messages = events.map(event => event.data.oidcIntegrationLog.message);
+    const timestamps = events.map(event =>
+      Date.parse(event.data.oidcIntegrationLog.timestamp as string),
+    );
+
+    expect(new Set(messages).size).toBe(messages.length);
+    expect(timestamps).toEqual([...timestamps].sort((a, b) => a - b));
+    expect(timestamps.every(Number.isFinite)).toBe(true);
+  });
+
+  // queryPlanPlugin hooks onExecute, which envelop does not run for subscription
+  // events. Asserted so the gap is documented rather than rediscovered.
+  it('does not attach a query plan to subscription events', async () => {
+    const { events } = await runSubscription(OIDC_LOG, { 'x-query-plan': 'simple' });
+
+    expect(events.every(event => event.extensions?.queryPlan === undefined)).toBe(true);
+  });
+});
+
+describe('mock queries', () => {
+  it('still resolves generated values', async () => {
+    const yoga = createMockYoga();
+
+    const response = await yoga.fetch('http://localhost/graphql', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: '{ me { id displayName } }' }),
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { me: { id: 'mock-id', displayName: 'displayName value' } },
+    });
+  });
+});

--- a/packages/libraries/laboratory/dev/mock-graphql.ts
+++ b/packages/libraries/laboratory/dev/mock-graphql.ts
@@ -10,6 +10,11 @@
  *
  * Send `x-query-plan: <fixture>` with a request to get an extensions.queryPlan back;
  * see dev/query-plan-fixtures.ts for the names. Omit the header for the empty state.
+ * Subscriptions never see one: queryPlanPlugin hooks onExecute, which envelop does
+ * not run for subscription events.
+ *
+ * Subscription fields stream a few generated events and then complete, so every
+ * transport the lab offers (SSE, graphql-ws, legacy ws) has something to carry.
  *
  * Note: everything here goes through graphql-yoga's own exports on purpose. The
  * workspace has two copies of `graphql` (16.9.0 hoisted at the root, 16.14.2 for
@@ -25,12 +30,17 @@ import { resolveQueryPlanFixture } from './query-plan-fixtures';
 type MockType = {
   ofType?: MockType;
   name?: string;
+  getFields?: () => Record<string, MockField>;
   getValues?: () => Array<{ value: unknown }>;
   serialize?: unknown;
   toString: () => string;
 };
 
-type MockField = { type: MockType; resolve?: (source: unknown) => unknown };
+type MockField = {
+  type: MockType;
+  resolve?: (source: unknown) => unknown;
+  subscribe?: () => AsyncGenerator<unknown>;
+};
 
 type MockNamedType = {
   name: string;
@@ -84,6 +94,51 @@ const mockValue = (type: MockType, fieldName: string): unknown => {
   return {};
 };
 
+/** Strip ! and [] structurally; a named type has no ofType, so this stops there. */
+const namedTypeOf = (type: MockType): MockType => (type.ofType ? namedTypeOf(type.ofType) : type);
+
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}T/;
+
+/**
+ * Make successive events tell themselves apart without changing their type: a
+ * DateTime stays a parseable DateTime, an enum stays a member of its enum.
+ */
+const withTick = (value: unknown, tick: number): unknown => {
+  if (typeof value === 'number') {
+    return value + tick;
+  }
+
+  if (typeof value === 'string') {
+    return ISO_8601.test(value)
+      ? new Date(Date.parse(value) + tick * 1000).toISOString()
+      : `${value} #${tick}`;
+  }
+
+  return value;
+};
+
+/**
+ * Seeds one event. The wrapper object matters: the generated root resolver returns
+ * source[fieldName] when present, so a bare payload would be ignored and every tick
+ * would render identically. Seeding only reaches the event type's own fields, which
+ * is enough for the flat event types in the schema.
+ */
+const mockEventSource = (field: MockField, fieldName: string, tick: number): unknown => {
+  const named = namedTypeOf(field.type);
+  const fields = typeof named.getFields === 'function' ? named.getFields() : null;
+
+  const payload = fields
+    ? Object.fromEntries(
+        Object.entries(fields).map(([name, eventField]) => [
+          name,
+          withTick(mockValue(eventField.type, name), tick),
+        ]),
+      )
+    : withTick(mockValue(field.type, fieldName), tick);
+
+  return { [fieldName]: payload };
+};
+
 const queryPlanPlugin: Plugin = {
   onExecute({ args }) {
     const request = (args.contextValue as { request?: Request } | undefined)?.request;
@@ -112,9 +167,13 @@ const queryPlanPlugin: Plugin = {
   },
 };
 
-export const createMockYoga = ({ graphqlEndpoint = '/graphql' } = {}) => {
+export const createMockYoga = ({
+  graphqlEndpoint = '/graphql',
+  subscriptions = { eventCount: 3, intervalMs: 500 },
+} = {}) => {
   const schemaPath = fileURLToPath(new URL('../../../../schema.graphql', import.meta.url));
   const schema = createSchema({ typeDefs: readFileSync(schemaPath, 'utf-8') });
+  const subscriptionTypeName = (schema.getSubscriptionType() as { name?: string } | null)?.name;
 
   for (const type of Object.values(schema.getTypeMap()) as unknown as MockNamedType[]) {
     if (type.name.startsWith('__')) {
@@ -131,6 +190,22 @@ export const createMockYoga = ({ graphqlEndpoint = '/graphql' } = {}) => {
           }
 
           return mockValue(field.type, fieldName);
+        };
+
+        if (type.name !== subscriptionTypeName) {
+          continue;
+        }
+
+        // Finite on purpose: the UI shows a run that completes, and specs can read
+        // the whole response body without a timeout.
+        field.subscribe = async function* mockEvents() {
+          for (let tick = 0; tick < subscriptions.eventCount; tick++) {
+            if (tick > 0 && subscriptions.intervalMs > 0) {
+              await new Promise(resolve => setTimeout(resolve, subscriptions.intervalMs));
+            }
+
+            yield mockEventSource(field, fieldName, tick);
+          }
         };
       }
     }

--- a/packages/libraries/laboratory/dev/mock-graphql.ts
+++ b/packages/libraries/laboratory/dev/mock-graphql.ts
@@ -170,8 +170,8 @@ const queryPlanPlugin: Plugin = {
 export const createMockYoga = ({
   graphqlEndpoint = '/graphql',
   subscriptions = { eventCount: 3, intervalMs: 500 },
+  schemaPath = fileURLToPath(new URL('../../../../schema.graphql', import.meta.url)),
 } = {}) => {
-  const schemaPath = fileURLToPath(new URL('../../../../schema.graphql', import.meta.url));
   const schema = createSchema({ typeDefs: readFileSync(schemaPath, 'utf-8') });
   const subscriptionTypeName = (schema.getSubscriptionType() as { name?: string } | null)?.name;
 

--- a/packages/libraries/laboratory/dev/operations.ts
+++ b/packages/libraries/laboratory/dev/operations.ts
@@ -41,6 +41,21 @@ query SimplePlan {
     extensions: '',
   },
   {
+    id: 'dev-op-subscription',
+    name: 'Subscription',
+    query: `# Streams three events, then completes. Switch the transport under
+# Settings > Subscriptions > Protocol; the mock serves them all.
+subscription OidcLog {
+  oidcIntegrationLog(input: { oidcIntegrationId: "dev" }) {
+    message
+    timestamp
+  }
+}`,
+    variables: '',
+    headers: '',
+    extensions: '',
+  },
+  {
     id: 'dev-op-defer-plan',
     name: 'Defer plan',
     query: `# Plan tree with a Defer node: one primary branch, one deferred.

--- a/packages/libraries/laboratory/dev/previews/subscriptions.preview.tsx
+++ b/packages/libraries/laboratory/dev/previews/subscriptions.preview.tsx
@@ -1,0 +1,67 @@
+/**
+ * One preview per subscription transport, so each can be opened and run without walking
+ * through the settings form. The mock endpoint serves all of them at once (SSE from yoga
+ * itself, the two WebSocket protocols from dev/subscription-transports.ts); the only
+ * thing these previews change is which one the client picks.
+ *
+ * The seeded "Subscription" tab is the one to run. Every transport should stream three
+ * events and then complete.
+ */
+import { createPreview, defineControls, type NavPath } from 'react-foundry';
+import { Laboratory } from '../../src/components/laboratory/laboratory';
+import { defaultLaboratorySettings, type LaboratorySettings } from '../../src/lib/settings';
+import { devCollections } from '../collections';
+import '../legacy-ws-shim';
+import { devActiveTabId, devOperations, devTabs } from '../operations';
+import { devPreflight } from '../preflight';
+
+export const nav: NavPath = 'Laboratory/Subscriptions';
+
+const PROTOCOLS = ['SSE', 'GRAPHQL_SSE', 'WS', 'LEGACY_WS'] as const;
+
+const settingsFor = (
+  protocol: LaboratorySettings['subscriptions']['protocol'],
+): LaboratorySettings => ({
+  ...defaultLaboratorySettings,
+  subscriptions: { protocol },
+});
+
+const LaboratoryWith = ({
+  protocol,
+}: {
+  protocol: LaboratorySettings['subscriptions']['protocol'];
+}) => (
+  <Laboratory
+    enableDocs
+    theme="dark"
+    defaultEndpoint={`${window.location.origin}/graphql`}
+    defaultSettings={settingsFor(protocol)}
+    defaultCollections={devCollections}
+    defaultOperations={devOperations}
+    defaultTabs={devTabs}
+    defaultActiveTabId={devActiveTabId}
+    defaultPreflight={devPreflight}
+  />
+);
+
+export const SSE = createPreview(() => <LaboratoryWith protocol="SSE" />);
+
+export const GraphQLSSE = createPreview({
+  label: 'GRAPHQL_SSE',
+  render: () => <LaboratoryWith protocol="GRAPHQL_SSE" />,
+});
+
+export const WS = createPreview(() => <LaboratoryWith protocol="WS" />);
+
+export const LegacyWS = createPreview({
+  label: 'LEGACY_WS',
+  render: () => <LaboratoryWith protocol="LEGACY_WS" />,
+});
+
+export const Protocols = createPreview({
+  controls: defineControls({
+    protocol: { type: 'select', options: [...PROTOCOLS], default: 'WS' },
+  }),
+  // Settings are seeded once at mount, so the key remounts the Laboratory on a switch.
+  render: values => <LaboratoryWith key={values.protocol} protocol={values.protocol} />,
+});

--- a/packages/libraries/laboratory/dev/subscription-transports.spec.ts
+++ b/packages/libraries/laboratory/dev/subscription-transports.spec.ts
@@ -1,0 +1,183 @@
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { createClient } from 'graphql-ws';
+import { WebSocket } from 'ws';
+import { createMockYoga } from './mock-graphql';
+import { attachSubscriptionTransports } from './subscription-transports';
+
+const OIDC_LOG = /* GraphQL */ `
+  subscription OidcLog {
+    oidcIntegrationLog(input: { oidcIntegrationId: "dev" }) {
+      message
+    }
+  }
+`;
+
+type Message = { type: string; id?: string; payload?: Record<string, any> };
+
+/** Collects socket messages and lets a test await the one it cares about. */
+class Inbox {
+  readonly messages: Message[] = [];
+  private waiters: Array<() => void> = [];
+
+  constructor(socket: WebSocket) {
+    socket.on('message', raw => {
+      this.messages.push(JSON.parse(String(raw)) as Message);
+      this.waiters.splice(0).forEach(notify => notify());
+    });
+  }
+
+  async waitFor(predicate: (message: Message) => boolean) {
+    while (!this.messages.some(predicate)) {
+      await new Promise<void>(resolve => this.waiters.push(resolve));
+    }
+
+    return this.messages.find(predicate)!;
+  }
+
+  ofType(type: string) {
+    return this.messages.filter(message => message.type === type);
+  }
+}
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    await cleanup();
+  }
+});
+
+const startServer = async (subscriptions = { eventCount: 3, intervalMs: 0 }) => {
+  const yoga = createMockYoga({ subscriptions });
+  const httpServer = createServer(yoga);
+  const transports = attachSubscriptionTransports({ httpServer, yoga, path: '/graphql' });
+
+  await new Promise<void>(resolve => httpServer.listen(0, resolve));
+
+  cleanups.push(async () => {
+    await transports.dispose();
+    await new Promise<void>(resolve => httpServer.close(() => resolve()));
+  });
+
+  const { port } = httpServer.address() as AddressInfo;
+
+  return `ws://localhost:${port}/graphql`;
+};
+
+const connect = async (url: string, protocol: string) => {
+  const socket = new WebSocket(url, protocol);
+  const inbox = new Inbox(socket);
+
+  await new Promise<void>((resolve, reject) => {
+    socket.once('open', resolve);
+    socket.once('error', reject);
+  });
+
+  cleanups.push(() => socket.close());
+
+  return { socket, inbox };
+};
+
+const send = (socket: WebSocket, message: Message) => socket.send(JSON.stringify(message));
+
+describe('legacy ws transport', () => {
+  it('acknowledges the connection, streams data, then completes', async () => {
+    const url = await startServer();
+    const { socket, inbox } = await connect(url, 'graphql-ws');
+
+    send(socket, { type: 'connection_init' });
+    await inbox.waitFor(message => message.type === 'connection_ack');
+
+    send(socket, { type: 'start', id: '1', payload: { query: OIDC_LOG } });
+    await inbox.waitFor(message => message.type === 'complete');
+
+    const data = inbox.ofType('data');
+    const messages = data.map(event => event.payload?.data.oidcIntegrationLog.message);
+
+    expect(data).toHaveLength(3);
+    expect(new Set(messages).size).toBe(3);
+    expect(data.every(event => event.id === '1')).toBe(true);
+  });
+
+  it('stops a running subscription on request', async () => {
+    // Slow enough that the stop lands mid-stream rather than after it finished.
+    const url = await startServer({ eventCount: 50, intervalMs: 50 });
+    const { socket, inbox } = await connect(url, 'graphql-ws');
+
+    send(socket, { type: 'connection_init' });
+    await inbox.waitFor(message => message.type === 'connection_ack');
+
+    send(socket, { type: 'start', id: '1', payload: { query: OIDC_LOG } });
+    await inbox.waitFor(message => message.type === 'data');
+
+    send(socket, { type: 'stop', id: '1' });
+    await inbox.waitFor(message => message.type === 'complete');
+
+    const afterComplete = inbox.messages.slice(
+      inbox.messages.findIndex(message => message.type === 'complete') + 1,
+    );
+
+    expect(inbox.ofType('data').length).toBeLessThan(50);
+    expect(afterComplete.filter(message => message.type === 'data')).toHaveLength(0);
+  });
+
+  it('reports validation errors instead of streaming', async () => {
+    const url = await startServer();
+    const { socket, inbox } = await connect(url, 'graphql-ws');
+
+    send(socket, { type: 'connection_init' });
+    await inbox.waitFor(message => message.type === 'connection_ack');
+
+    send(socket, { type: 'start', id: '1', payload: { query: 'subscription { nope }' } });
+    const error = await inbox.waitFor(message => message.type === 'error');
+
+    expect(error.id).toBe('1');
+    expect(inbox.ofType('data')).toHaveLength(0);
+  });
+});
+
+describe('graphql-ws transport', () => {
+  // Thin, but it covers our envelope bridge (onSubscribe plus the rootValue
+  // execute/subscribe pair), which is the part graphql-ws does not provide.
+  it('streams through the enveloped subscribe', async () => {
+    const url = await startServer();
+    const client = createClient({ url, webSocketImpl: WebSocket, retryAttempts: 0 });
+    cleanups.push(() => client.dispose());
+
+    const received: string[] = [];
+
+    for await (const result of client.iterate<{
+      oidcIntegrationLog: { message: string };
+    }>({ query: OIDC_LOG })) {
+      received.push(result.data!.oidcIntegrationLog.message);
+    }
+
+    expect(received).toHaveLength(3);
+    expect(new Set(received).size).toBe(3);
+  });
+});
+
+describe('upgrade dispatch', () => {
+  it('serves both subscription protocols on the same path', async () => {
+    const url = await startServer();
+
+    const modern = await connect(url, 'graphql-transport-ws');
+    const legacy = await connect(url, 'graphql-ws');
+
+    expect(modern.socket.protocol).toBe('graphql-transport-ws');
+    expect(legacy.socket.protocol).toBe('graphql-ws');
+  });
+
+  it('rejects an upgrade offering neither protocol', async () => {
+    const url = await startServer();
+    const socket = new WebSocket(url, 'chat');
+
+    await expect(
+      new Promise((resolve, reject) => {
+        socket.once('open', resolve);
+        socket.once('error', reject);
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/libraries/laboratory/dev/subscription-transports.ts
+++ b/packages/libraries/laboratory/dev/subscription-transports.ts
@@ -1,0 +1,99 @@
+/**
+ * Serves both WebSocket subscription protocols on the same path as the HTTP mock, so
+ * every value of the laboratory's Settings > Subscriptions > Protocol works against
+ * one endpoint: SSE and GRAPHQL_SSE come from yoga itself, WS and LEGACY_WS from here.
+ *
+ * Both servers are noServer and share one upgrade listener, dispatching on the offered
+ * subprotocol. Vite's HMR listener claims an upgrade only when the protocol is
+ * vite-hmr/vite-ping *and* the pathname is its base, so the two do not collide.
+ *
+ * Sockets are torn down when the dev server restarts, which any edit under dev/ causes
+ * (vite.config.ts imports these files, making them config dependencies). A live
+ * subscription drops at that point, by design: the next generation has a new schema.
+ */
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { useServer } from 'graphql-ws/use/ws';
+import { WebSocketServer } from 'ws';
+import { attachLegacyWSServer } from './legacy-ws-server';
+import { buildExecutionArgs, type EnvelopedRoot, type MockYoga } from './yoga-enveloped';
+
+const MODERN_PROTOCOL = 'graphql-transport-ws';
+const LEGACY_PROTOCOL = 'graphql-ws';
+
+type UpgradeListener = (request: IncomingMessage, socket: Duplex, head: Buffer) => void;
+
+/** Structural, so it accepts both a node http.Server and vite's HttpServer union. */
+type UpgradableServer = {
+  on(event: 'upgrade', listener: UpgradeListener): unknown;
+  off(event: 'upgrade', listener: UpgradeListener): unknown;
+};
+
+const offeredProtocols = (request: IncomingMessage) => {
+  const header = request.headers['sec-websocket-protocol'];
+  const raw = Array.isArray(header) ? header.join(',') : (header ?? '');
+
+  return raw.split(',').map(protocol => protocol.trim());
+};
+
+export const attachSubscriptionTransports = (options: {
+  httpServer: UpgradableServer;
+  yoga: MockYoga;
+  path: string;
+}) => {
+  const modern = new WebSocketServer({ noServer: true, handleProtocols: () => MODERN_PROTOCOL });
+  const legacy = new WebSocketServer({ noServer: true, handleProtocols: () => LEGACY_PROTOCOL });
+
+  const disposable = useServer(
+    {
+      execute: args => (args.rootValue as EnvelopedRoot).execute(args),
+      subscribe: args => (args.rootValue as EnvelopedRoot).subscribe(args),
+      onSubscribe: (ctx, _id, payload) =>
+        buildExecutionArgs(options.yoga, payload, {
+          request: ctx.extra.request,
+          socket: ctx.extra.socket,
+        }),
+    },
+    modern,
+  );
+
+  attachLegacyWSServer(legacy, options.yoga);
+
+  const onUpgrade = (request: IncomingMessage, socket: Duplex, head: Buffer) => {
+    const { pathname } = new URL(request.url ?? '/', 'http://localhost');
+
+    if (pathname !== options.path) {
+      return;
+    }
+
+    const offered = offeredProtocols(request);
+    const target = offered.includes(MODERN_PROTOCOL)
+      ? modern
+      : offered.includes(LEGACY_PROTOCOL)
+        ? legacy
+        : null;
+
+    // Nothing else owns this path, so an unknown subprotocol would hang forever.
+    if (!target) {
+      socket.write('HTTP/1.1 400 Bad Request\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
+    target.handleUpgrade(request, socket, head, client =>
+      target.emit('connection', client, request),
+    );
+  };
+
+  options.httpServer.on('upgrade', onUpgrade);
+
+  return {
+    async dispose() {
+      options.httpServer.off('upgrade', onUpgrade);
+      await disposable.dispose();
+      await Promise.all(
+        [modern, legacy].map(server => new Promise<void>(resolve => server.close(() => resolve()))),
+      );
+    },
+  };
+};

--- a/packages/libraries/laboratory/dev/vite-plugin-mock-graphql.ts
+++ b/packages/libraries/laboratory/dev/vite-plugin-mock-graphql.ts
@@ -1,0 +1,42 @@
+/**
+ * Mounts the mock endpoint and its WebSocket transports onto a vite dev server.
+ *
+ * Lives here rather than inline in vite.config.ts because foundry runs its own vite
+ * server and needs the same endpoint; both configs register this plugin.
+ */
+import type { PluginOption } from 'vite';
+import { createMockYoga } from './mock-graphql';
+import { attachSubscriptionTransports } from './subscription-transports';
+
+export const GRAPHQL_ENDPOINT = '/graphql';
+
+/** Same-origin mock endpoint so `pnpm dev` needs no second process and no CORS. */
+export const mockGraphQLEndpoint = (): PluginOption => ({
+  name: 'laboratory-mock-graphql',
+  apply: 'serve',
+  configureServer(server) {
+    const yoga = createMockYoga({ graphqlEndpoint: GRAPHQL_ENDPOINT });
+
+    // Mounted without a route prefix so connect leaves req.url intact for yoga.
+    server.middlewares.use((req, res, next) => {
+      if (!req.url?.startsWith(GRAPHQL_ENDPOINT)) {
+        return next();
+      }
+
+      return yoga(req, res);
+    });
+
+    // Null in middleware mode, where there is no server of ours to upgrade.
+    if (!server.httpServer) {
+      return;
+    }
+
+    const transports = attachSubscriptionTransports({
+      httpServer: server.httpServer,
+      yoga,
+      path: GRAPHQL_ENDPOINT,
+    });
+
+    server.httpServer.once('close', () => void transports.dispose());
+  },
+});

--- a/packages/libraries/laboratory/dev/vite-plugin-mock-graphql.ts
+++ b/packages/libraries/laboratory/dev/vite-plugin-mock-graphql.ts
@@ -4,18 +4,26 @@
  * Lives here rather than inline in vite.config.ts because foundry runs its own vite
  * server and needs the same endpoint; both configs register this plugin.
  */
+import path from 'node:path';
 import type { PluginOption } from 'vite';
 import { createMockYoga } from './mock-graphql';
 import { attachSubscriptionTransports } from './subscription-transports';
 
 export const GRAPHQL_ENDPOINT = '/graphql';
 
+/**
+ * Resolved from the working directory rather than import.meta.url: foundry bundles the
+ * config that imports this file into node_modules/.cache, which moves the module but not
+ * the process. Both `pnpm dev` and `pnpm foundry` run from the package directory.
+ */
+const DEFAULT_SCHEMA_PATH = path.resolve(process.cwd(), '../../../schema.graphql');
+
 /** Same-origin mock endpoint so `pnpm dev` needs no second process and no CORS. */
-export const mockGraphQLEndpoint = (): PluginOption => ({
+export const mockGraphQLEndpoint = ({ schemaPath = DEFAULT_SCHEMA_PATH } = {}): PluginOption => ({
   name: 'laboratory-mock-graphql',
   apply: 'serve',
   configureServer(server) {
-    const yoga = createMockYoga({ graphqlEndpoint: GRAPHQL_ENDPOINT });
+    const yoga = createMockYoga({ graphqlEndpoint: GRAPHQL_ENDPOINT, schemaPath });
 
     // Mounted without a route prefix so connect leaves req.url intact for yoga.
     server.middlewares.use((req, res, next) => {

--- a/packages/libraries/laboratory/dev/yoga-enveloped.ts
+++ b/packages/libraries/laboratory/dev/yoga-enveloped.ts
@@ -1,0 +1,75 @@
+/**
+ * The one place the dev WebSocket servers reach into yoga.
+ *
+ * Both of them need a schema, a parsed document and an execute/subscribe pair, and
+ * both must take them from `getEnveloped()` rather than importing `graphql`: the
+ * workspace has two copies of that package and mixing them fails yoga's instanceof
+ * checks with "Duplicate graphql modules cannot be used" (see dev/mock-graphql.ts).
+ */
+import type { IncomingMessage } from 'node:http';
+import type { createMockYoga } from './mock-graphql';
+
+export type MockYoga = ReturnType<typeof createMockYoga>;
+
+type Enveloped = ReturnType<MockYoga['getEnveloped']>;
+
+/** Carried on `rootValue` so a caller can run the operation with the same envelope. */
+export type EnvelopedRoot = Pick<Enveloped, 'execute' | 'subscribe'>;
+
+export type SubscribePayload = {
+  query: string;
+  variables?: Record<string, unknown> | null;
+  operationName?: string | null;
+  extensions?: Record<string, unknown> | null;
+};
+
+export type ConnectionExtra = { request: IncomingMessage; socket: unknown };
+
+/**
+ * Returns execution args ready to run, or the validation errors that stopped it.
+ * The shape matches what graphql-ws's `onSubscribe` is allowed to return, so the
+ * legacy server and the modern one can share it.
+ */
+export const buildExecutionArgs = async (
+  yoga: MockYoga,
+  payload: SubscribePayload,
+  extra: ConnectionExtra,
+) => {
+  const { schema, execute, subscribe, contextFactory, parse, validate } = yoga.getEnveloped({
+    ...extra,
+    req: extra.request,
+    params: payload,
+  });
+
+  const args = {
+    schema,
+    operationName: payload.operationName ?? undefined,
+    document: parse(payload.query),
+    variableValues: payload.variables ?? undefined,
+    contextValue: await contextFactory(),
+    rootValue: { execute, subscribe } satisfies EnvelopedRoot,
+  };
+
+  const errors = validate(args.schema, args.document);
+
+  return errors.length ? errors : args;
+};
+
+/**
+ * graphql-js picks the subscription root type for anything handed to `subscribe`, so
+ * the operation kind has to be decided before calling it. Read off the document
+ * rather than with graphql's own helpers, for the duplicate-module reason above.
+ */
+export const isSubscription = (
+  document: { definitions: ReadonlyArray<Record<string, unknown>> },
+  operationName?: string | null,
+) =>
+  document.definitions.some(definition => {
+    if (definition.kind !== 'OperationDefinition' || definition.operation !== 'subscription') {
+      return false;
+    }
+
+    const name = (definition.name as { value?: string } | undefined)?.value;
+
+    return !operationName || name === operationName;
+  });

--- a/packages/libraries/laboratory/foundry.config.ts
+++ b/packages/libraries/laboratory/foundry.config.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+import { defineConfig } from 'react-foundry';
+import monacoEditor from 'vite-plugin-monaco-editor';
+import tailwindcss from '@tailwindcss/vite';
+import { mockGraphQLEndpoint } from './dev/vite-plugin-mock-graphql';
+
+export default defineConfig({
+  previews: 'dev/previews/**/*.preview.tsx',
+  title: 'Hive Laboratory',
+  // 5173 belongs to `pnpm dev`, so both servers can run side by side.
+  port: 5174,
+  nav: [{ label: 'Laboratory', children: [{ label: 'Subscriptions' }] }],
+  viteConfig: {
+    // Foundry runs its own vite server and never loads vite.config.ts, so everything the
+    // Laboratory needs is restated here: its stylesheet is Tailwind, its editors are
+    // monaco, its internals import through the @ alias, and the previews talk to the
+    // same mock endpoint `pnpm dev` serves.
+    plugins: [
+      tailwindcss(),
+      mockGraphQLEndpoint(),
+      // @ts-expect-error temp
+      monacoEditor.default({
+        languageWorkers: ['json', 'typescript', 'editorWorkerService'],
+        customWorkers: [
+          {
+            label: 'graphql',
+            entry: 'monaco-graphql/dist/graphql.worker',
+          },
+        ],
+      }),
+    ],
+    resolve: {
+      // This config is bundled into node_modules/.cache/react-foundry before it runs, so
+      // import.meta.dirname would point there. cwd is where `foundry dev` was invoked.
+      alias: {
+        '@': path.resolve(process.cwd(), './src'),
+      },
+    },
+  },
+});

--- a/packages/libraries/laboratory/package.json
+++ b/packages/libraries/laboratory/package.json
@@ -91,6 +91,7 @@
     "@types/node": "24.13.3",
     "@types/react": "18.3.18",
     "@types/react-dom": "18.3.5",
+    "@types/ws": "8.18.1",
     "@vitejs/plugin-react": "^5.1.2",
     "@xyflow/react": "^12.10.0",
     "autoprefixer": "^10.4.23",
@@ -107,6 +108,7 @@
     "eslint-plugin-react-refresh": "^0.4.26",
     "globals": "^16.5.0",
     "graphql": "^16.14.0",
+    "graphql-ws": "6.0.6",
     "graphql-yoga": "5.22.0",
     "happy-dom": "^20.10.6",
     "jsdom": "^30.0.1",
@@ -139,6 +141,7 @@
     "vite-plugin-commonjs": "^0.10.4",
     "vite-plugin-dts": "^4.5.4",
     "vite-plugin-monaco-editor": "^1.1.0",
+    "ws": "8.21.0",
     "zod": "^4.3.6"
   },
   "publishConfig": {

--- a/packages/libraries/laboratory/package.json
+++ b/packages/libraries/laboratory/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "build": "vite build --config vite.lib.config.ts && vite build --config vite.umd.config.ts",
     "dev": "vite",
+    "foundry": "foundry dev",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -123,6 +124,7 @@
     "postcss-prefixwrap": "^1.57.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-foundry": "0.0.10",
     "react-resizable-panels": "^3.0.6",
     "react-shadow": "^20.6.0",
     "rollup-plugin-typescript2": "^0.36.0",

--- a/packages/libraries/laboratory/package.json
+++ b/packages/libraries/laboratory/package.json
@@ -38,7 +38,6 @@
     "lz-string": "^1.5.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "subscriptions-transport-ws": "^0.11.0",
     "tslib": "^2.8.1",
     "zod": "^4.1.12"
   },
@@ -129,7 +128,6 @@
     "react-shadow": "^20.6.0",
     "rollup-plugin-typescript2": "^0.36.0",
     "sonner": "^2.0.7",
-    "subscriptions-transport-ws": "^0.11.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",
     "tailwindcss-scoped-preflight": "^3.5.7",

--- a/packages/libraries/laboratory/src/components/laboratory/laboratory.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/laboratory.tsx
@@ -26,6 +26,7 @@ import { useOperations } from '../../lib/operations';
 import { LaboratoryPluginTab, usePlugins } from '../../lib/plugins';
 import { usePreflight, usePreflightPrompt } from '../../lib/preflight';
 import { useSettings } from '../../lib/settings';
+import { ensureShadowRoot } from '../../lib/shadow-root';
 import { LaboratoryTabCustom, useTabs } from '../../lib/tabs';
 import { useTests } from '../../lib/tests';
 import { cn } from '../../lib/utils';
@@ -89,7 +90,7 @@ const ShadowRootContainer = (props: { children: ReactNode }) => {
       return;
     }
 
-    setShadowRoot(hostRef.current.attachShadow({ mode: 'open' }));
+    setShadowRoot(ensureShadowRoot(hostRef.current));
   }, [shadowRoot]);
 
   useLayoutEffect(() => {

--- a/packages/libraries/laboratory/src/index.css
+++ b/packages/libraries/laboratory/src/index.css
@@ -1,6 +1,11 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+/* Tailwind's automatic detection is anchored to the vite root, which is this package
+   when the library builds but not when another dev server (foundry) imports this file.
+   Naming the sources relative to this stylesheet makes the output the same either way. */
+@source '../src';
+
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/packages/libraries/laboratory/src/lib/operations.spec.ts
+++ b/packages/libraries/laboratory/src/lib/operations.spec.ts
@@ -1,8 +1,19 @@
 // @vitest-environment happy-dom
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type { LaboratoryCollectionsActions, LaboratoryCollectionsState } from './collections';
 import { useOperations, type LaboratoryOperation } from './operations';
 import type { LaboratoryTabsActions, LaboratoryTabsState } from './tabs';
+
+const executor = vi.fn();
+
+vi.mock('@graphql-tools/url-loader', () => ({
+  UrlLoader: class {
+    getExecutorAsync() {
+      return executor;
+    }
+  },
+  SubscriptionProtocol: { GRAPHQL_SSE: 'GRAPHQL_SSE' },
+}));
 
 const op = (id: string): LaboratoryOperation => ({
   id,
@@ -157,5 +168,57 @@ describe('useOperations', () => {
     });
 
     expect(updateOperationInCollection).not.toHaveBeenCalled();
+  });
+});
+
+describe('runActiveOperation', () => {
+  // Mirrors @graphql-tools/executor-legacy-ws: an endless stream whose executor
+  // never looks at request.signal, so only our own wrapper can end it.
+  const endlessStream = () => {
+    let returned = false;
+
+    return {
+      wasReturned: () => returned,
+      stream: {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => {
+            await new Promise(resolve => setTimeout(resolve, 5));
+            return { done: false as const, value: { data: { tick: true } } };
+          },
+          return: async () => {
+            returned = true;
+            return { done: true as const, value: undefined };
+          },
+        }),
+      },
+    };
+  };
+
+  it('stops a subscription whose executor ignores the abort signal', async () => {
+    const source = endlessStream();
+    executor.mockResolvedValue(source.stream);
+
+    const onResponse = vi.fn();
+    const { result } = renderHook(() =>
+      useOperations({
+        checkPermissions: () => true,
+        defaultOperations: [op('op1')],
+        tabsApi: tabsApiFor('op1'),
+      }),
+    );
+
+    let run: Promise<unknown>;
+    act(() => {
+      run = result.current.runActiveOperation('http://localhost:4000/graphql', { onResponse });
+    });
+
+    await waitFor(() => expect(onResponse).toHaveBeenCalled());
+    await waitFor(() => expect(result.current.stopActiveOperation).toBeTruthy());
+
+    act(() => result.current.stopActiveOperation!());
+
+    await expect(run!).resolves.toBeNull();
+    expect(source.wasReturned()).toBe(true);
+    await waitFor(() => expect(result.current.stopActiveOperation).toBeFalsy());
   });
 });

--- a/packages/libraries/laboratory/src/lib/operations.ts
+++ b/packages/libraries/laboratory/src/lib/operations.ts
@@ -10,7 +10,7 @@ import {
 } from 'graphql';
 import { decompressFromEncodedURIComponent } from 'lz-string';
 import { v4 as uuidv4 } from 'uuid';
-import { isAsyncIterable } from '@/lib/utils';
+import { isAsyncIterable, untilAborted } from '@/lib/utils';
 import { SubscriptionProtocol, UrlLoader } from '@graphql-tools/url-loader';
 import { LaboratoryPermission, LaboratoryPermissions } from '../components/laboratory/context';
 import type {
@@ -473,7 +473,7 @@ export const useOperations = (
 
         if (isAsyncIterable(response)) {
           try {
-            for await (const item of response) {
+            for await (const item of untilAborted(response, abortController.signal)) {
               options?.onResponse?.(JSON.stringify(item ?? {}));
             }
           } finally {

--- a/packages/libraries/laboratory/src/lib/settings.ts
+++ b/packages/libraries/laboratory/src/lib/settings.ts
@@ -23,6 +23,9 @@ export const defaultLaboratorySettings: LaboratorySettings = {
     timeout: 10000,
     useGETForQueries: false,
   },
+  // WS is what most server stacks serve; Apollo has no SSE transport at all. Note
+  // url-loader 9.x maps SSE and GRAPHQL_SSE onto the same HTTP executor, so those two
+  // values behave identically.
   subscriptions: {
     protocol: 'WS',
   },

--- a/packages/libraries/laboratory/src/lib/shadow-root.spec.ts
+++ b/packages/libraries/laboratory/src/lib/shadow-root.spec.ts
@@ -1,0 +1,20 @@
+// @vitest-environment happy-dom
+import { ensureShadowRoot } from './shadow-root';
+
+describe('ensureShadowRoot', () => {
+  it('attaches a shadow root to a host that has none', () => {
+    const host = document.createElement('div');
+
+    expect(ensureShadowRoot(host)).toBe(host.shadowRoot);
+  });
+
+  // The second call is what a StrictMode remount makes: same element, fresh effect.
+  // Calling attachShadow again there throws, which took the whole Laboratory down.
+  it('reuses the existing root instead of attaching a second one', () => {
+    const host = document.createElement('div');
+    const first = ensureShadowRoot(host);
+
+    expect(() => host.attachShadow({ mode: 'open' })).toThrow();
+    expect(ensureShadowRoot(host)).toBe(first);
+  });
+});

--- a/packages/libraries/laboratory/src/lib/shadow-root.ts
+++ b/packages/libraries/laboratory/src/lib/shadow-root.ts
@@ -1,0 +1,11 @@
+/**
+ * React's StrictMode runs an effect, tears it down and runs it again against the same
+ * DOM node, and `attachShadow` throws when the host already hosts a shadow tree
+ * ("Shadow root cannot be created on a host which already hosts a shadow tree").
+ * Reusing the existing root keeps the Laboratory mountable under StrictMode, which any
+ * embedder may be running in development. The sibling effects on that container run
+ * twice for the same reason, which only duplicates inert style nodes.
+ */
+export function ensureShadowRoot(host: HTMLElement): ShadowRoot {
+  return host.shadowRoot ?? host.attachShadow({ mode: 'open' });
+}

--- a/packages/libraries/laboratory/src/lib/utils.spec.ts
+++ b/packages/libraries/laboratory/src/lib/utils.spec.ts
@@ -1,4 +1,4 @@
-import { formatBytes, tokenizeUrls } from './utils';
+import { formatBytes, tokenizeUrls, untilAborted } from './utils';
 
 describe('formatBytes', () => {
   it('renders small payloads in bytes instead of rounding them away to 0', () => {
@@ -129,5 +129,41 @@ describe('tokenizeUrls', () => {
       { type: 'url', value: 'https://example.com/b' },
       { type: 'text', value: '.' },
     ]);
+  });
+});
+
+describe('untilAborted', () => {
+  it('ends the stream when the signal aborts, even if the source never settles', async () => {
+    const controller = new AbortController();
+    const source = {
+      [Symbol.asyncIterator]: () => ({ next: () => new Promise<never>(() => {}) }),
+    } as AsyncIterable<unknown>;
+
+    const drained = (async () => {
+      for await (const _ of untilAborted(source, controller.signal)) {
+        // nothing arrives; the source never resolves a value
+      }
+    })();
+
+    controller.abort();
+
+    await expect(drained).resolves.toBeUndefined();
+  });
+
+  it('releases the source it wrapped', async () => {
+    const controller = new AbortController();
+    const returned = vi.fn(async () => ({ done: true as const, value: undefined }));
+    const source = {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => ({ done: false as const, value: 'tick' }),
+        return: returned,
+      }),
+    } as AsyncIterable<string>;
+
+    for await (const _ of untilAborted(source, controller.signal)) {
+      controller.abort();
+    }
+
+    expect(returned).toHaveBeenCalled();
   });
 });

--- a/packages/libraries/laboratory/src/lib/utils.ts
+++ b/packages/libraries/laboratory/src/lib/utils.ts
@@ -60,6 +60,43 @@ export function isAsyncIterable<T>(val: unknown): val is AsyncIterable<T> {
   return typeof Object(val)[Symbol.asyncIterator] === 'function';
 }
 
+/**
+ * Ends a stream when the signal aborts, whatever the source does with it:
+ * @graphql-tools/executor-legacy-ws ignores `request.signal` entirely, so a stopped
+ * LEGACY_WS subscription would otherwise keep streaming until the server finished.
+ * Racing the abort also covers a source whose return() never settles a pending next().
+ */
+export async function* untilAborted<T>(
+  source: AsyncIterable<T>,
+  signal: AbortSignal,
+): AsyncIterable<T> {
+  const iterator = source[Symbol.asyncIterator]();
+  const aborted = new Promise<{ done: true }>(resolve => {
+    if (signal.aborted) {
+      resolve({ done: true });
+      return;
+    }
+
+    signal.addEventListener('abort', () => resolve({ done: true }), { once: true });
+  });
+
+  try {
+    // The signal is checked first because a source that always has a value ready
+    // wins every race against it, and the run would never stop.
+    while (!signal.aborted) {
+      const next = await Promise.race([iterator.next(), aborted]);
+
+      if (next.done) {
+        return;
+      }
+
+      yield next.value;
+    }
+  } finally {
+    await iterator.return?.(undefined);
+  }
+}
+
 // Exclude whitespace and characters that are never part of a bare URL in log text.
 const URL_PATTERN = /https?:\/\/[^\s<>"'`]+/g;
 

--- a/packages/libraries/laboratory/src/main.tsx
+++ b/packages/libraries/laboratory/src/main.tsx
@@ -1,4 +1,5 @@
 import ReactDOM from 'react-dom/client';
+import '../dev/legacy-ws-shim';
 import { devCollections } from '../dev/collections';
 import { devActiveTabId, devOperations, devTabs } from '../dev/operations';
 import { devPreflight } from '../dev/preflight';

--- a/packages/libraries/laboratory/tsconfig.app.json
+++ b/packages/libraries/laboratory/tsconfig.app.json
@@ -28,5 +28,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  /* Previews are browser code (JSX, the @ alias) even though they live under dev/. */
+  "include": ["src", "dev/previews"]
 }

--- a/packages/libraries/laboratory/tsconfig.node.json
+++ b/packages/libraries/laboratory/tsconfig.node.json
@@ -22,7 +22,7 @@
     "noUncheckedSideEffectImports": true
   },
   "include": ["vite.config.ts", "vite.lib.config.ts", "vite.umd.config.ts", "dev/**/*.ts"],
-  /* Fixtures the browser app imports belong to the app program: they pull in JSX
-     and the @/* alias, neither of which this node config has. */
-  "exclude": ["dev/collections.ts"]
+  /* Fixtures the browser app imports belong to the app program: they pull in JSX,
+     the @/* alias and the DOM lib, none of which this node config has. */
+  "exclude": ["dev/collections.ts", "dev/legacy-ws-shim.ts"]
 }

--- a/packages/libraries/laboratory/vite.config.ts
+++ b/packages/libraries/laboratory/vite.config.ts
@@ -1,29 +1,9 @@
 import path from 'path';
-import { defineConfig, type PluginOption } from 'vite';
+import { defineConfig } from 'vite';
 import monacoEditor from 'vite-plugin-monaco-editor';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import { createMockYoga } from './dev/mock-graphql';
-
-const GRAPHQL_ENDPOINT = '/graphql';
-
-/** Same-origin mock endpoint so `pnpm dev` needs no second process and no CORS. */
-const mockGraphQLEndpoint = (): PluginOption => ({
-  name: 'laboratory-mock-graphql',
-  apply: 'serve',
-  configureServer(server) {
-    const yoga = createMockYoga({ graphqlEndpoint: GRAPHQL_ENDPOINT });
-
-    // Mounted without a route prefix so connect leaves req.url intact for yoga.
-    server.middlewares.use((req, res, next) => {
-      if (!req.url?.startsWith(GRAPHQL_ENDPOINT)) {
-        return next();
-      }
-
-      return yoga(req, res);
-    });
-  },
-});
+import { mockGraphQLEndpoint } from './dev/vite-plugin-mock-graphql';
 
 // https://vite.dev/config/
 export default defineConfig(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,6 +844,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.5
         version: 18.3.5(@types/react@18.3.18)
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
       '@vitejs/plugin-react':
         specifier: ^5.1.2
         version: 5.1.2(rolldown-vite@7.1.14(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
@@ -892,6 +895,9 @@ importers:
       graphql:
         specifier: ^16.14.0
         version: 16.14.2
+      graphql-ws:
+        specifier: 6.0.6
+        version: 6.0.6(graphql@16.14.2)(ws@8.21.0)
       graphql-yoga:
         specifier: 5.22.0
         version: 5.22.0(graphql@16.14.2)
@@ -988,6 +994,9 @@ importers:
       vite-plugin-monaco-editor:
         specifier: ^1.1.0
         version: 1.1.0(monaco-editor@0.52.2)
+      ws:
+        specifier: '>=8.21.0 || >=7.5.10 || >=6.2.3 || >=5.2.4'
+        version: 8.21.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1501,7 +1510,7 @@ importers:
     devDependencies:
       '@graphql-eslint/eslint-plugin':
         specifier: 3.20.1
-        version: 3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
+        version: 3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@24.13.3)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
       '@hive/service-common':
         specifier: workspace:*
         version: link:../service-common
@@ -1642,7 +1651,7 @@ importers:
         version: 8.0.2
       '@graphql-hive/plugin-opentelemetry':
         specifier: 1.4.35
-        version: 1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)
+        version: 1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)(ws@8.21.0)
       '@graphql-hive/yoga':
         specifier: workspace:*
         version: link:../../libraries/yoga/dist
@@ -22358,29 +22367,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@graphql-eslint/eslint-plugin@3.20.1(patch_hash=92716d09c5dd6166f88ca95d28b39ad4491682d48574a36c391e9875dd5060bb)(@babel/core@7.29.7)(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.29.7)(graphql@16.9.0)
-      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.29.7)(graphql@16.9.0)
-      '@graphql-tools/utils': 9.2.1(graphql@16.9.0)
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      fast-glob: 3.3.3
-      graphql: 16.9.0
-      graphql-config: 4.5.0(@types/node@25.5.0)(cosmiconfig-toml-loader@1.0.0)(encoding@0.1.13)(graphql@16.9.0)
-      graphql-depth-limit: 1.1.0(graphql@16.9.0)
-      lodash.lowercase: 4.3.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/node'
-      - bufferutil
-      - cosmiconfig-toml-loader
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   '@graphql-hive/core@0.21.1(graphql@16.14.2)(pino@10.3.0)':
     dependencies:
       '@graphql-hive/logger': 1.1.0(pino@10.3.0)
@@ -22695,7 +22681,7 @@ snapshots:
       - winston
       - ws
 
-  '@graphql-hive/plugin-opentelemetry@1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)':
+  '@graphql-hive/plugin-opentelemetry@1.4.35(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)(ws@8.21.0)':
     dependencies:
       '@graphql-hive/core': 0.21.1(graphql@16.9.0)(pino@10.3.0)
       '@graphql-hive/gateway-runtime': 2.9.10(graphql@16.9.0)(ioredis@5.10.1)(pino@10.3.0)(ws@8.21.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -955,9 +955,6 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      subscriptions-transport-ws:
-        specifier: ^0.11.0
-        version: 0.11.0(graphql@16.14.2)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -940,6 +940,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      react-foundry:
+        specifier: 0.0.10
+        version: 0.0.10(@types/node@24.13.3)(babel-plugin-react-compiler@19.1.0-rc.3)(jiti@2.6.1)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)
       react-resizable-panels:
         specifier: ^3.0.6
         version: 3.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -32167,6 +32170,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@6.0.3(babel-plugin-react-compiler@19.1.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)
+    optionalDependencies:
+      babel-plugin-react-compiler: 19.1.0-rc.3
+
   '@vitejs/plugin-react@6.0.3(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -39167,6 +39177,33 @@ snapshots:
   react-fast-compare@2.0.4: {}
 
   react-fast-compare@3.2.2: {}
+
+  react-foundry@0.0.10(@types/node@24.13.3)(babel-plugin-react-compiler@19.1.0-rc.3)(jiti@2.6.1)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3):
+    dependencies:
+      '@vitejs/plugin-react': 6.0.3(babel-plugin-react-compiler@19.1.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+      axe-core: 4.11.0
+      cac: 6.7.14
+      esbuild: 0.28.1
+      glob: 13.0.6
+      picocolors: 1.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@rolldown/plugin-babel'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - babel-plugin-react-compiler
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   react-foundry@0.0.10(@types/node@25.5.0)(jiti@2.6.1)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
This PR makes the Laboratory's subscription transports testable locally. The dev mock now serves subscriptions, the dev server speaks both WebSocket protocols alongside SSE, and a react-foundry instance gives each transport its own preview, so you can run a subscription against every protocol without an external server and without walking through the settings form.

It also fixes three bugs found while building it:

- Stop now cancels a running subscription on every transport. Cancellation relied on the executor honoring `request.signal`, which `@graphql-tools/executor-legacy-ws` does not, so stopping a `LEGACY_WS` subscription did nothing and events kept arriving until the server finished on its own.
- The Laboratory no longer crashes when rendered inside React's `StrictMode`, where a remount reuses the host element and the second `attachShadow` call threw.
- Tailwind's source detection is now anchored to the stylesheet instead of the Vite root, so the Laboratory is styled when a dev server other than its own imports it. The built CSS is byte-identical.

Finally, it drops `subscriptions-transport-ws`, a required peer dependency that nothing imported.
