### PR TITLE
measure s3 storage write latency and success/failure rate

### DIFF
--- a/deployment/grafana-dashboards/S3-R2-Write-Overview.json
+++ b/deployment/grafana-dashboards/S3-R2-Write-Overview.json
@@ -656,7 +656,7 @@
           "description": "",
           "id": 4,
           "links": [],
-          "title": "Overall write error rate (401s, all mirrors)",
+          "title": "Overall write error rate (all mirrors)",
           "vizConfig": {
             "group": "stat",
             "kind": "VizConfig",
@@ -1093,7 +1093,7 @@
           "description": "",
           "id": 9,
           "links": [],
-          "title": "Overall write error rate trend (401s, all mirrors)",
+          "title": "Overall write error rate trend (all mirrors)",
           "vizConfig": {
             "group": "timeseries",
             "kind": "VizConfig",

--- a/deployment/grafana-dashboards/S3-R2-Write-Overview.json
+++ b/deployment/grafana-dashboards/S3-R2-Write-Overview.json
@@ -37,14 +37,15 @@
                   "hidden": false,
                   "query": {
                     "datasource": {
-                      "name": "grafanacloud-prom"
+                      "name": "TEMPO_DATASOURCE_UID"
                     },
-                    "group": "prometheus",
+                    "group": "tempo",
                     "kind": "DataQuery",
                     "spec": {
-                      "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (rate(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
-                      "instant": true,
-                      "legendFormat": "{{mirror}}"
+                      "limit": 50,
+                      "query": "{ event:name = \"cloudflare.r2.error_responses\" } | select(event.cloudflare.ray.ids, event.http.response.status_codes, event.error.count)",
+                      "queryType": "traceql",
+                      "tableType": "spans"
                     },
                     "version": "v0"
                   },
@@ -58,6 +59,517 @@
         },
         "description": "",
         "id": 1,
+        "links": [],
+        "title": "Failed writes — Cloudflare Ray ID & status detail",
+        "vizConfig": {
+          "group": "table",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                    "type": "auto"
+                  },
+                  "footer": {
+                    "reducers": []
+                  },
+                  "inspect": false
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "cloudflare.ray.ids"
+                  },
+                  "properties": [
+                    {
+                      "id": "displayName",
+                      "value": "Cloudflare Ray IDs"
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "http.response.status_codes"
+                  },
+                  "properties": [
+                    {
+                      "id": "displayName",
+                      "value": "Status codes"
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "error.count"
+                  },
+                  "properties": [
+                    {
+                      "id": "displayName",
+                      "value": "Error count"
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Trace Service",
+                    "scope": "series"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 125
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Cloudflare Ray IDs",
+                    "scope": "series"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 206
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Trace Name",
+                    "scope": "series"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 194
+                    }
+                  ]
+                }
+              ]
+            },
+            "options": {
+              "cellHeight": "sm",
+              "showHeader": true
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-10": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "PROM_DATASOURCE_UID"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace(sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2 (15m)\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3 (15m)\", \"destination\", \".*amazonaws.*\")",
+                      "legendFormat": "{{mirror}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "PROM_DATASOURCE_UID"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace(sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[3h])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[3h])), \"mirror\", \"R2 (3h baseline)\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3 (3h baseline)\", \"destination\", \".*amazonaws.*\")",
+                      "legendFormat": "{{mirror}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "B"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 10,
+        "links": [],
+        "title": "Latency: recent (15m) vs baseline (3h) — R2 vs S3",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": ["lastNotNull", "max"],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-11": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "PROM_DATASOURCE_UID"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace(sum by (destination, status_code) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                      "legendFormat": "{{mirror}} [{{status_code}}]"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 11,
+        "links": [],
+        "title": "Write throughput by mirror & status",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "ops"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": ["lastNotNull", "mean"],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-2": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "TEMPO_DATASOURCE_UID"
+                    },
+                    "group": "tempo",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "query": "{ event:name = \"cloudflare.r2.error_responses\" } | count_over_time()",
+                      "queryType": "traceql",
+                      "serviceMapUseNativeHistograms": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 2,
+        "links": [],
+        "title": "Failed CDN writes over time",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": ["sum"],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-3": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "PROM_DATASOURCE_UID"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (rate(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                      "legendFormat": "{{mirror}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 3,
         "links": [],
         "title": "Avg write latency by mirror",
         "vizConfig": {
@@ -96,7 +608,7 @@
               "reduceOptions": {
                 "calcs": ["lastNotNull"],
                 "fields": "",
-                "values": true
+                "values": false
               },
               "showPercentChange": false,
               "textMode": "value_and_name",
@@ -107,7 +619,7 @@
         }
       }
     },
-    "panel-2": {
+    "panel-4": {
       "kind": "Panel",
       "spec": {
         "data": {
@@ -120,13 +632,12 @@
                   "hidden": false,
                   "query": {
                     "datasource": {
-                      "name": "grafanacloud-prom"
+                      "name": "PROM_DATASOURCE_UID"
                     },
                     "group": "prometheus",
                     "kind": "DataQuery",
                     "spec": {
                       "expr": "sum(rate(api_s3_writes_total{status_code!=\"200\"}[15m])) / sum(rate(api_s3_writes_total[15m]))",
-                      "instant": true,
                       "legendFormat": "error rate"
                     },
                     "version": "v0"
@@ -140,7 +651,7 @@
           }
         },
         "description": "",
-        "id": 2,
+        "id": 4,
         "links": [],
         "title": "Overall write error rate (401s, all mirrors)",
         "vizConfig": {
@@ -181,7 +692,7 @@
               "reduceOptions": {
                 "calcs": ["lastNotNull"],
                 "fields": "",
-                "values": true
+                "values": false
               },
               "showPercentChange": false,
               "textMode": "value_and_name",
@@ -192,7 +703,7 @@
         }
       }
     },
-    "panel-3": {
+    "panel-5": {
       "kind": "Panel",
       "spec": {
         "data": {
@@ -205,13 +716,12 @@
                   "hidden": false,
                   "query": {
                     "datasource": {
-                      "name": "grafanacloud-prom"
+                      "name": "PROM_DATASOURCE_UID"
                     },
                     "group": "prometheus",
                     "kind": "DataQuery",
                     "spec": {
                       "expr": "label_replace(label_replace((sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[15m]))) / (sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[3h])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[3h]))), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
-                      "instant": true,
                       "legendFormat": "{{mirror}}"
                     },
                     "version": "v0"
@@ -225,7 +735,7 @@
           }
         },
         "description": "",
-        "id": 3,
+        "id": 5,
         "links": [],
         "title": "Latency vs baseline (15m vs 3h) by mirror",
         "vizConfig": {
@@ -266,7 +776,7 @@
               "reduceOptions": {
                 "calcs": ["lastNotNull"],
                 "fields": "",
-                "values": true
+                "values": false
               },
               "showPercentChange": false,
               "textMode": "value_and_name",
@@ -277,7 +787,7 @@
         }
       }
     },
-    "panel-4": {
+    "panel-6": {
       "kind": "Panel",
       "spec": {
         "data": {
@@ -290,13 +800,12 @@
                   "hidden": false,
                   "query": {
                     "datasource": {
-                      "name": "grafanacloud-prom"
+                      "name": "PROM_DATASOURCE_UID"
                     },
                     "group": "prometheus",
                     "kind": "DataQuery",
                     "spec": {
                       "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
-                      "instant": true,
                       "legendFormat": "{{mirror}}"
                     },
                     "version": "v0"
@@ -310,7 +819,7 @@
           }
         },
         "description": "",
-        "id": 4,
+        "id": 6,
         "links": [],
         "title": "Write throughput by mirror",
         "vizConfig": {
@@ -345,7 +854,7 @@
               "reduceOptions": {
                 "calcs": ["lastNotNull"],
                 "fields": "",
-                "values": true
+                "values": false
               },
               "showPercentChange": false,
               "textMode": "value_and_name",
@@ -356,7 +865,7 @@
         }
       }
     },
-    "panel-5": {
+    "panel-7": {
       "kind": "Panel",
       "spec": {
         "data": {
@@ -369,7 +878,7 @@
                   "hidden": false,
                   "query": {
                     "datasource": {
-                      "name": "grafanacloud-prom"
+                      "name": "PROM_DATASOURCE_UID"
                     },
                     "group": "prometheus",
                     "kind": "DataQuery",
@@ -389,7 +898,7 @@
           }
         },
         "description": "",
-        "id": 5,
+        "id": 7,
         "links": [],
         "title": "Write detail by mirror, operation & status",
         "vizConfig": {
@@ -434,7 +943,7 @@
         }
       }
     },
-    "panel-6": {
+    "panel-8": {
       "kind": "Panel",
       "spec": {
         "data": {
@@ -447,7 +956,7 @@
                   "hidden": false,
                   "query": {
                     "datasource": {
-                      "name": "grafanacloud-prom"
+                      "name": "PROM_DATASOURCE_UID"
                     },
                     "group": "prometheus",
                     "kind": "DataQuery",
@@ -466,259 +975,9 @@
           }
         },
         "description": "",
-        "id": 6,
-        "links": [],
-        "title": "Avg write latency trend — R2 vs S3",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "s"
-              },
-              "overrides": []
-            },
-            "options": {
-              "legend": {
-                "calcs": ["lastNotNull", "max"],
-                "displayMode": "table",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "desc"
-              }
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-7": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "grafanacloud-prom"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "sum(rate(api_s3_writes_total{status_code!=\"200\"}[15m])) / sum(rate(api_s3_writes_total[15m]))",
-                      "legendFormat": "error rate (401s)"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 7,
-        "links": [],
-        "title": "Overall write error rate trend (401s, all mirrors)",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "min": 0,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 0.01
-                    },
-                    {
-                      "color": "red",
-                      "value": 0.05
-                    }
-                  ]
-                },
-                "unit": "percentunit"
-              },
-              "overrides": []
-            },
-            "options": {
-              "legend": {
-                "calcs": ["lastNotNull", "max"],
-                "displayMode": "table",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "desc"
-              }
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-8": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "grafanacloud-prom"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "label_replace(label_replace(sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2 (15m)\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3 (15m)\", \"destination\", \".*amazonaws.*\")",
-                      "legendFormat": "{{mirror}}"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "grafanacloud-prom"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "label_replace(label_replace(sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[3h])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[3h])), \"mirror\", \"R2 (3h baseline)\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3 (3h baseline)\", \"destination\", \".*amazonaws.*\")",
-                      "legendFormat": "{{mirror}}"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "B"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
         "id": 8,
         "links": [],
-        "title": "Latency: recent (15m) vs baseline (3h) — R2 vs S3",
+        "title": "Avg write latency trend — R2 vs S3",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -810,13 +1069,13 @@
                   "hidden": false,
                   "query": {
                     "datasource": {
-                      "name": "grafanacloud-prom"
+                      "name": "PROM_DATASOURCE_UID"
                     },
                     "group": "prometheus",
                     "kind": "DataQuery",
                     "spec": {
-                      "expr": "label_replace(label_replace(sum by (destination, status_code) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
-                      "legendFormat": "{{mirror}} [{{status_code}}]"
+                      "expr": "sum(rate(api_s3_writes_total{status_code!=\"200\"}[15m])) / sum(rate(api_s3_writes_total[15m]))",
+                      "legendFormat": "error rate (401s)"
                     },
                     "version": "v0"
                   },
@@ -831,7 +1090,7 @@
         "description": "",
         "id": 9,
         "links": [],
-        "title": "Write throughput by mirror & status",
+        "title": "Overall write error rate trend (401s, all mirrors)",
         "vizConfig": {
           "group": "timeseries",
           "kind": "VizConfig",
@@ -875,6 +1134,7 @@
                     "mode": "off"
                   }
                 },
+                "min": 0,
                 "thresholds": {
                   "mode": "absolute",
                   "steps": [
@@ -883,18 +1143,22 @@
                       "value": 0
                     },
                     {
+                      "color": "yellow",
+                      "value": 0.01
+                    },
+                    {
                       "color": "red",
-                      "value": 80
+                      "value": 0.05
                     }
                   ]
                 },
-                "unit": "ops"
+                "unit": "percentunit"
               },
               "overrides": []
             },
             "options": {
               "legend": {
-                "calcs": ["lastNotNull", "mean"],
+                "calcs": ["lastNotNull", "max"],
                 "displayMode": "table",
                 "placement": "bottom",
                 "showLegend": true
@@ -929,15 +1193,6 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-1"
-                      }
-                    }
-                  },
-                  {
-                    "kind": "AutoGridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
                         "name": "panel-3"
                       }
                     }
@@ -947,7 +1202,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-2"
+                        "name": "panel-5"
                       }
                     }
                   },
@@ -957,6 +1212,15 @@
                       "element": {
                         "kind": "ElementReference",
                         "name": "panel-4"
+                      }
+                    }
+                  },
+                  {
+                    "kind": "AutoGridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-6"
                       }
                     }
                   }
@@ -982,7 +1246,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-6"
+                        "name": "panel-8"
                       }
                     }
                   },
@@ -991,7 +1255,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-8"
+                        "name": "panel-10"
                       }
                     }
                   }
@@ -1017,7 +1281,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-9"
+                        "name": "panel-11"
                       }
                     }
                   },
@@ -1026,7 +1290,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-7"
+                        "name": "panel-9"
                       }
                     }
                   }
@@ -1043,6 +1307,46 @@
           "spec": {
             "collapse": false,
             "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-2"
+                      },
+                      "height": 8,
+                      "width": 10,
+                      "x": 0,
+                      "y": 0
+                    }
+                  },
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-1"
+                      },
+                      "height": 8,
+                      "width": 14,
+                      "x": 10,
+                      "y": 0
+                    }
+                  }
+                ]
+              }
+            },
+            "title": "Traces"
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "collapse": false,
+            "layout": {
               "kind": "AutoGridLayout",
               "spec": {
                 "columnWidthMode": "standard",
@@ -1052,7 +1356,7 @@
                     "spec": {
                       "element": {
                         "kind": "ElementReference",
-                        "name": "panel-5"
+                        "name": "panel-7"
                       }
                     }
                   }

--- a/deployment/grafana-dashboards/S3-R2-Write-Overview.json
+++ b/deployment/grafana-dashboards/S3-R2-Write-Overview.json
@@ -1,1397 +1,1401 @@
 {
-  "annotations": [
-    {
-      "kind": "AnnotationQuery",
-      "spec": {
-        "builtIn": true,
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "query": {
-          "datasource": {
-            "name": "-- Grafana --"
-          },
-          "group": "grafana",
-          "kind": "DataQuery",
-          "spec": {},
-          "version": "v0"
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
         }
       }
-    }
-  ],
-  "cursorSync": "Off",
-  "description": "On-call view for comparing Cloudflare R2 and AWS S3 write mirrors — latency and error-rate health at a glance.",
-  "editable": true,
-  "elements": {
-    "panel-1": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "TEMPO_DATASOURCE_UID"
-                    },
-                    "group": "tempo",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "limit": 50,
-                      "query": "{ event:name = \"cloudflare.r2.error_responses\" } | select(event.cloudflare.ray.ids, event.http.response.status_codes, event.error.count)",
-                      "queryType": "traceql",
-                      "tableType": "spans"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 1,
-        "links": [],
-        "title": "Failed writes — Cloudflare Ray ID & status detail",
-        "vizConfig": {
-          "group": "table",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "custom": {
-                  "align": "auto",
-                  "cellOptions": {
-                    "type": "auto"
-                  },
-                  "footer": {
-                    "reducers": []
-                  },
-                  "inspect": false
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": [
+    ],
+    "cursorSync": "Off",
+    "description": "On-call view for comparing Cloudflare R2 and AWS S3 write mirrors — latency and error-rate health at a glance.",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
                 {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "cloudflare.ray.ids"
-                  },
-                  "properties": [
-                    {
-                      "id": "displayName",
-                      "value": "Cloudflare Ray IDs"
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "http.response.status_codes"
-                  },
-                  "properties": [
-                    {
-                      "id": "displayName",
-                      "value": "Status codes"
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "error.count"
-                  },
-                  "properties": [
-                    {
-                      "id": "displayName",
-                      "value": "Error count"
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Trace Service",
-                    "scope": "series"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 125
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Cloudflare Ray IDs",
-                    "scope": "series"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 206
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Trace Name",
-                    "scope": "series"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 194
-                    }
-                  ]
-                }
-              ]
-            },
-            "options": {
-              "cellHeight": "sm",
-              "showHeader": true
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-10": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "PROM_DATASOURCE_UID"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "label_replace(label_replace(sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2 (15m)\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3 (15m)\", \"destination\", \".*amazonaws.*\")",
-                      "legendFormat": "{{mirror}}"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "PROM_DATASOURCE_UID"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "label_replace(label_replace(sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[3h])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[3h])), \"mirror\", \"R2 (3h baseline)\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3 (3h baseline)\", \"destination\", \".*amazonaws.*\")",
-                      "legendFormat": "{{mirror}}"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "B"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 10,
-        "links": [],
-        "title": "Latency: recent (15m) vs baseline (3h) — R2 vs S3",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "s"
-              },
-              "overrides": []
-            },
-            "options": {
-              "legend": {
-                "calcs": ["lastNotNull", "max"],
-                "displayMode": "table",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "desc"
-              }
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-11": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "PROM_DATASOURCE_UID"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "label_replace(label_replace(sum by (destination, status_code) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
-                      "legendFormat": "{{mirror}} [{{status_code}}]"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 11,
-        "links": [],
-        "title": "Write throughput by mirror & status",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "ops"
-              },
-              "overrides": []
-            },
-            "options": {
-              "legend": {
-                "calcs": ["lastNotNull", "mean"],
-                "displayMode": "table",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "desc"
-              }
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-2": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "TEMPO_DATASOURCE_UID"
-                    },
-                    "group": "tempo",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "query": "{ event:name = \"cloudflare.r2.error_responses\" } | count_over_time()",
-                      "queryType": "traceql",
-                      "serviceMapUseNativeHistograms": false
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 2,
-        "links": [],
-        "title": "Failed CDN writes over time",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "short"
-              },
-              "overrides": []
-            },
-            "options": {
-              "legend": {
-                "calcs": ["sum"],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "desc"
-              }
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-3": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "PROM_DATASOURCE_UID"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (rate(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
-                      "legendFormat": "{{mirror}}"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 3,
-        "links": [],
-        "title": "Avg write latency by mirror",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 0.2
-                    },
-                    {
-                      "color": "red",
-                      "value": 0.5
-                    }
-                  ]
-                },
-                "unit": "s"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "value",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "horizontal",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": ["lastNotNull"],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "value_and_name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-4": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "PROM_DATASOURCE_UID"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "sum(rate(api_s3_writes_total{status_code!=\"200\"}[15m])) / sum(rate(api_s3_writes_total[15m]))",
-                      "legendFormat": "error rate"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 4,
-        "links": [],
-        "title": "Overall write error rate (401s, all mirrors)",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "max": 1,
-                "min": 0,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 0.01
-                    },
-                    {
-                      "color": "red",
-                      "value": 0.05
-                    }
-                  ]
-                },
-                "unit": "percentunit"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "value",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "horizontal",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": ["lastNotNull"],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "value_and_name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-5": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "PROM_DATASOURCE_UID"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "label_replace(label_replace((sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[15m]))) / (sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[3h])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[3h]))), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
-                      "legendFormat": "{{mirror}}"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 5,
-        "links": [],
-        "title": "Latency vs baseline (15m vs 3h) by mirror",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "max": 1,
-                "min": 0,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 1.2
-                    },
-                    {
-                      "color": "red",
-                      "value": 2
-                    }
-                  ]
-                },
-                "unit": "percentunit"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "value",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "horizontal",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": ["lastNotNull"],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "value_and_name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-6": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "PROM_DATASOURCE_UID"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
-                      "legendFormat": "{{mirror}}"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 6,
-        "links": [],
-        "title": "Write throughput by mirror",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "ops"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "horizontal",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": ["lastNotNull"],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "value_and_name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-7": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "PROM_DATASOURCE_UID"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "label_replace(label_replace(sum by (destination, operation, status_code) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
-                      "format": "table",
-                      "instant": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 7,
-        "links": [],
-        "title": "Write detail by mirror, operation & status",
-        "vizConfig": {
-          "group": "table",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "custom": {
-                  "align": "auto",
-                  "cellOptions": {
-                    "type": "auto"
-                  },
-                  "footer": {
-                    "reducers": []
-                  },
-                  "inspect": false
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "ops"
-              },
-              "overrides": []
-            },
-            "options": {
-              "cellHeight": "sm",
-              "showHeader": true
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-8": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "PROM_DATASOURCE_UID"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (rate(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
-                      "legendFormat": "{{mirror}}"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 8,
-        "links": [],
-        "title": "Avg write latency trend — R2 vs S3",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "s"
-              },
-              "overrides": []
-            },
-            "options": {
-              "legend": {
-                "calcs": ["lastNotNull", "max"],
-                "displayMode": "table",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "desc"
-              }
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    },
-    "panel-9": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "PROM_DATASOURCE_UID"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "expr": "sum(rate(api_s3_writes_total{status_code!=\"200\"}[15m])) / sum(rate(api_s3_writes_total[15m]))",
-                      "legendFormat": "error rate (401s)"
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 9,
-        "links": [],
-        "title": "Overall write error rate trend (401s, all mirrors)",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "min": 0,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 0.01
-                    },
-                    {
-                      "color": "red",
-                      "value": 0.05
-                    }
-                  ]
-                },
-                "unit": "percentunit"
-              },
-              "overrides": []
-            },
-            "options": {
-              "legend": {
-                "calcs": ["lastNotNull", "max"],
-                "displayMode": "table",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "multi",
-                "sort": "desc"
-              }
-            }
-          },
-          "version": "13.3.0-32457798232"
-        }
-      }
-    }
-  },
-  "layout": {
-    "kind": "RowsLayout",
-    "spec": {
-      "rows": [
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "AutoGridLayout",
-              "spec": {
-                "columnWidthMode": "standard",
-                "items": [
-                  {
-                    "kind": "AutoGridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-3"
-                      }
-                    }
-                  },
-                  {
-                    "kind": "AutoGridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-5"
-                      }
-                    }
-                  },
-                  {
-                    "kind": "AutoGridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-4"
-                      }
-                    }
-                  },
-                  {
-                    "kind": "AutoGridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-6"
-                      }
-                    }
-                  }
-                ],
-                "maxColumnCount": 3,
-                "rowHeightMode": "standard"
-              }
-            },
-            "title": "Overview"
-          }
-        },
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "AutoGridLayout",
-              "spec": {
-                "columnWidthMode": "standard",
-                "items": [
-                  {
-                    "kind": "AutoGridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-8"
-                      }
-                    }
-                  },
-                  {
-                    "kind": "AutoGridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-10"
-                      }
-                    }
-                  }
-                ],
-                "maxColumnCount": 3,
-                "rowHeightMode": "standard"
-              }
-            },
-            "title": "Latency"
-          }
-        },
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "AutoGridLayout",
-              "spec": {
-                "columnWidthMode": "standard",
-                "items": [
-                  {
-                    "kind": "AutoGridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-11"
-                      }
-                    }
-                  },
-                  {
-                    "kind": "AutoGridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-9"
-                      }
-                    }
-                  }
-                ],
-                "maxColumnCount": 3,
-                "rowHeightMode": "standard"
-              }
-            },
-            "title": "Throughput & Errors"
-          }
-        },
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "GridLayout",
-              "spec": {
-                "items": [
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-2"
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "TEMPO_DATASOURCE_UID"
                       },
-                      "height": 8,
-                      "width": 10,
-                      "x": 0,
-                      "y": 0
-                    }
+                      "group": "tempo",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "limit": 50,
+                        "query": "{ event:name = \"cloudflare.r2.error_responses\" } | select(event.cloudflare.ray.ids, event.http.response.status_codes, event.error.count)",
+                        "queryType": "traceql",
+                        "tableType": "spans"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 1,
+          "links": [],
+          "title": "Failed writes — Cloudflare Ray ID & status detail",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "cloudflare.ray.ids"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Cloudflare Ray IDs"
+                      }
+                    ]
                   },
                   {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-1"
-                      },
-                      "height": 8,
-                      "width": 14,
-                      "x": 10,
-                      "y": 0
-                    }
+                    "matcher": {
+                      "id": "byName",
+                      "options": "http.response.status_codes"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Status codes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "error.count"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Error count"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trace Service",
+                      "scope": "series"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 125
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Cloudflare Ray IDs",
+                      "scope": "series"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 206
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trace Name",
+                      "scope": "series"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 194
+                      }
+                    ]
                   }
                 ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
               }
             },
-            "title": "Traces"
-          }
-        },
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "AutoGridLayout",
-              "spec": {
-                "columnWidthMode": "standard",
-                "items": [
-                  {
-                    "kind": "AutoGridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-7"
-                      }
-                    }
-                  }
-                ],
-                "maxColumnCount": 3,
-                "rowHeightMode": "standard"
-              }
-            },
-            "title": "Details"
+            "version": "13.3.0-32457798232"
           }
         }
-      ]
-    }
-  },
-  "links": [],
-  "liveNow": false,
-  "preferences": {
-    "layout": {
-      "kind": "GridLayout",
-      "spec": {
-        "items": []
+      },
+      "panel-10": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PROM_DATASOURCE_UID"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "label_replace(label_replace(sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2 (15m)\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3 (15m)\", \"destination\", \".*amazonaws.*\")",
+                        "legendFormat": "{{mirror}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PROM_DATASOURCE_UID"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "label_replace(label_replace(sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[3h])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[3h])), \"mirror\", \"R2 (3h baseline)\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3 (3h baseline)\", \"destination\", \".*amazonaws.*\")",
+                        "legendFormat": "{{mirror}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 10,
+          "links": [],
+          "title": "Latency: recent (15m) vs baseline (3h) — R2 vs S3",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": ["lastNotNull", "max"],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-11": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PROM_DATASOURCE_UID"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "label_replace(label_replace(sum by (destination, status_code) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                        "legendFormat": "{{mirror}} [{{status_code}}]"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 11,
+          "links": [],
+          "title": "Write throughput by mirror & status",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": ["lastNotNull", "mean"],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "TEMPO_DATASOURCE_UID"
+                      },
+                      "group": "tempo",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "query": "{ event:name = \"cloudflare.r2.error_responses\" } | count_over_time()",
+                        "queryType": "traceql",
+                        "serviceMapUseNativeHistograms": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 2,
+          "links": [],
+          "title": "Failed CDN writes over time",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": ["sum"],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PROM_DATASOURCE_UID"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (rate(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                        "legendFormat": "{{mirror}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 3,
+          "links": [],
+          "title": "Avg write latency by mirror",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.2
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.5
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": ["lastNotNull"],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PROM_DATASOURCE_UID"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum(rate(api_s3_writes_total{status_code!=\"200\"}[15m])) / sum(rate(api_s3_writes_total[15m]))",
+                        "legendFormat": "error rate"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 4,
+          "links": [],
+          "title": "Overall write error rate (401s, all mirrors)",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.01
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.05
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": ["lastNotNull"],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PROM_DATASOURCE_UID"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "label_replace(label_replace((sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[15m]))) / (sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[3h])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[3h]))), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                        "legendFormat": "{{mirror}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 5,
+          "links": [],
+          "title": "Latency vs baseline (15m vs 3h) by mirror",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 1.2
+                      },
+                      {
+                        "color": "red",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": ["lastNotNull"],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PROM_DATASOURCE_UID"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                        "legendFormat": "{{mirror}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 6,
+          "links": [],
+          "title": "Write throughput by mirror",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": ["lastNotNull"],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PROM_DATASOURCE_UID"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "label_replace(label_replace(sum by (destination, operation, status_code) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                        "format": "table",
+                        "instant": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 7,
+          "links": [],
+          "title": "Write detail by mirror, operation & status",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PROM_DATASOURCE_UID"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (rate(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                        "legendFormat": "{{mirror}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 8,
+          "links": [],
+          "title": "Avg write latency trend — R2 vs S3",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": ["lastNotNull", "max"],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
+      },
+      "panel-9": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PROM_DATASOURCE_UID"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum(rate(api_s3_writes_total{status_code!=\"200\"}[15m])) / sum(rate(api_s3_writes_total[15m]))",
+                        "legendFormat": "error rate (401s)"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 9,
+          "links": [],
+          "title": "Overall write error rate trend (401s, all mirrors)",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.01
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.05
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": ["lastNotNull", "max"],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.3.0-32457798232"
+          }
+        }
       }
-    }
-  },
-  "preload": false,
-  "tags": ["s3", "r2", "storage", "mirrors"],
-  "timeSettings": {
-    "autoRefresh": "",
-    "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
-    "fiscalYearStartMonth": 0,
-    "from": "now-6h",
-    "hideTimepicker": false,
-    "timezone": "browser",
-    "to": "now"
-  },
-  "title": "S3 Mirror Health: R2 vs AWS S3",
-  "variables": []
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-3"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-5"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-4"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-6"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Overview"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-8"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-10"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Latency"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-11"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-9"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Throughput & Errors"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-2"
+                        },
+                        "height": 8,
+                        "width": 10,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-1"
+                        },
+                        "height": 8,
+                        "width": 14,
+                        "x": 10,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Traces"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-7"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Details"
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preferences": {
+      "layout": {
+        "kind": "GridLayout",
+        "spec": {
+          "items": []
+        }
+      }
+    },
+    "preload": false,
+    "tags": ["s3", "r2", "storage", "mirrors"],
+    "timeSettings": {
+      "autoRefresh": "",
+      "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+      "fiscalYearStartMonth": 0,
+      "from": "now-6h",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "S3 Mirror Health: R2 vs AWS S3",
+    "variables": []
+  }
 }

--- a/deployment/grafana-dashboards/S3-R2-Write-Overview.json
+++ b/deployment/grafana-dashboards/S3-R2-Write-Overview.json
@@ -1,0 +1,1093 @@
+{
+  "annotations": [
+    {
+      "kind": "AnnotationQuery",
+      "spec": {
+        "builtIn": true,
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "query": {
+          "datasource": {
+            "name": "-- Grafana --"
+          },
+          "group": "grafana",
+          "kind": "DataQuery",
+          "spec": {},
+          "version": "v0"
+        }
+      }
+    }
+  ],
+  "cursorSync": "Off",
+  "description": "On-call view for comparing Cloudflare R2 and AWS S3 write mirrors — latency and error-rate health at a glance.",
+  "editable": true,
+  "elements": {
+    "panel-1": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (rate(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                      "instant": true,
+                      "legendFormat": "{{mirror}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 1,
+        "links": [],
+        "title": "Avg write latency by mirror",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.2
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.5
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "value",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "horizontal",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": ["lastNotNull"],
+                "fields": "",
+                "values": true
+              },
+              "showPercentChange": false,
+              "textMode": "value_and_name",
+              "wideLayout": true
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-2": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum(rate(api_s3_writes_total{status_code!=\"200\"}[15m])) / sum(rate(api_s3_writes_total[15m]))",
+                      "instant": true,
+                      "legendFormat": "error rate"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 2,
+        "links": [],
+        "title": "Overall write error rate (401s, all mirrors)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.01
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.05
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "value",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "horizontal",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": ["lastNotNull"],
+                "fields": "",
+                "values": true
+              },
+              "showPercentChange": false,
+              "textMode": "value_and_name",
+              "wideLayout": true
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-3": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace((sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[15m]))) / (sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[3h])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[3h]))), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                      "instant": true,
+                      "legendFormat": "{{mirror}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 3,
+        "links": [],
+        "title": "Latency vs baseline (15m vs 3h) by mirror",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1.2
+                    },
+                    {
+                      "color": "red",
+                      "value": 2
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "value",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "horizontal",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": ["lastNotNull"],
+                "fields": "",
+                "values": true
+              },
+              "showPercentChange": false,
+              "textMode": "value_and_name",
+              "wideLayout": true
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-4": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                      "instant": true,
+                      "legendFormat": "{{mirror}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 4,
+        "links": [],
+        "title": "Write throughput by mirror",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "ops"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "none",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "horizontal",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": ["lastNotNull"],
+                "fields": "",
+                "values": true
+              },
+              "showPercentChange": false,
+              "textMode": "value_and_name",
+              "wideLayout": true
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-5": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace(sum by (destination, operation, status_code) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                      "format": "table",
+                      "instant": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 5,
+        "links": [],
+        "title": "Write detail by mirror, operation & status",
+        "vizConfig": {
+          "group": "table",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                    "type": "auto"
+                  },
+                  "footer": {
+                    "reducers": []
+                  },
+                  "inspect": false
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "ops"
+              },
+              "overrides": []
+            },
+            "options": {
+              "cellHeight": "sm",
+              "showHeader": true
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-6": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace(sum by (destination) (rate(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (rate(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                      "legendFormat": "{{mirror}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 6,
+        "links": [],
+        "title": "Avg write latency trend — R2 vs S3",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": ["lastNotNull", "max"],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-7": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum(rate(api_s3_writes_total{status_code!=\"200\"}[15m])) / sum(rate(api_s3_writes_total[15m]))",
+                      "legendFormat": "error rate (401s)"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 7,
+        "links": [],
+        "title": "Overall write error rate trend (401s, all mirrors)",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.01
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.05
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": ["lastNotNull", "max"],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-8": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace(sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[15m])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[15m])), \"mirror\", \"R2 (15m)\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3 (15m)\", \"destination\", \".*amazonaws.*\")",
+                      "legendFormat": "{{mirror}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace(sum by (destination) (increase(api_s3_write_duration_seconds_sum{destination!=\"\"}[3h])) / sum by (destination) (increase(api_s3_write_duration_seconds_count{destination!=\"\"}[3h])), \"mirror\", \"R2 (3h baseline)\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3 (3h baseline)\", \"destination\", \".*amazonaws.*\")",
+                      "legendFormat": "{{mirror}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "B"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 8,
+        "links": [],
+        "title": "Latency: recent (15m) vs baseline (3h) — R2 vs S3",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": ["lastNotNull", "max"],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    },
+    "panel-9": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "grafanacloud-prom"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "label_replace(label_replace(sum by (destination, status_code) (rate(api_s3_writes_total{destination!=\"\"}[15m])), \"mirror\", \"R2\", \"destination\", \".*cloudflarestorage.*\"), \"mirror\", \"S3\", \"destination\", \".*amazonaws.*\")",
+                      "legendFormat": "{{mirror}} [{{status_code}}]"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 9,
+        "links": [],
+        "title": "Write throughput by mirror & status",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "ops"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": ["lastNotNull", "mean"],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            }
+          },
+          "version": "13.3.0-32457798232"
+        }
+      }
+    }
+  },
+  "layout": {
+    "kind": "RowsLayout",
+    "spec": {
+      "rows": [
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "collapse": false,
+            "layout": {
+              "kind": "AutoGridLayout",
+              "spec": {
+                "columnWidthMode": "standard",
+                "items": [
+                  {
+                    "kind": "AutoGridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-1"
+                      }
+                    }
+                  },
+                  {
+                    "kind": "AutoGridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-3"
+                      }
+                    }
+                  },
+                  {
+                    "kind": "AutoGridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-2"
+                      }
+                    }
+                  },
+                  {
+                    "kind": "AutoGridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-4"
+                      }
+                    }
+                  }
+                ],
+                "maxColumnCount": 3,
+                "rowHeightMode": "standard"
+              }
+            },
+            "title": "Overview"
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "collapse": false,
+            "layout": {
+              "kind": "AutoGridLayout",
+              "spec": {
+                "columnWidthMode": "standard",
+                "items": [
+                  {
+                    "kind": "AutoGridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-6"
+                      }
+                    }
+                  },
+                  {
+                    "kind": "AutoGridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-8"
+                      }
+                    }
+                  }
+                ],
+                "maxColumnCount": 3,
+                "rowHeightMode": "standard"
+              }
+            },
+            "title": "Latency"
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "collapse": false,
+            "layout": {
+              "kind": "AutoGridLayout",
+              "spec": {
+                "columnWidthMode": "standard",
+                "items": [
+                  {
+                    "kind": "AutoGridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-9"
+                      }
+                    }
+                  },
+                  {
+                    "kind": "AutoGridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-7"
+                      }
+                    }
+                  }
+                ],
+                "maxColumnCount": 3,
+                "rowHeightMode": "standard"
+              }
+            },
+            "title": "Throughput & Errors"
+          }
+        },
+        {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "collapse": false,
+            "layout": {
+              "kind": "AutoGridLayout",
+              "spec": {
+                "columnWidthMode": "standard",
+                "items": [
+                  {
+                    "kind": "AutoGridLayoutItem",
+                    "spec": {
+                      "element": {
+                        "kind": "ElementReference",
+                        "name": "panel-5"
+                      }
+                    }
+                  }
+                ],
+                "maxColumnCount": 3,
+                "rowHeightMode": "standard"
+              }
+            },
+            "title": "Details"
+          }
+        }
+      ]
+    }
+  },
+  "links": [],
+  "liveNow": false,
+  "preferences": {
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": []
+      }
+    }
+  },
+  "preload": false,
+  "tags": ["s3", "r2", "storage", "mirrors"],
+  "timeSettings": {
+    "autoRefresh": "",
+    "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+    "fiscalYearStartMonth": 0,
+    "from": "now-6h",
+    "hideTimepicker": false,
+    "timezone": "browser",
+    "to": "now"
+  },
+  "title": "S3 Mirror Health: R2 vs AWS S3",
+  "variables": []
+}

--- a/deployment/services/grafana.ts
+++ b/deployment/services/grafana.ts
@@ -37,9 +37,10 @@ export function deployGrafana(envName: string, tableSuffix: string) {
     const configJson = JSON.parse(configString);
 
     // Pin a stable uid from the filename so dashboard URLs survive redeploys
-    configJson.uid = `hive-${identifier.toLowerCase().replace(/^hive-/, '')}`;
-    delete configJson.id;
-    delete configJson.version;
+    const dashboardConfig = configJson.spec ?? configJson;
+    dashboardConfig.uid = `hive-${identifier.toLowerCase().replace(/^hive-/, '')}`;
+    delete dashboardConfig.id;
+    delete dashboardConfig.version;
 
     return new oss.Dashboard(`dashboard-${identifier.toLowerCase()}`, {
       folder: folder.uid,

--- a/packages/services/api/src/create.ts
+++ b/packages/services/api/src/create.ts
@@ -64,7 +64,8 @@ import { PrometheusConfig } from './modules/shared/providers/prometheus-config';
 import { HivePubSub, PUB_SUB_CONFIG } from './modules/shared/providers/pub-sub';
 import { REDIS_INSTANCE, type Redis } from './modules/shared/providers/redis';
 import { RedisRateLimiter } from './modules/shared/providers/redis-rate-limiter';
-import { S3_CONFIG, type S3Config } from './modules/shared/providers/s3-config';
+import { S3Config } from './modules/shared/providers/s3-config';
+import { S3Writer } from './modules/shared/providers/s3-writer';
 import { Storage } from './modules/shared/providers/storage';
 import { RateLimitConfig, WEB_APP_URL } from './modules/shared/providers/tokens';
 import { supportModule } from './modules/support';
@@ -166,7 +167,7 @@ export function createRegistry({
   prometheus: null | Record<string, unknown>;
   taskScheduler: TaskScheduler;
 }) {
-  const s3Config: S3Config = [
+  const s3Config = new S3Config([
     {
       client: new AwsClient({
         credentialProvider: s3.credentialProvider,
@@ -175,20 +176,19 @@ export function createRegistry({
       bucket: s3.bucketName,
       endpoint: s3.endpoint,
     },
-  ];
-
-  if (s3Mirror) {
-    s3Config.push({
-      client: new AwsClient({
-        credentialProvider: s3Mirror.credentialProvider,
-        service: 's3',
-      }),
-      bucket: s3Mirror.bucketName,
-      endpoint: s3Mirror.endpoint,
-    });
-  }
-
-  const artifactStorageWriter = new ArtifactStorageWriter(s3Config, logger);
+    ...(s3Mirror
+      ? [
+          {
+            client: new AwsClient({
+              credentialProvider: s3Mirror.credentialProvider,
+              service: 's3',
+            }),
+            bucket: s3Mirror.bucketName,
+            endpoint: s3Mirror.endpoint,
+          },
+        ]
+      : []),
+  ]);
 
   const auditLogS3Config = s3AuditLogs
     ? new AuditLogS3Config(
@@ -199,7 +199,11 @@ export function createRegistry({
         s3AuditLogs.endpoint,
         s3AuditLogs.bucketName,
       )
-    : new AuditLogS3Config(s3Config[0].client, s3Config[0].endpoint, s3Config[0].bucket);
+    : new AuditLogS3Config(
+        s3Config.destinations[0].client,
+        s3Config.destinations[0].endpoint,
+        s3Config.destinations[0].bucket,
+      );
 
   const providers: Provider[] = [
     AuditLogRecorder,
@@ -210,13 +214,12 @@ export function createRegistry({
     InMemoryRateLimitStore,
     InMemoryRateLimiter,
     RedisRateLimiter,
+    S3Writer,
+    ArtifactStorageWriter,
+
     {
       provide: AuditLogS3Config,
       useValue: auditLogS3Config,
-    },
-    {
-      provide: ArtifactStorageWriter,
-      useValue: artifactStorageWriter,
     },
     {
       provide: Logger,
@@ -259,7 +262,7 @@ export function createRegistry({
       scope: Scope.Singleton,
     },
     {
-      provide: S3_CONFIG,
+      provide: S3Config,
       useValue: s3Config,
       scope: Scope.Singleton,
     },

--- a/packages/services/api/src/create.ts
+++ b/packages/services/api/src/create.ts
@@ -214,9 +214,11 @@ export function createRegistry({
     InMemoryRateLimitStore,
     InMemoryRateLimiter,
     RedisRateLimiter,
-    S3Writer,
     ArtifactStorageWriter,
-
+    {
+      provide: S3Writer,
+      useValue: new S3Writer(s3Config),
+    },
     {
       provide: AuditLogS3Config,
       useValue: auditLogS3Config,

--- a/packages/services/api/src/modules/app-deployments/providers/app-deployments.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/app-deployments.ts
@@ -25,7 +25,7 @@ import { ClickHouse, sql as cSql } from '../../operations/providers/clickhouse-c
 import { SchemaVersionHelper } from '../../schema/providers/schema-version-helper';
 import { SchemaVersionStore } from '../../schema/providers/schema-version-store';
 import { Logger } from '../../shared/providers/logger';
-import { S3_CONFIG, type S3Config } from '../../shared/providers/s3-config';
+import { S3Writer } from '../../shared/providers/s3-writer';
 import { Storage } from '../../shared/providers/storage';
 import { APP_DEPLOYMENTS_ENABLED } from './app-deployments-enabled-token';
 import { PersistedDocumentScheduler } from './persisted-document-scheduler';
@@ -56,7 +56,7 @@ export class AppDeployments {
   constructor(
     logger: Logger,
     private pool: PostgresDatabasePool,
-    @Inject(S3_CONFIG) private s3: S3Config,
+    private s3: S3Writer,
     private clickhouse: ClickHouse,
     private storage: Storage,
     private schemaVersionHelper: SchemaVersionHelper,
@@ -460,61 +460,49 @@ export class AppDeployments {
     const appDeploymentDocumentHashes =
       await this._getAllDocumentHashesForAppDeployment(appDeployment);
 
-    for (const s3 of this.s3) {
-      let result = await s3.client.fetch(
-        [
-          s3.endpoint,
-          s3.bucket,
-          buildAppDeploymentIsEnabledKey(
-            appDeployment.targetId,
-            appDeployment.name,
-            appDeployment.version,
-          ),
-        ].join('/'),
-        {
-          method: 'PUT',
-          body: '1',
-          headers: {
-            'content-type': 'text/plain',
-          },
-          aws: {
-            signQuery: true,
-          },
+    let results = await this.s3.write(
+      buildAppDeploymentIsEnabledKey(
+        appDeployment.targetId,
+        appDeployment.name,
+        appDeployment.version,
+      ),
+      'app_deployment_enabled',
+      {
+        body: '1',
+        headers: {
+          'content-type': 'text/plain',
         },
-      );
+      },
+    );
 
+    for (const result of results) {
       if (result.statusCode !== 200) {
         throw new Error(`Failed to enable app deployment: ${result.statusMessage}`);
       }
+    }
 
-      result = await s3.client.fetch(
-        [
-          s3.endpoint,
-          s3.bucket,
-          buildAppDeploymentManifestKey(
-            appDeployment.targetId,
-            appDeployment.name,
-            appDeployment.version,
-          ),
-        ].join('/'),
-        {
-          method: 'PUT',
-          body: JSON.stringify({
-            id: appDeployment.id,
-            appName: appDeployment.name,
-            appVersion: appDeployment.version,
-            documentHashes: appDeploymentDocumentHashes.sort(),
-            isActive: true,
-          } satisfies z.TypeOf<typeof AppDeploymentManifestModel>),
-          headers: {
-            'content-type': 'application/json',
-          },
-          aws: {
-            signQuery: true,
-          },
+    results = await this.s3.write(
+      buildAppDeploymentManifestKey(
+        appDeployment.targetId,
+        appDeployment.name,
+        appDeployment.version,
+      ),
+      'app_deployment_manifest',
+      {
+        body: JSON.stringify({
+          id: appDeployment.id,
+          appName: appDeployment.name,
+          appVersion: appDeployment.version,
+          documentHashes: appDeploymentDocumentHashes.sort(),
+          isActive: true,
+        } satisfies z.TypeOf<typeof AppDeploymentManifestModel>),
+        headers: {
+          'content-type': 'application/json',
         },
-      );
+      },
+    );
 
+    for (const result of results) {
       if (result.statusCode !== 200) {
         throw new Error(`Failed to write app manifest: ${result.statusMessage}`);
       }
@@ -754,26 +742,19 @@ export class AppDeployments {
     const appDeploymentDocumentHashes =
       await this._getAllDocumentHashesForAppDeployment(appDeployment);
 
-    for (const s3 of this.s3) {
-      let result = await s3.client.fetch(
-        [
-          s3.endpoint,
-          s3.bucket,
-          buildAppDeploymentIsEnabledKey(
-            appDeployment.targetId,
-            appDeployment.name,
-            appDeployment.version,
-          ),
-        ].join('/'),
-        {
-          method: 'DELETE',
-          aws: {
-            signQuery: true,
-          },
-        },
-      );
+    let results = await this.s3.request(
+      buildAppDeploymentIsEnabledKey(
+        appDeployment.targetId,
+        appDeployment.name,
+        appDeployment.version,
+      ),
+      {
+        method: 'DELETE',
+      },
+    );
 
-      /** We receive a 204 status code if the DELETE operation was successful */
+    /** We receive a 204 status code if the DELETE operation was successful */
+    for (const result of results) {
       if (result.statusCode !== 204) {
         this.logger.error(
           'Failed to disable app deployment (organizationId=%s, targetId=%s, appDeploymentId=%s, statusCode=%s)',
@@ -786,35 +767,30 @@ export class AppDeployments {
           `Failed to disable app deployment. Request failed with status code "${result.statusMessage}".`,
         );
       }
+    }
 
-      result = await s3.client.fetch(
-        [
-          s3.endpoint,
-          s3.bucket,
-          buildAppDeploymentManifestKey(
-            appDeployment.targetId,
-            appDeployment.name,
-            appDeployment.version,
-          ),
-        ].join('/'),
-        {
-          method: 'PUT',
-          body: JSON.stringify({
-            id: appDeployment.id,
-            appName: appDeployment.name,
-            appVersion: appDeployment.version,
-            documentHashes: appDeploymentDocumentHashes.sort(),
-            isActive: false,
-          } satisfies z.TypeOf<typeof AppDeploymentManifestModel>),
-          headers: {
-            'content-type': 'application/json',
-          },
-          aws: {
-            signQuery: true,
-          },
+    results = await this.s3.write(
+      buildAppDeploymentManifestKey(
+        appDeployment.targetId,
+        appDeployment.name,
+        appDeployment.version,
+      ),
+      'app_deployment_manifest',
+      {
+        body: JSON.stringify({
+          id: appDeployment.id,
+          appName: appDeployment.name,
+          appVersion: appDeployment.version,
+          documentHashes: appDeploymentDocumentHashes.sort(),
+          isActive: false,
+        } satisfies z.TypeOf<typeof AppDeploymentManifestModel>),
+        headers: {
+          'content-type': 'application/json',
         },
-      );
+      },
+    );
 
+    for (const result of results) {
       if (result.statusCode !== 200) {
         throw new Error(`Failed to write app manifest: ${result.statusMessage}`);
       }

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
@@ -16,7 +16,9 @@ import { collectSchemaCoordinates, preprocessOperation } from '@graphql-hive/cor
 import { buildOperationS3BucketKey } from '@hive/cdn-script/artifact-storage-reader';
 import { ServiceLogger, setErrorSource } from '@hive/service-common';
 import { sql as c_sql, ClickHouse } from '../../operations/providers/clickhouse-client';
-import { S3Config } from '../../shared/providers/s3-config';
+import { S3Writer } from '../../shared/providers/s3-writer';
+import type { S3WriteMetric } from '../../shared/providers/s3-writer';
+import type { SerializedWorkerError } from './persisted-document-scheduler';
 
 type DocumentRecord = {
   appDeploymentId: string;
@@ -113,6 +115,7 @@ export type BatchProcessEvent = {
 export type BatchProcessedEvent = {
   event: 'processedBatch';
   id: string;
+  s3WriteMetrics: Array<S3WriteMetric>;
   data:
     | {
         type: 'error';
@@ -131,13 +134,20 @@ export type BatchProcessedEvent = {
       };
 };
 
+export type BatchProcessingErrorEvent = {
+  event: 'error';
+  id: string;
+  error: SerializedWorkerError;
+  s3WriteMetrics: Array<S3WriteMetric>;
+};
+
 export class PersistedDocumentIngester {
   private promiseQueue = new PromiseQueue({ concurrency: 30 });
   private logger: ServiceLogger;
 
   constructor(
     private clickhouse: ClickHouse,
-    private s3: S3Config,
+    private s3: S3Writer,
     logger: ServiceLogger,
   ) {
     this.logger = logger.child({ source: 'PersistedDocumentIngester' });
@@ -374,25 +384,20 @@ export class PersistedDocumentIngester {
 
       tasks.push(
         this.promiseQueue.add(async () => {
-          for (const s3 of this.s3) {
-            const response = await s3.client.fetch([s3.endpoint, s3.bucket, s3Key].join('/'), {
-              method: 'PUT',
-              headers: {
-                'content-type': 'text/plain',
-              },
-              body: document.body,
-              aws: {
-                // This boolean makes Google Cloud Storage & AWS happy.
-                signQuery: true,
-              },
-            });
+          const responses = await this.s3.write(s3Key, 'persisted_document', {
+            headers: {
+              'content-type': 'text/plain',
+            },
+            body: document.body,
+          });
 
+          for (const response of responses) {
             if (response.statusCode !== 200) {
               throw setErrorSource(
                 new Error(
-                  `Failed to upload operation to S3 object storage (${s3.endpoint}/${s3.bucket}): [${response.statusCode}] ${response.statusMessage}`,
+                  `Failed to upload operation to S3 object storage (${response.url}): [${response.statusCode}] ${response.statusMessage}`,
                 ),
-                `s3 ${s3.endpoint}`,
+                `s3 ${new URL(response.url).origin}`,
               );
             }
           }

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
@@ -17,7 +17,7 @@ import { buildOperationS3BucketKey } from '@hive/cdn-script/artifact-storage-rea
 import { ServiceLogger, setErrorSource } from '@hive/service-common';
 import { sql as c_sql, ClickHouse } from '../../operations/providers/clickhouse-client';
 import { S3Writer } from '../../shared/providers/s3-writer';
-import type { S3WriteMetric } from '../../shared/providers/s3-writer';
+import type { R2ErrorTraceSummary, S3WriteMetric } from '../../shared/providers/s3-writer';
 import type { SerializedWorkerError } from './persisted-document-scheduler';
 
 type DocumentRecord = {
@@ -116,6 +116,7 @@ export type BatchProcessedEvent = {
   event: 'processedBatch';
   id: string;
   s3WriteMetrics: Array<S3WriteMetric>;
+  r2ErrorTraceSummary: R2ErrorTraceSummary;
   data:
     | {
         type: 'error';
@@ -139,6 +140,7 @@ export type BatchProcessingErrorEvent = {
   id: string;
   error: SerializedWorkerError;
   s3WriteMetrics: Array<S3WriteMetric>;
+  r2ErrorTraceSummary: R2ErrorTraceSummary;
 };
 
 export class PersistedDocumentIngester {

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-scheduler.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-scheduler.ts
@@ -4,7 +4,12 @@ import { fileURLToPath } from 'url';
 import { Injectable, Scope } from 'graphql-modules';
 import { getErrorSource, setErrorSource } from '@hive/service-common';
 import { Logger, registerWorkerLogging } from '../../shared/providers/logger';
-import { BatchProcessedEvent, BatchProcessEvent } from './persisted-document-ingester';
+import { observeS3Write } from '../../shared/providers/s3-writer';
+import {
+  type BatchProcessedEvent,
+  type BatchProcessEvent,
+  type BatchProcessingErrorEvent,
+} from './persisted-document-ingester';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -87,20 +92,19 @@ export class PersistedDocumentScheduler {
 
     registerWorkerLogging(this.logger, worker, name);
 
-    worker.on(
-      'message',
-      (
-        data: BatchProcessedEvent | { event: 'error'; id: string; error: SerializedWorkerError },
-      ) => {
-        if (data.event === 'error') {
-          tasks.get(data.id)?.reject(deserializeWorkerError(data.error));
-        }
+    worker.on('message', (data: BatchProcessedEvent | BatchProcessingErrorEvent) => {
+      for (const metric of data.s3WriteMetrics) {
+        observeS3Write(metric);
+      }
 
-        if (data.event === 'processedBatch') {
-          tasks.get(data.id)?.resolve(data);
-        }
-      },
-    );
+      if (data.event === 'error') {
+        tasks.get(data.id)?.reject(deserializeWorkerError(data.error));
+      }
+
+      if (data.event === 'processedBatch') {
+        tasks.get(data.id)?.resolve(data);
+      }
+    });
 
     const { logger } = this;
 

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-scheduler.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-scheduler.ts
@@ -2,9 +2,14 @@ import path from 'node:path';
 import { Worker } from 'node:worker_threads';
 import { fileURLToPath } from 'url';
 import { Injectable, Scope } from 'graphql-modules';
-import { getErrorSource, setErrorSource } from '@hive/service-common';
+import { getErrorSource, invariant, setErrorSource, traceFn } from '@hive/service-common';
 import { Logger, registerWorkerLogging } from '../../shared/providers/logger';
-import { observeS3Write } from '../../shared/providers/s3-writer';
+import {
+  observeR2ErrorTrace,
+  observeS3Write,
+  R2ErrorTraceSummary,
+  S3WriteMetric,
+} from '../../shared/providers/s3-writer';
 import {
   type BatchProcessedEvent,
   type BatchProcessEvent,
@@ -16,6 +21,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 type PendingTaskRecord = {
   resolve: (data: BatchProcessedEvent) => void;
   reject: (err: unknown) => void;
+  onMetrics: (metrics: {
+    s3WriteMetrics?: S3WriteMetric[];
+    r2ErrorTraceSummary?: R2ErrorTraceSummary;
+  }) => void;
 };
 
 export type SerializedWorkerError = {
@@ -93,9 +102,13 @@ export class PersistedDocumentScheduler {
     registerWorkerLogging(this.logger, worker, name);
 
     worker.on('message', (data: BatchProcessedEvent | BatchProcessingErrorEvent) => {
-      for (const metric of data.s3WriteMetrics) {
-        observeS3Write(metric);
-      }
+      const task = tasks.get(data.id);
+      invariant(task, 'The task must exist.');
+
+      task.onMetrics({
+        s3WriteMetrics: data.s3WriteMetrics,
+        r2ErrorTraceSummary: data.r2ErrorTraceSummary,
+      });
 
       if (data.event === 'error') {
         tasks.get(data.id)?.reject(deserializeWorkerError(data.error));
@@ -131,6 +144,17 @@ export class PersistedDocumentScheduler {
           clearTimeout(timeout);
           d.reject(err);
         },
+        onMetrics(data) {
+          if (data.s3WriteMetrics) {
+            for (const metric of data.s3WriteMetrics) {
+              observeS3Write(metric);
+            }
+          }
+
+          if (data.r2ErrorTraceSummary) {
+            observeR2ErrorTrace(data.r2ErrorTraceSummary);
+          }
+        },
       };
 
       tasks.set(id, task);
@@ -155,6 +179,14 @@ export class PersistedDocumentScheduler {
     return this.workers[Math.floor(Math.random() * this.workers.length)];
   }
 
+  @traceFn('PersistedDocumentScheduler.processBatch', {
+    initAttributes: data => ({
+      'hive.target.id': data.targetId,
+      'hive.appDeployment.documentCount': data.documents.length,
+      'hive.appDeployment.id': data.appDeployment.id,
+      'hive.appDeployment.version': data.appDeployment.version,
+    }),
+  })
   async processBatch(data: BatchProcessEvent['data']) {
     return this.getRandomWorker()(data);
   }

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-scheduler.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-scheduler.ts
@@ -103,7 +103,10 @@ export class PersistedDocumentScheduler {
 
     worker.on('message', (data: BatchProcessedEvent | BatchProcessingErrorEvent) => {
       const task = tasks.get(data.id);
-      invariant(task, 'The task must exist.');
+
+      if (!task) {
+        return;
+      }
 
       task.onMetrics({
         s3WriteMetrics: data.s3WriteMetrics,
@@ -111,11 +114,11 @@ export class PersistedDocumentScheduler {
       });
 
       if (data.event === 'error') {
-        tasks.get(data.id)?.reject(deserializeWorkerError(data.error));
+        task.reject(deserializeWorkerError(data.error));
       }
 
       if (data.event === 'processedBatch') {
-        tasks.get(data.id)?.resolve(data);
+        task.resolve(data);
       }
     });
 

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-scheduler.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-scheduler.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { Worker } from 'node:worker_threads';
 import { fileURLToPath } from 'url';
 import { Injectable, Scope } from 'graphql-modules';
-import { getErrorSource, invariant, setErrorSource, traceFn } from '@hive/service-common';
+import { getErrorSource, setErrorSource, traceFn } from '@hive/service-common';
 import { Logger, registerWorkerLogging } from '../../shared/providers/logger';
 import {
   observeR2ErrorTrace,

--- a/packages/services/api/src/modules/app-deployments/worker/persisted-documents-worker.ts
+++ b/packages/services/api/src/modules/app-deployments/worker/persisted-documents-worker.ts
@@ -5,10 +5,13 @@ import { ClickHouse } from '../../operations/providers/clickhouse-client';
 import { HttpClient } from '../../shared/providers/http-client';
 import { Logger } from '../../shared/providers/logger';
 import { S3Config } from '../../shared/providers/s3-config';
+import { S3Writer } from '../../shared/providers/s3-writer';
+import type { S3WriteMetric } from '../../shared/providers/s3-writer';
 import {
-  BatchProcessedEvent,
   PersistedDocumentIngester,
+  type BatchProcessedEvent,
   type BatchProcessEvent,
+  type BatchProcessingErrorEvent,
 } from '../providers/persisted-document-ingester';
 import { serializeWorkerError } from '../providers/persisted-document-scheduler';
 
@@ -39,7 +42,7 @@ export function createWorker(
     };
   },
 ) {
-  const s3Config: S3Config = [
+  const s3Config = new S3Config([
     {
       client: new AwsClient({
         credentialProvider: env.s3.credentialProvider,
@@ -48,30 +51,25 @@ export function createWorker(
       bucket: env.s3.bucketName,
       endpoint: env.s3.endpoint,
     },
-  ];
-
-  if (env.s3Mirror) {
-    s3Config.push({
-      client: new AwsClient({
-        credentialProvider: env.s3Mirror.credentialProvider,
-        service: 's3',
-      }),
-      bucket: env.s3Mirror.bucketName,
-      endpoint: env.s3Mirror.endpoint,
-    });
-  }
+    ...(env.s3Mirror
+      ? [
+          {
+            client: new AwsClient({
+              credentialProvider: env.s3Mirror.credentialProvider,
+              service: 's3',
+            }),
+            bucket: env.s3Mirror.bucketName,
+            endpoint: env.s3Mirror.endpoint,
+          },
+        ]
+      : []),
+  ]);
 
   const logger = baseLogger.child({
     source: 'PersistedDocumentsWorker',
   });
 
   const clickhouse = new ClickHouse(env.clickhouse, new HttpClient(), logger);
-
-  const persistedOperationsProcessor = new PersistedDocumentIngester(
-    clickhouse,
-    s3Config,
-    logger as any,
-  );
 
   process.on('unhandledRejection', function (err) {
     console.error('unhandledRejection', err);
@@ -94,6 +92,12 @@ export function createWorker(
 
   port.on('message', async (message: BatchProcessEvent) => {
     logger.debug('processing message', message.id, message.event);
+    const s3WriteMetrics: Array<S3WriteMetric> = [];
+    const persistedOperationsProcessor = new PersistedDocumentIngester(
+      clickhouse,
+      new S3Writer(s3Config, metric => s3WriteMetrics.push(metric)),
+      logger as any,
+    );
     try {
       const result = await persistedOperationsProcessor.processBatch(message.data);
       logger.debug('send message result', message.id, message.event);
@@ -101,6 +105,7 @@ export function createWorker(
         event: 'processedBatch',
         id: message.id,
         data: result,
+        s3WriteMetrics,
       } satisfies BatchProcessedEvent);
     } catch (err: unknown) {
       logger.error(
@@ -112,7 +117,8 @@ export function createWorker(
         event: 'error',
         id: message.id,
         error: serializeWorkerError(err),
-      });
+        s3WriteMetrics,
+      } satisfies BatchProcessingErrorEvent);
     }
   });
 

--- a/packages/services/api/src/modules/app-deployments/worker/persisted-documents-worker.ts
+++ b/packages/services/api/src/modules/app-deployments/worker/persisted-documents-worker.ts
@@ -5,8 +5,8 @@ import { ClickHouse } from '../../operations/providers/clickhouse-client';
 import { HttpClient } from '../../shared/providers/http-client';
 import { Logger } from '../../shared/providers/logger';
 import { S3Config } from '../../shared/providers/s3-config';
-import { S3Writer } from '../../shared/providers/s3-writer';
-import type { S3WriteMetric } from '../../shared/providers/s3-writer';
+import { S3Writer, summarizeR2ErrorTraces } from '../../shared/providers/s3-writer';
+import type { R2ErrorTrace, S3WriteMetric } from '../../shared/providers/s3-writer';
 import {
   PersistedDocumentIngester,
   type BatchProcessedEvent,
@@ -93,9 +93,14 @@ export function createWorker(
   port.on('message', async (message: BatchProcessEvent) => {
     logger.debug('processing message', message.id, message.event);
     const s3WriteMetrics: Array<S3WriteMetric> = [];
+    const r2ErrorTraces: Array<R2ErrorTrace> = [];
     const persistedOperationsProcessor = new PersistedDocumentIngester(
       clickhouse,
-      new S3Writer(s3Config, metric => s3WriteMetrics.push(metric)),
+      new S3Writer(
+        s3Config,
+        metric => s3WriteMetrics.push(metric),
+        errors => r2ErrorTraces.push(...errors),
+      ),
       logger as any,
     );
     try {
@@ -106,6 +111,7 @@ export function createWorker(
         id: message.id,
         data: result,
         s3WriteMetrics,
+        r2ErrorTraceSummary: summarizeR2ErrorTraces(r2ErrorTraces),
       } satisfies BatchProcessedEvent);
     } catch (err: unknown) {
       logger.error(
@@ -118,6 +124,7 @@ export function createWorker(
         id: message.id,
         error: serializeWorkerError(err),
         s3WriteMetrics,
+        r2ErrorTraceSummary: summarizeR2ErrorTraces(r2ErrorTraces),
       } satisfies BatchProcessingErrorEvent);
     }
   });

--- a/packages/services/api/src/modules/audit-logs/providers/audit-logs-manager.ts
+++ b/packages/services/api/src/modules/audit-logs/providers/audit-logs-manager.ts
@@ -9,6 +9,8 @@ import { Session } from '../../auth/lib/authz';
 import { type AwsClient } from '../../cdn/providers/aws';
 import { ClickHouse, sql } from '../../operations/providers/clickhouse-client';
 import { Logger } from '../../shared/providers/logger';
+import { S3Config } from '../../shared/providers/s3-config';
+import { S3Writer } from '../../shared/providers/s3-writer';
 import { Storage } from '../../shared/providers/storage';
 import { formatToClickhouseDateTime } from './audit-log-recorder';
 import { AuditLogClickhouseArrayModel } from './audit-logs-types';
@@ -165,8 +167,16 @@ export class AuditLogManager {
       const cleanEndDate = filter.endDate.toISOString().split('T')[0];
       const unixTimestampInSeconds = Math.floor(Date.now() / 1000);
       const key = `audit-logs/${organizationId}/${unixTimestampInSeconds}-${cleanStartDate}-${cleanEndDate}.csv`;
-      const uploadResult = await client.fetch([endpoint, bucket, key].join('/'), {
-        method: 'PUT',
+      const auditLogS3 = new S3Writer(
+        new S3Config([
+          {
+            client,
+            endpoint,
+            bucket,
+          },
+        ]),
+      );
+      const uploadResult = await auditLogS3.writePrimary(key, 'audit_log_export', {
         headers: {
           'Content-Type': 'text/csv',
         },

--- a/packages/services/api/src/modules/cdn/providers/aws.ts
+++ b/packages/services/api/src/modules/cdn/providers/aws.ts
@@ -266,7 +266,7 @@ export class AwsClient {
       region: init?.aws?.region || this.region,
       cache: init?.aws?.cache || this.cache,
       datetime: init?.aws?.datetime,
-      signQuery: init?.aws?.signQuery,
+      signQuery: init?.aws?.signQuery ?? true,
       appendSessionToken: init?.aws?.appendSessionToken,
       allHeaders: init?.aws?.allHeaders,
       singleEncode: init?.aws?.singleEncode,
@@ -361,7 +361,7 @@ export class AwsV4Signer {
 
     this.cache = cache || new Map();
     this.datetime = datetime || new Date().toISOString().replace(/[:-]|\.\d{3}/g, '');
-    this.signQuery = signQuery;
+    this.signQuery = signQuery ?? true;
     this.appendSessionToken = appendSessionToken || this.service === 'iotdevicegateway';
 
     this.headers.delete('Host'); // Can't be set in insecure env anyway

--- a/packages/services/api/src/modules/cdn/providers/cdn.provider.ts
+++ b/packages/services/api/src/modules/cdn/providers/cdn.provider.ts
@@ -11,7 +11,7 @@ import { Session } from '../../auth/lib/authz';
 import type { Contract } from '../../schema/providers/contracts';
 import { IdTranslator } from '../../shared/providers/id-translator';
 import { Logger } from '../../shared/providers/logger';
-import { S3_CONFIG, type S3Config } from '../../shared/providers/s3-config';
+import { S3Writer } from '../../shared/providers/s3-writer';
 import { Storage } from '../../shared/providers/storage';
 import { CDN_CONFIG, type CDNConfig } from './tokens';
 
@@ -30,7 +30,7 @@ export class CdnProvider {
     private auditLog: AuditLogRecorder,
     private idTranslator: IdTranslator,
     @Inject(CDN_CONFIG) private config: CDNConfig,
-    @Inject(S3_CONFIG) private s3Config: S3Config,
+    private s3: S3Writer,
     @Inject(Storage) private storage: Storage,
   ) {
     this.logger = logger.child({ source: 'CdnProvider' });
@@ -119,16 +119,11 @@ export class CdnProvider {
       s3Key,
     );
 
-    for (const s3 of this.s3Config) {
-      // Check if key already exists
-      const headResponse = await s3.client.fetch([s3.endpoint, s3.bucket, s3Key].join('/'), {
-        method: 'HEAD',
-        aws: {
-          // This boolean makes Google Cloud Storage & AWS happy.
-          signQuery: true,
-        },
-      });
+    const headResponses = await this.s3.request(s3Key, {
+      method: 'HEAD',
+    });
 
+    for (const headResponse of headResponses) {
       if (headResponse.statusCode !== 404) {
         this.logger.debug(
           'Failed creating CDN access token. Head request on S3 returned unexpected status while checking token availability. (organizationId=%s, projectId=%s, targetId=%s, status=%s)',
@@ -154,17 +149,11 @@ export class CdnProvider {
       s3Key,
     );
 
-    for (const s3 of this.s3Config) {
-      // put key onto s3 bucket
-      const putResponse = await s3.client.fetch([s3.endpoint, s3.bucket, s3Key].join('/'), {
-        method: 'PUT',
-        body: privateKeyHash,
-        aws: {
-          // This boolean makes Google Cloud Storage & AWS happy.
-          signQuery: true,
-        },
-      });
+    const putResponses = await this.s3.write(s3Key, 'cdn_access_token', {
+      body: privateKeyHash,
+    });
 
+    for (const putResponse of putResponses) {
       if (putResponse.statusCode !== 200) {
         this.logger.debug(
           'Failed creating CDN Access Token. Head request on S3 returned unexpected status while creating token. (organizationId=%s, projectId=%s, targetId=%s, status=%s)',
@@ -313,18 +302,11 @@ export class CdnProvider {
       } as const;
     }
 
-    for (const s3 of this.s3Config) {
-      const deleteResponse = await s3.client.fetch(
-        [s3.endpoint, s3.bucket, record.s3Key].join('/'),
-        {
-          method: 'DELETE',
-          aws: {
-            // This boolean makes Google Cloud Storage & AWS happy.
-            signQuery: true,
-          },
-        },
-      );
+    const deleteResponses = await this.s3.request(record.s3Key, {
+      method: 'DELETE',
+    });
 
+    for (const deleteResponse of deleteResponses) {
       if (deleteResponse.statusCode !== 204) {
         this.logger.debug(
           'Delete CDN access token error. Head request on S3 failed. (organizationId=%s, projectId=%s, targetId=%s, cdnAccessTokenId=%s)',

--- a/packages/services/api/src/modules/cdn/providers/s3-iam.spec.ts
+++ b/packages/services/api/src/modules/cdn/providers/s3-iam.spec.ts
@@ -264,6 +264,7 @@ describe('AwsClient signing', () => {
       const signed = await (client as any).sign('https://s3.us-east-1.amazonaws.com/bucket/key', {
         method: 'GET',
         headers: {},
+        aws: { signQuery: false },
       });
 
       expect(mockProvider.getCredentials).toHaveBeenCalledOnce();
@@ -292,11 +293,13 @@ describe('AwsClient signing', () => {
       const signed1 = await (client as any).sign('https://s3.us-east-1.amazonaws.com/bucket/key', {
         method: 'GET',
         headers: {},
+        aws: { signQuery: false },
       });
       const signed2 = await (client as any).sign('https://s3.us-east-1.amazonaws.com/bucket/key', {
         method: 'PUT',
         headers: {},
         body: 'artifact-content',
+        aws: { signQuery: false },
       });
 
       expect(signed1.init.headers['authorization']).toContain('KEY_1');
@@ -321,6 +324,7 @@ describe('AwsClient signing', () => {
       const signed = await (client as any).sign('https://s3.us-east-1.amazonaws.com/bucket/key', {
         method: 'GET',
         headers: {},
+        aws: { signQuery: false },
       });
 
       expect(signed.init.headers['x-amz-security-token']).toBe('MY_SESSION_TOKEN');
@@ -344,6 +348,7 @@ describe('AwsClient signing', () => {
         method: 'PUT',
         headers: {},
         body: 'artifact-data',
+        aws: { signQuery: false },
       });
 
       expect(signed.init.headers['x-amz-content-sha256']).toBe('UNSIGNED-PAYLOAD');
@@ -366,6 +371,7 @@ describe('AwsClient signing', () => {
       const signed = await (client as any).sign('https://s3.eu-west-1.amazonaws.com/bucket/key', {
         method: 'GET',
         headers: {},
+        aws: { signQuery: false },
       });
 
       expect(signed.init.headers['authorization']).toContain('eu-west-1/s3/aws4_request');

--- a/packages/services/api/src/modules/schema/providers/artifact-storage-writer.ts
+++ b/packages/services/api/src/modules/schema/providers/artifact-storage-writer.ts
@@ -1,9 +1,9 @@
 import { createHash } from 'node:crypto';
-import { Inject } from 'graphql-modules';
+import { Injectable, Scope } from 'graphql-modules';
 import { buildArtifactStorageKey } from '@hive/cdn-script/artifact-storage-reader';
 import { setErrorSource, traceFn } from '@hive/service-common';
 import { Logger } from '../../shared/providers/logger';
-import { S3_CONFIG, type S3Config } from '../../shared/providers/s3-config';
+import { S3Writer } from '../../shared/providers/s3-writer';
 
 const artifactMeta = {
   sdl: {
@@ -27,11 +27,12 @@ const artifactMeta = {
 /**
  * Write an Artifact to an S3 bucket.
  */
+@Injectable({ scope: Scope.Singleton, global: true })
 export class ArtifactStorageWriter {
   private logger: Logger;
 
   constructor(
-    @Inject(S3_CONFIG) private s3Mirrors: S3Config,
+    private s3: S3Writer,
     logger: Logger,
   ) {
     this.logger = logger.child({ service: 'f' });
@@ -59,36 +60,29 @@ export class ArtifactStorageWriter {
     const meta = artifactMeta[args.artifactType];
     const body = meta.preprocessor(args.artifact);
 
-    for (const s3 of this.s3Mirrors) {
-      this.logger.debug(
-        'Writing artifact to S3 (targetId=%s, artifactType=%s, contractName=%s, versionId=%s, latestKey=%s, versionedKey=%s)',
-        args.targetId,
-        args.artifactType,
-        args.contractName,
-        args.versionId,
-        latestKey,
-        versionedKey,
-      );
+    this.logger.debug(
+      'Writing artifact to S3 (targetId=%s, artifactType=%s, contractName=%s, versionId=%s, latestKey=%s, versionedKey=%s)',
+      args.targetId,
+      args.artifactType,
+      args.contractName,
+      args.versionId,
+      latestKey,
+      versionedKey,
+    );
 
-      // Write versioned key first (if versionId provided)
-      // This order ensures that if versioned write fails, "latest" still points to the previous version
-      if (versionedKey && args.versionId) {
-        const versionedResult = await s3.client.fetch(
-          [s3.endpoint, s3.bucket, versionedKey].join('/'),
-          {
-            method: 'PUT',
-            headers: {
-              'content-type': meta.contentType,
-              // Store version ID as S3 object metadata for CDN response headers
-              'x-amz-meta-x-hive-schema-version-id': args.versionId,
-            },
-            body,
-            aws: {
-              signQuery: true,
-            },
-          },
-        );
+    // Write versioned key first (if versionId provided)
+    // This order ensures that if versioned write fails, "latest" still points to the previous version
+    if (versionedKey && args.versionId) {
+      const versionedResults = await this.s3.write(versionedKey, 'artifact_versioned', {
+        headers: {
+          'content-type': meta.contentType,
+          // Store version ID as S3 object metadata for CDN response headers
+          'x-amz-meta-x-hive-schema-version-id': args.versionId,
+        },
+        body,
+      });
 
+      for (const versionedResult of versionedResults) {
         if (versionedResult.statusCode !== 200) {
           this.logger.error(
             'Failed to write versioned artifact (targetId=%s, artifactType=%s, versionId=%s, key=%s, statusCode=%s)',
@@ -102,26 +96,23 @@ export class ArtifactStorageWriter {
             new Error(
               `Unexpected status code ${versionedResult.statusCode} when writing versioned artifact (targetId=${args.targetId}, artifactType=${args.artifactType}, versionId=${args.versionId}, key=${versionedKey})`,
             ),
-            `s3 ${s3.endpoint}`,
+            `s3 ${new URL(versionedResult.url).origin}`,
           );
         }
       }
+    }
 
-      // Write to latest key (always) - only after versioned succeeds
-      const latestResult = await s3.client.fetch([s3.endpoint, s3.bucket, latestKey].join('/'), {
-        method: 'PUT',
-        headers: {
-          'content-type': meta.contentType,
-          // Store version ID as S3 object metadata for CDN response headers
-          ...(args.versionId ? { 'x-amz-meta-x-hive-schema-version-id': args.versionId } : {}),
-        },
-        body,
-        aws: {
-          // This boolean makes Google Cloud Storage & AWS happy.
-          signQuery: true,
-        },
-      });
+    // Write to latest key (always) - only after versioned succeeds
+    const latestResults = await this.s3.write(latestKey, 'artifact_latest', {
+      headers: {
+        'content-type': meta.contentType,
+        // Store version ID as S3 object metadata for CDN response headers
+        ...(args.versionId ? { 'x-amz-meta-x-hive-schema-version-id': args.versionId } : {}),
+      },
+      body,
+    });
 
+    for (const latestResult of latestResults) {
       if (latestResult.statusCode !== 200) {
         this.logger.error(
           'Failed to write latest artifact after versioned succeeded (targetId=%s, artifactType=%s, versionId=%s, versionedKey=%s written, latestKey=%s failed)',
@@ -135,7 +126,7 @@ export class ArtifactStorageWriter {
           new Error(
             `Unexpected status code ${latestResult.statusCode} when writing latest artifact (targetId=${args.targetId}, artifactType=${args.artifactType}, contractName=${args.contractName}, key=${latestKey}). Note: versioned artifact was already written.`,
           ),
-          `s3 ${new URL(s3.endpoint).origin}`,
+          `s3 ${new URL(latestResult.url).origin}`,
         );
       }
     }
@@ -161,15 +152,11 @@ export class ArtifactStorageWriter {
     );
     const key = buildArtifactStorageKey(args.targetId, args.artifactType, args.contractName);
 
-    for (const s3 of this.s3Mirrors) {
-      const result = await s3.client.fetch([s3.endpoint, s3.bucket, key].join('/'), {
-        method: 'DELETE',
-        aws: {
-          // This boolean makes Google Cloud Storage & AWS happy.
-          signQuery: true,
-        },
-      });
+    const results = await this.s3.request(key, {
+      method: 'DELETE',
+    });
 
+    for (const result of results) {
       if (result.statusCode !== 204) {
         this.logger.debug(
           'Failed deleting artifact, S3 compatible storage returned unexpected status code. (targetId=%s, contractName=%s, artifactType=%s, statusCode=%s)',
@@ -201,21 +188,14 @@ export class ArtifactStorageWriter {
 
     const hash = hashBuilder.digest('hex');
 
-    const firstMirror = this.s3Mirrors[0];
-    const url = [firstMirror.endpoint, firstMirror.bucket, 'debug-artifacts', hash + '.json'].join(
-      '/',
-    );
+    const key = `debug-artifacts/${hash}.json`;
+    const url = this.s3.primaryUrl(key);
 
-    await firstMirror.client.fetch(url, {
-      method: 'PUT',
+    await this.s3.writePrimary(key, 'debug_artifact', {
       headers: {
         'content-type': 'application/json',
       },
       body: JSON.stringify(subgraphs),
-      aws: {
-        // This boolean makes Google Cloud Storage & AWS happy.
-        signQuery: true,
-      },
     });
 
     return { id: hash.substring(0, 10), url };

--- a/packages/services/api/src/modules/shared/providers/s3-config.ts
+++ b/packages/services/api/src/modules/shared/providers/s3-config.ts
@@ -1,10 +1,18 @@
-import { InjectionToken } from 'graphql-modules';
+import { Injectable, Scope } from 'graphql-modules';
 import type { AwsClient } from '../../cdn/providers/aws';
 
-export type S3Config = Array<{
+type AtLeastOneReadonlyArray<T> = readonly [T, ...T[]];
+
+export type S3Destination = {
   client: AwsClient;
   endpoint: string;
   bucket: string;
-}>;
+};
 
-export const S3_CONFIG = new InjectionToken<S3Config>('S3_CONFIG');
+/**
+ * S3 bucket storage configurations for dual writes to a primary and secondary destination.
+ */
+@Injectable({ scope: Scope.Singleton, global: true })
+export class S3Config {
+  constructor(public destinations: AtLeastOneReadonlyArray<S3Destination>) {}
+}

--- a/packages/services/api/src/modules/shared/providers/s3-writer.ts
+++ b/packages/services/api/src/modules/shared/providers/s3-writer.ts
@@ -1,5 +1,5 @@
 import { Injectable, Scope } from 'graphql-modules';
-import { metrics } from '@hive/service-common';
+import { metrics, trace } from '@hive/service-common';
 import { AwsClient } from '../../cdn/providers/aws';
 import { S3Config, S3Destination } from './s3-config';
 
@@ -17,6 +17,17 @@ export type S3WriteMetric = {
   operation: S3WriteOperation;
   result: 'success' | 'failure';
   durationSeconds: number;
+};
+
+export type R2ErrorTrace = {
+  rayId: string;
+  statusCode: number;
+};
+
+export type R2ErrorTraceSummary = {
+  rayIds: Array<string>;
+  statusCodes: Array<number>;
+  totalCount: number;
 };
 
 const s3Writes = new metrics.Counter({
@@ -45,6 +56,8 @@ export class S3Writer {
   constructor(
     private s3Config: S3Config,
     private observer: (metric: S3WriteMetric) => void = observeS3Write,
+    private r2ErrorObserver: (errors: Array<R2ErrorTrace>) => void = errors =>
+      observeR2ErrorTrace(summarizeR2ErrorTraces(errors)),
   ) {}
 
   private async writeS3Object(
@@ -61,6 +74,15 @@ export class S3Writer {
         ...init,
         method: 'PUT',
       });
+      if (
+        response.statusCode >= 400 &&
+        new URL(s3.endpoint).hostname.endsWith('.r2.cloudflarestorage.com')
+      ) {
+        const rayId = response.headers['cf-ray'];
+        if (typeof rayId === 'string') {
+          this.r2ErrorObserver([{ rayId, statusCode: response.statusCode }]);
+        }
+      }
       result = response.ok ? 'success' : 'failure';
       return response;
     } finally {
@@ -99,4 +121,26 @@ export class S3Writer {
   private url(destination: S3Destination, key: string) {
     return [destination.endpoint, destination.bucket, key].join('/');
   }
+}
+
+export function observeR2ErrorTrace(summary: R2ErrorTraceSummary) {
+  if (summary.totalCount === 0) {
+    return;
+  }
+
+  trace.getActiveSpan()?.addEvent('cloudflare.r2.error_responses', {
+    'cloudflare.ray.ids': summary.rayIds,
+    'http.response.status_codes': summary.statusCodes,
+    'error.count': summary.totalCount,
+    'error.truncated_count': Math.max(0, summary.totalCount - summary.rayIds.length),
+  });
+}
+
+export function summarizeR2ErrorTraces(errors: Array<R2ErrorTrace>): R2ErrorTraceSummary {
+  const slicedErrors = errors.slice(0, 10);
+  return {
+    rayIds: slicedErrors.map(err => err.rayId),
+    statusCodes: slicedErrors.map(err => err.statusCode),
+    totalCount: errors.length,
+  };
 }

--- a/packages/services/api/src/modules/shared/providers/s3-writer.ts
+++ b/packages/services/api/src/modules/shared/providers/s3-writer.ts
@@ -14,6 +14,7 @@ export type S3WriteOperation =
   | 'persisted_document';
 
 export type S3WriteMetric = {
+  destination: string;
   operation: S3WriteOperation;
   statusCode: number | 'none';
   durationSeconds: number;
@@ -33,18 +34,22 @@ export type R2ErrorTraceSummary = {
 const s3Writes = new metrics.Counter({
   name: 'api_s3_writes_total',
   help: 'Number of S3-compatible object storage write attempts from the GraphQL API',
-  labelNames: ['operation', 'status_code'],
+  labelNames: ['destination', 'operation', 'status_code'],
 });
 
 const s3WriteDuration = new metrics.Histogram({
   name: 'api_s3_write_duration_seconds',
   help: 'Latency of S3-compatible object storage write attempts from the GraphQL API',
-  labelNames: ['operation', 'status_code'],
+  labelNames: ['destination', 'operation', 'status_code'],
   buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
 });
 
 export function observeS3Write(metric: S3WriteMetric) {
-  const labels = { operation: metric.operation, status_code: metric.statusCode };
+  const labels = {
+    destination: metric.destination,
+    operation: metric.operation,
+    status_code: metric.statusCode,
+  };
   s3Writes.inc(labels);
   s3WriteDuration.observe(labels, metric.durationSeconds);
 }
@@ -87,6 +92,7 @@ export class S3Writer {
       return response;
     } finally {
       this.observer({
+        destination: s3.endpoint + '/' + s3.bucket,
         operation,
         statusCode,
         durationSeconds: Number(process.hrtime.bigint() - startedAt) / 1e9,

--- a/packages/services/api/src/modules/shared/providers/s3-writer.ts
+++ b/packages/services/api/src/modules/shared/providers/s3-writer.ts
@@ -15,7 +15,7 @@ export type S3WriteOperation =
 
 export type S3WriteMetric = {
   operation: S3WriteOperation;
-  result: 'success' | 'failure';
+  statusCode: number | 'none';
   durationSeconds: number;
 };
 
@@ -33,18 +33,18 @@ export type R2ErrorTraceSummary = {
 const s3Writes = new metrics.Counter({
   name: 'api_s3_writes_total',
   help: 'Number of S3-compatible object storage write attempts from the GraphQL API',
-  labelNames: ['operation', 'result'],
+  labelNames: ['operation', 'status_code'],
 });
 
 const s3WriteDuration = new metrics.Histogram({
   name: 'api_s3_write_duration_seconds',
   help: 'Latency of S3-compatible object storage write attempts from the GraphQL API',
-  labelNames: ['operation', 'result'],
+  labelNames: ['operation', 'status_code'],
   buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
 });
 
 export function observeS3Write(metric: S3WriteMetric) {
-  const labels = { operation: metric.operation, result: metric.result };
+  const labels = { operation: metric.operation, status_code: metric.statusCode };
   s3Writes.inc(labels);
   s3WriteDuration.observe(labels, metric.durationSeconds);
 }
@@ -67,7 +67,7 @@ export class S3Writer {
     init: Omit<Parameters<AwsClient['fetch']>[1], 'method'>,
   ) {
     const startedAt = process.hrtime.bigint();
-    let result: S3WriteMetric['result'] = 'failure';
+    let statusCode: S3WriteMetric['statusCode'] = 'none';
 
     try {
       const response = await s3.client.fetch([s3.endpoint, s3.bucket, key].join('/'), {
@@ -83,12 +83,12 @@ export class S3Writer {
           this.r2ErrorObserver([{ rayId, statusCode: response.statusCode }]);
         }
       }
-      result = response.ok ? 'success' : 'failure';
+      statusCode = response.statusCode;
       return response;
     } finally {
       this.observer({
         operation,
-        result,
+        statusCode,
         durationSeconds: Number(process.hrtime.bigint() - startedAt) / 1e9,
       });
     }

--- a/packages/services/api/src/modules/shared/providers/s3-writer.ts
+++ b/packages/services/api/src/modules/shared/providers/s3-writer.ts
@@ -1,0 +1,102 @@
+import { Injectable, Scope } from 'graphql-modules';
+import { metrics } from '@hive/service-common';
+import { AwsClient } from '../../cdn/providers/aws';
+import { S3Config, S3Destination } from './s3-config';
+
+export type S3WriteOperation =
+  | 'app_deployment_enabled'
+  | 'app_deployment_manifest'
+  | 'artifact_latest'
+  | 'artifact_versioned'
+  | 'audit_log_export'
+  | 'cdn_access_token'
+  | 'debug_artifact'
+  | 'persisted_document';
+
+export type S3WriteMetric = {
+  operation: S3WriteOperation;
+  result: 'success' | 'failure';
+  durationSeconds: number;
+};
+
+const s3Writes = new metrics.Counter({
+  name: 'api_s3_writes_total',
+  help: 'Number of S3-compatible object storage write attempts from the GraphQL API',
+  labelNames: ['operation', 'result'],
+});
+
+const s3WriteDuration = new metrics.Histogram({
+  name: 'api_s3_write_duration_seconds',
+  help: 'Latency of S3-compatible object storage write attempts from the GraphQL API',
+  labelNames: ['operation', 'result'],
+  buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+});
+
+export function observeS3Write(metric: S3WriteMetric) {
+  const labels = { operation: metric.operation, result: metric.result };
+  s3Writes.inc(labels);
+  s3WriteDuration.observe(labels, metric.durationSeconds);
+}
+
+type S3RequestInit = Parameters<AwsClient['fetch']>[1];
+
+@Injectable({ scope: Scope.Singleton, global: true })
+export class S3Writer {
+  constructor(
+    private s3Config: S3Config,
+    private observer: (metric: S3WriteMetric) => void = observeS3Write,
+  ) {}
+
+  private async writeS3Object(
+    s3: S3Destination,
+    key: string,
+    operation: S3WriteOperation,
+    init: Omit<Parameters<AwsClient['fetch']>[1], 'method'>,
+  ) {
+    const startedAt = process.hrtime.bigint();
+    let result: S3WriteMetric['result'] = 'failure';
+
+    try {
+      const response = await s3.client.fetch([s3.endpoint, s3.bucket, key].join('/'), {
+        ...init,
+        method: 'PUT',
+      });
+      result = response.ok ? 'success' : 'failure';
+      return response;
+    } finally {
+      this.observer({
+        operation,
+        result,
+        durationSeconds: Number(process.hrtime.bigint() - startedAt) / 1e9,
+      });
+    }
+  }
+
+  async write(key: string, operation: S3WriteOperation, init: Omit<S3RequestInit, 'method'>) {
+    const responses = [];
+    for (const destination of this.s3Config.destinations) {
+      responses.push(await this.writeS3Object(destination, key, operation, init));
+    }
+    return responses;
+  }
+
+  writePrimary(key: string, operation: S3WriteOperation, init: Omit<S3RequestInit, 'method'>) {
+    return this.writeS3Object(this.s3Config.destinations[0], key, operation, init);
+  }
+
+  async request(key: string, init: S3RequestInit) {
+    const responses = [];
+    for (const destination of this.s3Config.destinations) {
+      responses.push(await destination.client.fetch(this.url(destination, key), init));
+    }
+    return responses;
+  }
+
+  primaryUrl(key: string) {
+    return this.url(this.s3Config.destinations[0], key);
+  }
+
+  private url(destination: S3Destination, key: string) {
+    return [destination.endpoint, destination.bucket, key].join('/');
+  }
+}

--- a/packages/services/cdn-worker/src/artifact-storage-reader.ts
+++ b/packages/services/cdn-worker/src/artifact-storage-reader.ts
@@ -134,9 +134,6 @@ export class ArtifactStorageReader {
       .fetch(primaryObjectEndpoint, {
         method: args.method,
         headers: args.headers,
-        aws: {
-          signQuery: true,
-        },
         timeout: this.timeout,
         retries: this.s3Mirror ? 1 : undefined,
         isResponseOk: response =>
@@ -189,9 +186,6 @@ export class ArtifactStorageReader {
             .fetch(primaryObjectEndpoint, {
               method: args.method,
               headers: args.headers,
-              aws: {
-                signQuery: true,
-              },
               timeout: this.timeout,
               signal: primaryController.signal,
               isResponseOk: response =>
@@ -212,9 +206,6 @@ export class ArtifactStorageReader {
             .fetch(mirrorObjectEndpoint, {
               method: args.method,
               headers: args.headers,
-              aws: {
-                signQuery: true,
-              },
               timeout: this.timeout,
               signal: mirrorController.signal,
               isResponseOk: response =>

--- a/packages/services/cdn-worker/src/aws.ts
+++ b/packages/services/cdn-worker/src/aws.ts
@@ -369,7 +369,7 @@ export class AwsV4Signer {
 
     this.cache = cache || new Map();
     this.datetime = datetime || new Date().toISOString().replace(/[:-]|\.\d{3}/g, '');
-    this.signQuery = signQuery;
+    this.signQuery = signQuery ?? true;
     this.appendSessionToken = appendSessionToken || this.service === 'iotdevicegateway';
 
     this.headers.delete('Host'); // Can't be set in insecure env anyway

--- a/packages/services/cdn-worker/tests/s3-iam.spec.ts
+++ b/packages/services/cdn-worker/tests/s3-iam.spec.ts
@@ -79,6 +79,7 @@ describe('S3 IAM AwsClient (cdn-worker)', () => {
 
       const [url, signed] = await client.sign('https://s3.us-east-1.amazonaws.com/bucket/key', {
         method: 'GET',
+        aws: { signQuery: false },
       });
 
       expect(mockProvider.getCredentials).toHaveBeenCalledOnce();
@@ -108,9 +109,11 @@ describe('S3 IAM AwsClient (cdn-worker)', () => {
 
       const [, signed1] = await client.sign('https://s3.us-east-1.amazonaws.com/bucket/key', {
         method: 'GET',
+        aws: { signQuery: false },
       });
       const [, signed2] = await client.sign('https://s3.us-east-1.amazonaws.com/bucket/key', {
         method: 'GET',
+        aws: { signQuery: false },
       });
 
       const auth1 = (signed1.headers as Headers).get('authorization');
@@ -137,6 +140,7 @@ describe('S3 IAM AwsClient (cdn-worker)', () => {
 
       const [, signed] = await client.sign('https://s3.us-east-1.amazonaws.com/bucket/key', {
         method: 'GET',
+        aws: { signQuery: false },
       });
 
       const tokenHeader = (signed.headers as Headers).get('x-amz-security-token');


### PR DESCRIPTION
Improve the observability story of the external S3 compatible storages (Cloudflare R2 and AWS S3).

Summary:
- Adds metrics for write latency and HTTP status codes, grouped by destination (R2 or S3) and operation (e.g. schema sdl, app deployment, etc)
- Adds Cloudflare Ray IDs to traces for failed R2 writes
- Centralizes object storage writes in a shared S3Writer class
- Propagates worker-thread metrics and R2 error details to the API process (so they can be scraped from the metrics endpoint)
- Adds a Grafana dashboard for monitoring write latency, volume, and failures

___

We now have some information about the r2 ray ids and status on the traces when writes to r2 fail (I enforced this failure by setting the wrong access key in a dev deployment):

<img width="1565" height="768" alt="image" src="https://github.com/user-attachments/assets/53fe6c31-9ef9-4f8b-8561-70beb5f20725" />

Comes with a new dashboard for displaying the new metrics - this should help us make follow-up decissions.

<img width="1091" height="771" alt="image" src="https://github.com/user-attachments/assets/6e245e10-8b84-4d96-a88a-e2771052c17b" />

