### PR TITLE
Fix latent bug in lab build scalar field

### DIFF
--- a/.changeset/rare-donkeys-clap.md
+++ b/.changeset/rare-donkeys-clap.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/laboratory': minor
+---
+
+Union and interface fields are now expandable in the query builder: each abstract field lists its possible types as a `... on Type` row, with `__typename` selected automatically so the operation stays valid. Previously an abstract field was written with no selection set and servers rejected the request. Search now finds fields inside those branches, and a field selected inside a hand-written inline fragment checks the row under its own type rather than the parent's.

--- a/packages/libraries/laboratory/dev/operations.spec.ts
+++ b/packages/libraries/laboratory/dev/operations.spec.ts
@@ -1,7 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { buildSchema, parse, validate } from 'graphql';
 import { devActiveTabId, devOperations, devTabs } from './operations';
 import { queryPlanFixtures } from './query-plan-fixtures';
 
+/** The same schema the mock endpoint serves, so a seed cannot drift from it. */
+const schema = buildSchema(readFileSync('schema.graphql', 'utf-8'));
+
 describe('dev operations', () => {
+  // Seeds are hand-written against a large schema. An invalid one still parses,
+  // so it loads looking fine and only shows up as red squiggles in the editor.
+  it.each(devOperations)('$name is valid against the schema', operation => {
+    expect(validate(schema, parse(operation.query)).map(error => error.message)).toEqual([]);
+  });
+
   // An operation is only reachable through a tab, so a mismatched id seeds a tab
   // that renders nothing rather than failing loudly.
   it.each(devTabs)('tab $id points at a seeded operation', tab => {

--- a/packages/libraries/laboratory/dev/operations.ts
+++ b/packages/libraries/laboratory/dev/operations.ts
@@ -56,6 +56,63 @@ subscription OidcLog {
     extensions: '',
   },
   {
+    id: 'dev-op-shared-field-names',
+    name: 'Shared field names',
+    query: `# CompositeSchema and SingleSchema both declare id, author, commit, date,
+# metadata and source. Only the CompositeSchema branch is selected here, so on
+# load exactly one of the two id rows is ticked. Expand
+# latestValidVersion > schemas > edges > node in the builder to see both.
+query SharedFieldNames {
+  latestValidVersion {
+    schemas {
+      edges {
+        node {
+          __typename
+          ... on CompositeSchema {
+            id
+            service
+          }
+        }
+      }
+    }
+  }
+}`,
+    variables: '',
+    headers: '',
+    extensions: '',
+  },
+  {
+    id: 'dev-op-legacy-fragments',
+    name: 'Legacy fragments',
+    query: `# A document the builder did not write: a hand-placed __typename, an inline
+# fragment, and a named fragment spread the builder does not manage. The tree
+# should expand to the fragment rows on load, and unticking url below
+# "... on CompositeSchema" must leave a document that still parses rather than a
+# bare "... on CompositeSchema". The spread must survive untouched.
+query LegacyFragments {
+  latestValidVersion {
+    schemas {
+      edges {
+        node {
+          __typename
+          ... on CompositeSchema {
+            url
+          }
+          ...SchemaFields
+        }
+      }
+    }
+  }
+}
+
+fragment SchemaFields on CompositeSchema {
+  commit
+}`,
+    variables: '',
+    headers: '',
+    extensions: '',
+  },
+  {
     id: 'dev-op-defer-plan',
     name: 'Defer plan',
     query: `# Plan tree with a Defer node: one primary branch, one deferred.
@@ -72,10 +129,13 @@ query DeferPlan {
   },
 ];
 
+/** The tab surfacing a seeded operation, so a preview can open one by name. */
+export const devTabIdFor = (operationId: string) => `dev-tab-${operationId}`;
+
 export const devTabs: LaboratoryTab[] = devOperations.map(operation => ({
-  id: `dev-tab-${operation.id}`,
+  id: devTabIdFor(operation.id),
   type: 'operation',
   data: { id: operation.id, name: operation.name },
 }));
 
-export const devActiveTabId = 'dev-tab-dev-op-query-plan';
+export const devActiveTabId = devTabIdFor('dev-op-query-plan');

--- a/packages/libraries/laboratory/dev/operations.ts
+++ b/packages/libraries/laboratory/dev/operations.ts
@@ -56,6 +56,41 @@ subscription OidcLog {
     extensions: '',
   },
   {
+    id: 'dev-op-union-expansion',
+    name: 'Union expansion',
+    query: `# tokenInfo is a union one level down from the root, so the builder opens on
+# it. It has a chevron and a "... on" row per member, where it used to render as
+# a leaf. The __typename below is what ticking an abstract field now writes on
+# its own; untick tokenInfo and tick it again to watch that happen. Run works.
+query UnionExpansion {
+  tokenInfo {
+    __typename
+  }
+}`,
+    variables: '',
+    headers: '',
+    extensions: '',
+  },
+  {
+    id: 'dev-op-interface-expansion',
+    name: 'Interface expansion',
+    query: `# schemaCheck is an interface. Its own fields render directly, with
+# "... on FailedSchemaCheck" and "... on SuccessfulSchemaCheck" below them
+# carrying only what each implementation adds, so there is no second id row.
+# The arguments are filled in so the document validates; it is not meant to run.
+query InterfaceExpansion($target: TargetReferenceInput!, $checkId: ID!) {
+  target(reference: $target) {
+    schemaCheck(id: $checkId) {
+      __typename
+      id
+    }
+  }
+}`,
+    variables: '',
+    headers: '',
+    extensions: '',
+  },
+  {
     id: 'dev-op-shared-field-names',
     name: 'Shared field names',
     query: `# CompositeSchema and SingleSchema both declare id, author, commit, date,

--- a/packages/libraries/laboratory/dev/previews/abstract-types.preview.tsx
+++ b/packages/libraries/laboratory/dev/previews/abstract-types.preview.tsx
@@ -1,12 +1,13 @@
 /**
  * Union and interface fields in the builder, against Hive's own schema.
  *
- * What each preview should show:
+ * Every preview seeds a document that opens the tree where it is aimed, so none
+ * of them need navigating to. What each should show:
  *
- * - UnionExpansion: `tokenInfo` is a union at the top level, so it has a chevron
- *   and two `... on` rows under it. Ticking `tokenInfo` alone writes
- *   `tokenInfo { __typename }`, and Run returns data rather than a 400. That is
- *   the reported bug: it used to write a bare `tokenInfo` with no selection set.
+ * - UnionExpansion: `tokenInfo` has a chevron and a `... on` row per member,
+ *   where it used to render as a leaf. Untick it and tick it again: it comes
+ *   back as `tokenInfo { __typename }`, never a bare field. Run returns data
+ *   rather than the 400 the reported bug produced.
  *
  * - SharedFieldNames: CompositeSchema and SingleSchema share six field names. The
  *   seeded document selects `id` under CompositeSchema only, so on load exactly
@@ -15,7 +16,8 @@
  *
  * - InterfaceExpansion: `schemaCheck` is an interface. Its own fields stay where
  *   they were, with `... on FailedSchemaCheck` and `... on SuccessfulSchemaCheck`
- *   below them carrying only what each implementation adds.
+ *   below them carrying only what each implementation adds, so `id` appears once
+ *   rather than once per branch.
  *
  * - LegacyDocument: a document the builder did not write. The tree should expand
  *   to its fragment rows on load, the named fragment spread should survive every
@@ -56,7 +58,7 @@ const LaboratoryWith = ({ activeTabId }: { activeTabId: string }) => (
 
 export const UnionExpansion = createPreview({
   label: 'Union expansion',
-  render: () => <LaboratoryWith activeTabId={devTabIdFor('dev-op-me')} />,
+  render: () => <LaboratoryWith activeTabId={devTabIdFor('dev-op-union-expansion')} />,
 });
 
 export const SharedFieldNames = createPreview({
@@ -66,7 +68,7 @@ export const SharedFieldNames = createPreview({
 
 export const InterfaceExpansion = createPreview({
   label: 'Interface expansion',
-  render: () => <LaboratoryWith activeTabId={devTabIdFor('dev-op-me')} />,
+  render: () => <LaboratoryWith activeTabId={devTabIdFor('dev-op-interface-expansion')} />,
 });
 
 export const LegacyDocument = createPreview({

--- a/packages/libraries/laboratory/dev/previews/abstract-types.preview.tsx
+++ b/packages/libraries/laboratory/dev/previews/abstract-types.preview.tsx
@@ -22,6 +22,16 @@
  *   edit untouched, and unticking the last field inside a fragment must leave the
  *   editor alive. An emptied `... on X` prints without braces and does not parse,
  *   which would freeze every row at once.
+ *
+ * - AbstractSearch: search `canBeApproved`. Every hit is inside a branch
+ *   (`... on FailedSchemaCheck`), and before branches were crawled this returned
+ *   nothing at all. `commit` finds the field under `... on PushedSchemaLog` and
+ *   `... on CompositeSchema` as well as on plain object types. In list mode a
+ *   branch reads `on CompositeSchema`, never the encoded `on:CompositeSchema`.
+ *   `singleschema` must match nothing: matching runs on field names, so the
+ *   spelling of a branch's own type is not searchable. Avoid `service` and
+ *   `composite` as checks; real fields are named `ownedByServiceNames` and
+ *   `compositeSchemaSDL`, so those terms are legitimately noisy.
  */
 import { createPreview, type NavPath } from 'react-foundry';
 import { Laboratory } from '../../src/components/laboratory/laboratory';
@@ -62,4 +72,9 @@ export const InterfaceExpansion = createPreview({
 export const LegacyDocument = createPreview({
   label: 'Legacy document',
   render: () => <LaboratoryWith activeTabId={devTabIdFor('dev-op-legacy-fragments')} />,
+});
+
+export const AbstractSearch = createPreview({
+  label: 'Abstract search',
+  render: () => <LaboratoryWith activeTabId={devTabIdFor('dev-op-shared-field-names')} />,
 });

--- a/packages/libraries/laboratory/dev/previews/abstract-types.preview.tsx
+++ b/packages/libraries/laboratory/dev/previews/abstract-types.preview.tsx
@@ -1,0 +1,65 @@
+/**
+ * Union and interface fields in the builder, against Hive's own schema.
+ *
+ * What each preview should show:
+ *
+ * - UnionExpansion: `tokenInfo` is a union at the top level, so it has a chevron
+ *   and two `... on` rows under it. Ticking `tokenInfo` alone writes
+ *   `tokenInfo { __typename }`, and Run returns data rather than a 400. That is
+ *   the reported bug: it used to write a bare `tokenInfo` with no selection set.
+ *
+ * - SharedFieldNames: CompositeSchema and SingleSchema share six field names. The
+ *   seeded document selects `id` under CompositeSchema only, so on load exactly
+ *   one of the two identically named `id` rows is ticked. Ticking the other must
+ *   not disturb the first.
+ *
+ * - InterfaceExpansion: `schemaCheck` is an interface. Its own fields stay where
+ *   they were, with `... on FailedSchemaCheck` and `... on SuccessfulSchemaCheck`
+ *   below them carrying only what each implementation adds.
+ *
+ * - LegacyDocument: a document the builder did not write. The tree should expand
+ *   to its fragment rows on load, the named fragment spread should survive every
+ *   edit untouched, and unticking the last field inside a fragment must leave the
+ *   editor alive. An emptied `... on X` prints without braces and does not parse,
+ *   which would freeze every row at once.
+ */
+import { createPreview, type NavPath } from 'react-foundry';
+import { Laboratory } from '../../src/components/laboratory/laboratory';
+import { devCollections } from '../collections';
+import { devOperations, devTabIdFor, devTabs } from '../operations';
+import { devPreflight } from '../preflight';
+
+export const nav: NavPath = 'Laboratory/Abstract types';
+
+const LaboratoryWith = ({ activeTabId }: { activeTabId: string }) => (
+  <Laboratory
+    enableDocs
+    theme="dark"
+    defaultEndpoint={`${window.location.origin}/graphql`}
+    defaultCollections={devCollections}
+    defaultOperations={devOperations}
+    defaultTabs={devTabs}
+    defaultActiveTabId={activeTabId}
+    defaultPreflight={devPreflight}
+  />
+);
+
+export const UnionExpansion = createPreview({
+  label: 'Union expansion',
+  render: () => <LaboratoryWith activeTabId={devTabIdFor('dev-op-me')} />,
+});
+
+export const SharedFieldNames = createPreview({
+  label: 'Shared field names',
+  render: () => <LaboratoryWith activeTabId={devTabIdFor('dev-op-shared-field-names')} />,
+});
+
+export const InterfaceExpansion = createPreview({
+  label: 'Interface expansion',
+  render: () => <LaboratoryWith activeTabId={devTabIdFor('dev-op-me')} />,
+});
+
+export const LegacyDocument = createPreview({
+  label: 'Legacy document',
+  render: () => <LaboratoryWith activeTabId={devTabIdFor('dev-op-legacy-fragments')} />,
+});

--- a/packages/libraries/laboratory/foundry.config.ts
+++ b/packages/libraries/laboratory/foundry.config.ts
@@ -9,7 +9,9 @@ export default defineConfig({
   title: 'Hive Laboratory',
   // 5173 belongs to `pnpm dev`, so both servers can run side by side.
   port: 5174,
-  nav: [{ label: 'Laboratory', children: [{ label: 'Subscriptions' }] }],
+  nav: [
+    { label: 'Laboratory', children: [{ label: 'Subscriptions' }, { label: 'Abstract types' }] },
+  ],
   viteConfig: {
     // Foundry runs its own vite server and never loads vite.config.ts, so everything the
     // Laboratory needs is restated here: its stylesheet is Tailwind, its editors are

--- a/packages/libraries/laboratory/package.json
+++ b/packages/libraries/laboratory/package.json
@@ -123,7 +123,7 @@
     "postcss-prefixwrap": "^1.57.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-foundry": "0.0.10",
+    "react-foundry": "0.0.13",
     "react-resizable-panels": "^3.0.6",
     "react-shadow": "^20.6.0",
     "rollup-plugin-typescript2": "^0.36.0",

--- a/packages/libraries/laboratory/src/components/laboratory/builder-abstract-fields.spec.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/builder-abstract-fields.spec.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { buildSchema, type GraphQLInterfaceType, type GraphQLObjectType } from 'graphql';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BuilderField, BuilderTypeConditionField } from './builder';
+
+const laboratory = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
+
+vi.mock('./context', () => ({
+  useLaboratory: () => laboratory.current,
+}));
+
+const schema = buildSchema(`
+  type Image { url: String, title: String }
+  type Video { url: String, duration: Int }
+  union CmsContent = Image | Video
+  interface Node { id: ID!, name: String }
+  type Article implements Node { id: ID!, name: String, body: String }
+  type Bare implements Node { id: ID!, name: String }
+  type Page { content: [CmsContent!]!, node: Node }
+  type Query { page: Page }
+`);
+
+const pageType = schema.getType('Page') as GraphQLObjectType;
+const contentField = pageType.getFields().content;
+const nodeField = pageType.getFields().node;
+
+const addPathToActiveOperation = vi.fn();
+const openDocs = vi.fn();
+
+const mount = (node: React.ReactElement, query = '') => {
+  laboratory.current = {
+    schema,
+    enableDocs: true,
+    openDocs,
+    activeOperation: { query },
+    activeTab: { type: 'operation' },
+    addPathToActiveOperation,
+    deletePathFromActiveOperation: vi.fn(),
+    addArgToActiveOperation: vi.fn(),
+    deleteArgFromActiveOperation: vi.fn(),
+  };
+
+  return render(node);
+};
+
+const fieldRow = (field: typeof contentField, name: string) => (
+  <BuilderField
+    field={field}
+    path={['query', 'page', name]}
+    openPaths={['query.page.content', 'query.page.node']}
+    setOpenPaths={vi.fn()}
+  />
+);
+
+describe('abstract fields in the builder', () => {
+  beforeEach(() => {
+    addPathToActiveOperation.mockReset();
+    openDocs.mockReset();
+  });
+
+  // The reported bug: a union field rendered as a leaf checkbox with no expander.
+  it('expands a union field into a row per possible type', () => {
+    mount(fieldRow(contentField, 'content'));
+
+    expect(screen.getByText('Image')).toBeDefined();
+    expect(screen.getByText('Video')).toBeDefined();
+  });
+
+  it('shows an interface its own fields as well as its implementations', () => {
+    mount(fieldRow(nodeField, 'node'));
+
+    expect(screen.getByText('id')).toBeDefined();
+    expect(screen.getByText('name')).toBeDefined();
+    expect(screen.getByText('Article')).toBeDefined();
+  });
+
+  it('omits an implementation that adds nothing to the interface', () => {
+    mount(fieldRow(nodeField, 'node'));
+
+    expect(screen.queryByText('Bare')).toBeNull();
+  });
+});
+
+const conditionRow = (typeName: string, parent: 'CmsContent' | 'Node', query = '') =>
+  mount(
+    <BuilderTypeConditionField
+      type={schema.getType(typeName) as GraphQLObjectType}
+      parentType={schema.getType(parent) as GraphQLObjectType | GraphQLInterfaceType}
+      path={['query', 'page', 'content', `on:${typeName}`]}
+      openPaths={['query.page.content.on:' + typeName]}
+      setOpenPaths={vi.fn()}
+    />,
+    query,
+  );
+
+describe('BuilderTypeConditionField', () => {
+  beforeEach(() => {
+    addPathToActiveOperation.mockReset();
+    openDocs.mockReset();
+  });
+
+  it('renders the type condition as GraphQL', () => {
+    const { container } = conditionRow('Image', 'CmsContent');
+
+    expect(container.textContent).toContain('... on');
+    expect(screen.getByText('Image')).toBeDefined();
+  });
+
+  // A disabled checkbox here reads as broken rather than as "not selectable", and
+  // a type condition groups fields rather than being one you select.
+  it('offers no checkbox to tick', () => {
+    const { container } = conditionRow('Image', 'CmsContent');
+    // The row itself, not its field rows, which are tickable.
+    const row = container.querySelector('button')!;
+
+    expect(row.textContent).toContain('... on');
+    expect(row.querySelector('[data-slot="checkbox"]')).toBeNull();
+  });
+
+  it('reflects a fragment that is already in the document', () => {
+    const query = 'query { page { content { __typename ... on Image { url } } } }';
+    const { container } = conditionRow('Image', 'CmsContent', query);
+
+    expect(container.querySelector('.text-foreground-primary')).not.toBeNull();
+  });
+
+  it('ticks a member field with the encoded path and the schema', () => {
+    conditionRow('Image', 'CmsContent');
+
+    fireEvent.click(screen.getByText('url').closest('div')!.querySelector('button')!);
+
+    expect(addPathToActiveOperation).toHaveBeenCalledWith(
+      'query.page.content.on:Image.url',
+      undefined,
+      schema,
+    );
+  });
+
+  it('offers the possible type in the docs menu', () => {
+    const { container } = conditionRow('Image', 'CmsContent');
+
+    fireEvent.contextMenu(container.querySelector('button')!);
+    fireEvent.click(screen.getByText('Open in Docs'));
+
+    expect(openDocs).toHaveBeenCalledWith({ kind: 'type', name: 'Image' });
+  });
+});

--- a/packages/libraries/laboratory/src/components/laboratory/builder-abstract-fields.spec.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/builder-abstract-fields.spec.tsx
@@ -1,7 +1,17 @@
 // @vitest-environment jsdom
-import { buildSchema, type GraphQLInterfaceType, type GraphQLObjectType } from 'graphql';
+import {
+  buildSchema,
+  OperationTypeNode,
+  type GraphQLInterfaceType,
+  type GraphQLObjectType,
+} from 'graphql';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { BuilderField, BuilderTypeConditionField } from './builder';
+import {
+  BuilderField,
+  BuilderSearchResultMode,
+  BuilderSearchResults,
+  BuilderTypeConditionField,
+} from './builder';
 
 const laboratory = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
 
@@ -134,6 +144,32 @@ describe('BuilderTypeConditionField', () => {
       undefined,
       schema,
     );
+  });
+
+  // The encoded segment is internal; a list result showing `on:Image` would be
+  // leaking the path format into the UI.
+  it('renders a branch segment as GraphQL in list-mode results', () => {
+    const { container } = render(
+      <BuilderSearchResults
+        type="query"
+        fields={[]}
+        openPaths={[]}
+        setOpenPaths={vi.fn()}
+        visiblePaths={null}
+        matchedPaths={['query.page.content.on:Image.url']}
+        forcedOpenPaths={null}
+        isSearchActive
+        mode={BuilderSearchResultMode.LIST}
+        isReadOnly={false}
+        operation={null}
+        searchValue="url"
+        schema={schema}
+        tab={OperationTypeNode.QUERY}
+      />,
+    );
+
+    expect(container.textContent).toContain('on Image');
+    expect(container.textContent).not.toContain('on:Image');
   });
 
   it('offers the possible type in the docs menu', () => {

--- a/packages/libraries/laboratory/src/components/laboratory/builder.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/builder.tsx
@@ -8,14 +8,18 @@ import {
   useState,
 } from 'react';
 import {
-  GraphQLEnumType,
-  GraphQLObjectType,
-  GraphQLScalarType,
+  getNamedType,
   GraphQLSchema,
-  GraphQLUnionType,
+  isEnumType,
+  isInterfaceType,
+  isObjectType,
+  isScalarType,
+  isUnionType,
   OperationTypeNode,
   type GraphQLArgument,
   type GraphQLField,
+  type GraphQLNamedType,
+  type GraphQLObjectType,
 } from 'graphql';
 import { throttle } from 'lodash';
 import {
@@ -40,6 +44,7 @@ import {
   mergeOpenPaths,
   searchSchemaPaths,
 } from '../../lib/operations.utils';
+import { encodeTypeConditionSegment } from '../../lib/schema-path';
 import { cn, splitIdentifier } from '../../lib/utils';
 import { GraphQLType } from '../graphql-type';
 import { GraphQLIcon } from '../icons';
@@ -177,8 +182,13 @@ export const BuilderScalarField = (props: {
   label?: React.ReactNode;
   disableChildren?: boolean;
 }) => {
-  const { activeOperation, addPathToActiveOperation, deletePathFromActiveOperation, activeTab } =
-    useLaboratory();
+  const {
+    schema,
+    activeOperation,
+    addPathToActiveOperation,
+    deletePathFromActiveOperation,
+    activeTab,
+  } = useLaboratory();
 
   const operation = useMemo(() => {
     return props.operation ?? activeOperation ?? null;
@@ -251,7 +261,7 @@ export const BuilderScalarField = (props: {
             onCheckedChange={checked => {
               if (checked) {
                 setIsOpen(true);
-                addPathToActiveOperation(path, props.operationName);
+                addPathToActiveOperation(path, props.operationName, schema ?? undefined);
               } else {
                 deletePathFromActiveOperation(path, props.operationName);
               }
@@ -306,7 +316,7 @@ export const BuilderScalarField = (props: {
                 onCheckedChange={checked => {
                   if (checked) {
                     setIsOpen(true);
-                    addPathToActiveOperation(path, props.operationName);
+                    addPathToActiveOperation(path, props.operationName, schema ?? undefined);
                   } else {
                     deletePathFromActiveOperation(path, props.operationName);
                   }
@@ -401,7 +411,11 @@ export const BuilderScalarField = (props: {
           disabled={activeTab?.type !== 'operation'}
           onCheckedChange={checked => {
             if (checked) {
-              addPathToActiveOperation(props.path.join('.'), props.operationName);
+              addPathToActiveOperation(
+                props.path.join('.'),
+                props.operationName,
+                schema ?? undefined,
+              );
             } else {
               deletePathFromActiveOperation(props.path.join('.'), props.operationName);
             }
@@ -467,15 +481,28 @@ export const BuilderObjectField = (props: {
     [path, props],
   );
 
+  const namedType = useMemo(() => getNamedType(props.field.type), [props.field.type]);
+
   const fields = useMemo(
     () =>
-      Object.values(
-        (
-          schema?.getType(props.field.type.toString().replace(/\[|\]|!/g, '')) as GraphQLObjectType
-        )?.getFields?.() ?? {},
-      ),
-    [schema, props.field.type],
+      isObjectType(namedType) || isInterfaceType(namedType)
+        ? Object.values(namedType.getFields())
+        : [],
+    [namedType],
   );
+
+  /**
+   * A union selects nothing without a type condition, and an interface can only
+   * reach an implementation's own fields through one, so each possible type gets
+   * a row that writes `... on Type`.
+   */
+  const possibleTypes = useMemo(() => {
+    if (isUnionType(namedType)) {
+      return namedType.getTypes();
+    }
+
+    return isInterfaceType(namedType) ? (schema?.getPossibleTypes(namedType) ?? []) : [];
+  }, [namedType, schema]);
 
   const args = useMemo(() => {
     return (props.field as GraphQLField<unknown, unknown, unknown>).args ?? [];
@@ -525,7 +552,7 @@ export const BuilderObjectField = (props: {
             onCheckedChange={checked => {
               if (checked) {
                 setIsOpen(true);
-                addPathToActiveOperation(path, props.operationName);
+                addPathToActiveOperation(path, props.operationName, schema ?? undefined);
               } else {
                 deletePathFromActiveOperation(path, props.operationName);
               }
@@ -579,7 +606,7 @@ export const BuilderObjectField = (props: {
               onCheckedChange={checked => {
                 if (checked) {
                   setIsOpen(true);
-                  addPathToActiveOperation(path, props.operationName);
+                  addPathToActiveOperation(path, props.operationName, schema ?? undefined);
                 } else {
                   deletePathFromActiveOperation(path, props.operationName);
                 }
@@ -661,6 +688,162 @@ export const BuilderObjectField = (props: {
                 searchValue={props.searchValue}
               />
             ))}
+            {possibleTypes.map(possibleType => (
+              <BuilderTypeConditionField
+                key={possibleType.name}
+                type={possibleType}
+                parentType={namedType}
+                path={[...props.path, encodeTypeConditionSegment(possibleType.name)]}
+                openPaths={props.openPaths}
+                setOpenPaths={props.setOpenPaths}
+                visiblePaths={props.visiblePaths}
+                forcedOpenPaths={props.forcedOpenPaths}
+                isSearchActive={props.isSearchActive}
+                isReadOnly={props.isReadOnly}
+                operation={operation}
+                operationName={props.operationName}
+                searchValue={props.searchValue}
+              />
+            ))}
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+/**
+ * One possible type of an abstract field, written as `... on Type`.
+ *
+ * Like the `[arguments]` row this is not a field, so its checkbox only reports
+ * whether anything below it is selected. Ticking it on its own would mean writing
+ * an inline fragment with no selections, which does not parse, so the fragment is
+ * created and pruned by its children instead.
+ *
+ * Unlike that row it is a real level in the path, so its open state is tracked in
+ * `openPaths` and it can be forced open by a search.
+ */
+export const BuilderTypeConditionField = (props: {
+  type: GraphQLObjectType;
+  parentType: GraphQLNamedType;
+  path: string[];
+  openPaths: string[];
+  setOpenPaths: (openPaths: string[]) => void;
+  visiblePaths?: Set<string> | null;
+  forcedOpenPaths?: Set<string> | null;
+  isSearchActive?: boolean;
+  isReadOnly?: boolean;
+  operation?: LaboratoryOperation | null;
+  operationName?: string | null;
+  searchValue?: string;
+}) => {
+  const { activeOperation } = useLaboratory();
+
+  const operation = useMemo(
+    () => props.operation ?? activeOperation ?? null,
+    [props.operation, activeOperation],
+  );
+
+  const path = useMemo(() => props.path.join('.'), [props.path]);
+
+  const isOpen = useMemo(
+    () => props.openPaths.includes(path) || !!props.forcedOpenPaths?.has(path),
+    [props.openPaths, props.forcedOpenPaths, path],
+  );
+
+  const setIsOpen = useCallback(
+    (isOpen: boolean) => {
+      props.setOpenPaths(
+        isOpen ? [...props.openPaths, path] : props.openPaths.filter(openPath => openPath !== path),
+      );
+    },
+    [path, props],
+  );
+
+  /**
+   * An implementation only adds what the interface does not already declare; those
+   * fields are on the rows above. A union has no such parent level, and members
+   * sharing a field name is exactly what the branch exists to separate.
+   */
+  const fields = useMemo(() => {
+    const own = Object.values(props.type.getFields());
+
+    if (!isInterfaceType(props.parentType)) {
+      return own;
+    }
+
+    const inherited = new Set(Object.keys(props.parentType.getFields()));
+
+    return own.filter(field => !inherited.has(field.name));
+  }, [props.type, props.parentType]);
+
+  const isInQuery = useMemo(
+    () => isPathInQuery(operation?.query ?? '', path, props.operationName),
+    [operation?.query, path, props.operationName],
+  );
+
+  if (props.isSearchActive && props.visiblePaths && !props.visiblePaths.has(path)) {
+    return null;
+  }
+
+  // A row that opens onto nothing is worse than no row.
+  if (fields.length === 0) {
+    return null;
+  }
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <BuilderRowContextMenu path={props.path}>
+        <CollapsibleTrigger asChild>
+          <Button
+            variant="ghost"
+            className={cn(
+              'text-muted-foreground bg-card p-1! group sticky top-0 z-10 w-full justify-start overflow-hidden text-xs',
+              {
+                'text-foreground-primary': isInQuery,
+              },
+            )}
+            style={{
+              top: `${(props.path.length - 2) * 32}px`,
+            }}
+            size="sm"
+          >
+            <div className="bg-card absolute left-0 top-0 -z-20 size-full" />
+            <div className="group-hover:bg-accent/50 absolute left-0 top-0 -z-10 size-full transition-colors" />
+            <ChevronDownIcon
+              className={cn('text-muted-foreground size-4 transition-all', {
+                '-rotate-90': !isOpen,
+              })}
+            />
+            {/* A spacer, not a checkbox: a type condition groups fields rather than
+                being one you select, so there is nothing here to tick. The row still
+                highlights while something inside it is selected. Aligns the label with
+                the field rows below, the way BuilderArgument spaces its chevron. */}
+            <div className="size-4" />
+            <CuboidIcon className="size-4 text-amber-400" />
+            ... on <GraphQLType type={props.type} />
+          </Button>
+        </CollapsibleTrigger>
+      </BuilderRowContextMenu>
+      <CollapsibleContent className="border-border relative z-0 ml-4 flex flex-col border-l pl-1">
+        {isOpen && (
+          <div>
+            {fields.map(child => (
+              <BuilderField
+                key={child.name}
+                field={child}
+                path={[...props.path, child.name]}
+                openPaths={props.openPaths}
+                setOpenPaths={props.setOpenPaths}
+                visiblePaths={props.visiblePaths}
+                forcedOpenPaths={props.forcedOpenPaths}
+                isSearchActive={props.isSearchActive}
+                isReadOnly={props.isReadOnly}
+                operation={operation}
+                operationName={props.operationName}
+                searchValue={props.searchValue}
+              />
+            ))}
           </div>
         )}
       </CollapsibleContent>
@@ -683,16 +866,11 @@ export const BuilderField = (props: {
   label?: React.ReactNode;
   disableChildren?: boolean;
 }) => {
-  const { schema } = useLaboratory();
+  // Unions and interfaces are expandable: they get a row per possible type. Only
+  // scalars and enums genuinely have nothing underneath them.
+  const type = getNamedType(props.field.type);
 
-  const type = schema?.getType(props.field.type.toString().replace(/\[|\]|!/g, ''));
-
-  if (
-    !type ||
-    type instanceof GraphQLScalarType ||
-    type instanceof GraphQLEnumType ||
-    type instanceof GraphQLUnionType
-  ) {
+  if (!type || isScalarType(type) || isEnumType(type)) {
     return (
       <BuilderScalarField
         field={props.field}

--- a/packages/libraries/laboratory/src/components/laboratory/builder.tsx
+++ b/packages/libraries/laboratory/src/components/laboratory/builder.tsx
@@ -44,7 +44,7 @@ import {
   mergeOpenPaths,
   searchSchemaPaths,
 } from '../../lib/operations.utils';
-import { encodeTypeConditionSegment } from '../../lib/schema-path';
+import { decodeTypeConditionSegment, encodeTypeConditionSegment } from '../../lib/schema-path';
 import { cn, splitIdentifier } from '../../lib/utils';
 import { GraphQLType } from '../graphql-type';
 import { GraphQLIcon } from '../icons';
@@ -1012,6 +1012,20 @@ export const BuilderSearchResults = (props: {
           label={
             <span>
               {path.split('.').map((part, index) => {
+                const typeName = decodeTypeConditionSegment(part);
+
+                // The encoded form is internal. Show the type condition as GraphQL,
+                // and never highlight it: matching runs on field names, so a hit
+                // here would be claiming a match the search never made.
+                if (typeName !== null) {
+                  return (
+                    <Fragment key={index}>
+                      <span className="text-amber-400">on {typeName}</span>
+                      {index < path.split('.').length - 1 && '.'}
+                    </Fragment>
+                  );
+                }
+
                 const splittedPart = splitIdentifier(part);
 
                 const isMatch = splittedPart.some(p =>

--- a/packages/libraries/laboratory/src/lib/docs.spec.ts
+++ b/packages/libraries/laboratory/src/lib/docs.spec.ts
@@ -7,7 +7,10 @@ const schema = buildSchema(`
   interface Node { id: ID! }
   type Address { city: String }
   type Profile implements Node { id: ID!, address: Address }
-  type User implements Node { id: ID!, profile: Profile }
+  type Photo { url: String }
+  type Clip { url: String, duration: Int }
+  union Media = Photo | Clip
+  type User implements Node { id: ID!, profile: Profile, media: [Media!]! }
   type Query { me: User }
   type Mutation { signIn: User }
 `);
@@ -56,6 +59,34 @@ describe('docsTargetFromPath', () => {
   it('returns null without a schema or a field segment', () => {
     expect(docsTargetFromPath(['query', 'me'], null)).toBeNull();
     expect(docsTargetFromPath(['query'], schema)).toBeNull();
+  });
+
+  it('resolves a union field, which previously returned nothing below it', () => {
+    expect(docsTargetFromPath(['query', 'me', 'media'], schema)).toEqual({
+      kind: 'field',
+      typeName: 'User',
+      fieldName: 'media',
+    });
+  });
+
+  it('resolves a type-condition row to the type it narrows to', () => {
+    expect(docsTargetFromPath(['query', 'me', 'media', 'on:Photo'], schema)).toEqual({
+      kind: 'type',
+      name: 'Photo',
+    });
+  });
+
+  // The parent is the member the field is selected on, not the union.
+  it('resolves a field inside a type condition to its member type', () => {
+    expect(docsTargetFromPath(['query', 'me', 'media', 'on:Clip', 'duration'], schema)).toEqual({
+      kind: 'field',
+      typeName: 'Clip',
+      fieldName: 'duration',
+    });
+  });
+
+  it('returns null for a type that is not a member of the union', () => {
+    expect(docsTargetFromPath(['query', 'me', 'media', 'on:Profile'], schema)).toBeNull();
   });
 });
 

--- a/packages/libraries/laboratory/src/lib/docs.ts
+++ b/packages/libraries/laboratory/src/lib/docs.ts
@@ -1,12 +1,6 @@
 import { useCallback, useState } from 'react';
-import {
-  getNamedType,
-  isInterfaceType,
-  isObjectType,
-  type GraphQLField,
-  type GraphQLNamedType,
-  type GraphQLSchema,
-} from 'graphql';
+import type { GraphQLSchema } from 'graphql';
+import { resolveSchemaPath } from './schema-path';
 
 export type LaboratoryActivePanel =
   | 'collections'
@@ -34,41 +28,21 @@ export const docsTargetFromPath = (
   path: string[],
   schema: GraphQLSchema | null,
 ): LaboratoryDocsTarget | null => {
-  const [operation, ...segments] = path;
-
-  if (!schema || segments.length === 0) {
+  if (!schema) {
     return null;
   }
 
-  let type: GraphQLNamedType | null | undefined =
-    operation === 'query'
-      ? schema.getQueryType()
-      : operation === 'mutation'
-        ? schema.getMutationType()
-        : operation === 'subscription'
-          ? schema.getSubscriptionType()
-          : null;
+  const steps = resolveSchemaPath(path.join('.'), schema);
+  const last = steps?.at(-1);
 
-  for (let i = 0; i < segments.length; i++) {
-    if (!type || (!isObjectType(type) && !isInterfaceType(type))) {
-      return null;
-    }
-
-    const parentName = type.name;
-    const field: GraphQLField<unknown, unknown> | undefined = type.getFields()[segments[i]];
-
-    if (!field) {
-      return null;
-    }
-
-    if (i === segments.length - 1) {
-      return { kind: 'field', typeName: parentName, fieldName: field.name };
-    }
-
-    type = getNamedType(field.type);
+  if (!last) {
+    return null;
   }
 
-  return null;
+  // A type-condition row represents the type it narrows to, not a field.
+  return last.field
+    ? { kind: 'field', typeName: last.parentType.name, fieldName: last.field.name }
+    : { kind: 'type', name: last.type.name };
 };
 
 export interface LaboratoryDocsState {

--- a/packages/libraries/laboratory/src/lib/editor-options.spec.ts
+++ b/packages/libraries/laboratory/src/lib/editor-options.spec.ts
@@ -5,6 +5,10 @@ describe('buildEditorOptions', () => {
     expect(buildEditorOptions().fixedOverflowWidgets).toBe(true);
   });
 
+  it('keeps sticky scroll off', () => {
+    expect(buildEditorOptions().stickyScroll?.enabled).toBe(false);
+  });
+
   // Caller options are spread first on purpose; flipping to the more familiar
   // {...defaults, ...overrides} order would let an editor clip its own hovers.
   it('does not let a caller turn the shared options off', () => {

--- a/packages/libraries/laboratory/src/lib/editor-options.ts
+++ b/packages/libraries/laboratory/src/lib/editor-options.ts
@@ -25,6 +25,12 @@ export function buildEditorOptions(overrides?: EditorOptions): EditorOptions {
       enabled: false,
     },
     automaticLayout: true,
+    // On by default in monaco. Its backdrop inherits `editor.background`, which the
+    // laboratory themes make transparent so the panel shows through, so the pinned
+    // scopes render over the scrolling document with nothing behind them.
+    stickyScroll: {
+      enabled: false,
+    },
     tabSize: 2,
     formatOnPaste: true,
     // Editors sit inside overflow-hidden panels, so hovers (including validation

--- a/packages/libraries/laboratory/src/lib/operations.ts
+++ b/packages/libraries/laboratory/src/lib/operations.ts
@@ -62,7 +62,12 @@ export interface LaboratoryOperationsActions {
   setOperations: (operations: LaboratoryOperation[]) => void;
   updateActiveOperation: (operation: Partial<Omit<LaboratoryOperation, 'id'>>) => void;
   deleteOperation: (operationId: string) => void;
-  addPathToActiveOperation: (path: string, operationName?: string | null) => void;
+  /** With a schema, an abstract field is given `__typename` so it is never selection-less. */
+  addPathToActiveOperation: (
+    path: string,
+    operationName?: string | null,
+    schema?: GraphQLSchema,
+  ) => void;
   deletePathFromActiveOperation: (path: string, operationName?: string | null) => void;
   addArgToActiveOperation: (
     path: string,
@@ -291,13 +296,13 @@ export const useOperations = (
   );
 
   const addPathToActiveOperation = useCallback(
-    (path: string, operationName?: string | null) => {
+    (path: string, operationName?: string | null, schema?: GraphQLSchema) => {
       if (!activeOperation) {
         return;
       }
       const newActiveOperation = {
         ...activeOperation,
-        query: addPathToQuery(activeOperation.query, path, operationName),
+        query: addPathToQuery(activeOperation.query, path, operationName, schema),
       };
       updateActiveOperation(newActiveOperation);
     },

--- a/packages/libraries/laboratory/src/lib/operations.utils.spec.ts
+++ b/packages/libraries/laboratory/src/lib/operations.utils.spec.ts
@@ -7,6 +7,7 @@ import {
   createSchemaPathSearchIndex,
   deletePathFromQuery,
   extractPaths,
+  getFieldByPath,
   getOpenPaths,
   getOperationName,
   getOperationType,
@@ -172,6 +173,10 @@ describe('addArgToField / removeArgFromField', () => {
     type Query {
       a(id: ID!): User
       b(id: ID!): User
+      posts: [Post!]!
+    }
+    type Post {
+      author(verified: Boolean): User
     }
     type User {
       id: ID!
@@ -196,6 +201,54 @@ describe('addArgToField / removeArgFromField', () => {
     const withArg = addArgToField('query { a { id } }', 'query.a', 'id', schema);
     const removed = removeArgFromField(withArg, 'query.a', 'id');
     expect(isArgInQuery(removed, 'query.a', 'id')).toBe(false);
+  });
+
+  // Resolving the arg means walking the path back to its field in the schema,
+  // which for a nested path has to see through the list wrapper on `posts`.
+  it('adds an argument to a nested field reached through a list', () => {
+    const result = addArgToField(
+      'query { posts { author { id } } }',
+      'query.posts.author',
+      'verified',
+      schema,
+    );
+
+    expect(isArgInQuery(result, 'query.posts.author', 'verified')).toBe(true);
+
+    const removed = removeArgFromField(result, 'query.posts.author', 'verified');
+
+    expect(isArgInQuery(removed, 'query.posts.author', 'verified')).toBe(false);
+  });
+});
+
+describe('getFieldByPath', () => {
+  const schema = buildSchema(/* GraphQL */ `
+    type Query {
+      posts: [Post!]!
+      user: User
+    }
+    type Post {
+      title: String!
+      author: User
+    }
+    type User {
+      name: String!
+    }
+  `);
+
+  it('resolves a field through an object-typed parent', () => {
+    expect(getFieldByPath('query.user.name', schema)?.name).toBe('name');
+  });
+
+  // The walk used to keep the wrapper type, so it silently stopped at the list
+  // field and handed back the parent instead of the field the path named.
+  it('resolves a field through a list-typed parent', () => {
+    expect(getFieldByPath('query.posts.title', schema)?.name).toBe('title');
+    expect(getFieldByPath('query.posts.author.name', schema)?.name).toBe('name');
+  });
+
+  it('returns null for a field the type does not have', () => {
+    expect(getFieldByPath('query.posts.nope', schema)).toBeNull();
   });
 });
 

--- a/packages/libraries/laboratory/src/lib/operations.utils.spec.ts
+++ b/packages/libraries/laboratory/src/lib/operations.utils.spec.ts
@@ -263,6 +263,12 @@ describe('inline fragments in the document', () => {
     expect(addPathToQuery(query, 'query.page.title')).toContain('...Fields');
   });
 
+  it('does not confuse a fragment path for the parent-level field of the same name', () => {
+    const both = addPathToQuery(addPathToQuery('', IMAGE), VIDEO);
+
+    expect(isPathInQuery(both, 'query.page.content.url')).toBe(false);
+  });
+
   it('adds and removes an argument on a field inside a fragment', () => {
     const schema = buildSchema(/* GraphQL */ `
       type Image {
@@ -334,6 +340,89 @@ describe('addArgToField / removeArgFromField', () => {
     const removed = removeArgFromField(result, 'query.posts.author', 'verified');
 
     expect(isArgInQuery(removed, 'query.posts.author', 'verified')).toBe(false);
+  });
+});
+
+describe('__typename on abstract fields', () => {
+  const schema = buildSchema(/* GraphQL */ `
+    type Image {
+      url: String
+    }
+    type Video {
+      url: String
+    }
+    union CmsContent = Image | Video
+    interface Node {
+      id: ID!
+    }
+    type Page {
+      content: [CmsContent!]!
+      node: Node
+      meta: Meta
+    }
+    type Meta {
+      title: String
+    }
+    type Query {
+      categoryPage: Page
+    }
+  `);
+
+  // The reported bug: the builder wrote `content` with no selection set, and the
+  // customer's server rejected the operation with a 400.
+  it('gives a union field a selection set instead of leaving it bare', () => {
+    const result = addPathToQuery('', 'query.categoryPage.content', null, schema);
+
+    expect(result).toContain('__typename');
+    expect(() => parse(result)).not.toThrow();
+    expect(result).not.toMatch(/content\s*\n/);
+  });
+
+  it('gives an interface field the same treatment', () => {
+    expect(addPathToQuery('', 'query.categoryPage.node', null, schema)).toContain('__typename');
+  });
+
+  it('leaves an object field alone', () => {
+    expect(addPathToQuery('', 'query.categoryPage.meta', null, schema)).not.toContain('__typename');
+  });
+
+  it('puts __typename on the abstract parent, not inside each branch', () => {
+    const result = addPathToQuery('', 'query.categoryPage.content.on:Image.url', null, schema);
+
+    expect(result.match(/__typename/g)).toHaveLength(1);
+    expect(result.indexOf('__typename')).toBeLessThan(result.indexOf('... on Image'));
+  });
+
+  it('does not duplicate __typename when the path is added again', () => {
+    const once = addPathToQuery('', 'query.categoryPage.content', null, schema);
+    const twice = addPathToQuery(once, 'query.categoryPage.content', null, schema);
+
+    expect(twice.match(/__typename/g)).toHaveLength(1);
+  });
+
+  it('preserves a hand-written __typename', () => {
+    const result = addPathToQuery(
+      'query { categoryPage { content { __typename } } }',
+      'query.categoryPage.content.on:Image.url',
+      null,
+      schema,
+    );
+
+    expect(result.match(/__typename/g)).toHaveLength(1);
+  });
+
+  // Unticking the last branch has to land back on a document that still runs.
+  it('leaves a valid selection set after the last branch is removed', () => {
+    const withBranch = addPathToQuery('', 'query.categoryPage.content.on:Image.url', null, schema);
+    const result = deletePathFromQuery(withBranch, 'query.categoryPage.content.on:Image.url');
+
+    expect(() => parse(result)).not.toThrow();
+    expect(result).toContain('__typename');
+    expect(result).not.toContain('... on Image');
+  });
+
+  it('adds nothing without a schema', () => {
+    expect(addPathToQuery('', 'query.categoryPage.content')).not.toContain('__typename');
   });
 });
 

--- a/packages/libraries/laboratory/src/lib/operations.utils.spec.ts
+++ b/packages/libraries/laboratory/src/lib/operations.utils.spec.ts
@@ -511,6 +511,92 @@ describe('searchSchemaPaths', () => {
   });
 });
 
+describe('searchSchemaPaths across abstract types', () => {
+  const schema = buildSchema(/* GraphQL */ `
+    type Image {
+      url: String
+      caption: String
+    }
+    type Video {
+      url: String
+    }
+    union CmsContent = Image | Video
+    interface Node {
+      id: ID!
+    }
+    type Article implements Node {
+      id: ID!
+      body: String
+    }
+    type Recursive {
+      again: Wrapper
+    }
+    union Wrapper = Recursive
+    type Page {
+      content: [CmsContent!]!
+      node: Node
+      loop: Wrapper
+    }
+    type Query {
+      page: Page
+    }
+  `);
+
+  it('finds a field inside a union member', () => {
+    const result = searchSchemaPaths(schema, 'caption');
+
+    expect(result.matchedPaths).toContain('query.page.content.on:Image.caption');
+  });
+
+  it('forces the branch row open so the match is reachable', () => {
+    const result = searchSchemaPaths(schema, 'caption');
+
+    expect(result.forcedOpenPaths.has('query.page.content.on:Image')).toBe(true);
+    expect(result.visiblePaths.has('query.page.content')).toBe(true);
+  });
+
+  it('finds the same field name in every member that declares it', () => {
+    const result = searchSchemaPaths(schema, 'url');
+
+    expect(result.matchedPaths).toContain('query.page.content.on:Image.url');
+    expect(result.matchedPaths).toContain('query.page.content.on:Video.url');
+  });
+
+  it('finds a field an interface implementation adds', () => {
+    const result = searchSchemaPaths(schema, 'body');
+
+    expect(result.matchedPaths).toContain('query.page.node.on:Article.body');
+  });
+
+  it('leaves interface fields on the interface rather than in every branch', () => {
+    const result = searchSchemaPaths(schema, 'id');
+
+    expect(result.matchedPaths).toContain('query.page.node.id');
+    expect(result.matchedPaths).not.toContain('query.page.node.on:Article.id');
+  });
+
+  // Matching runs on field names only. Without that, the `on:Image` segment would
+  // make every field of Image a hit for a search that merely spells the type.
+  it('does not match a field because its branch segment spells the search', () => {
+    const result = searchSchemaPaths(schema, 'image');
+
+    expect(result.matchedPaths).toEqual([]);
+  });
+
+  it('matches a dotted search through a branch', () => {
+    const result = searchSchemaPaths(schema, 'content.caption');
+
+    expect(result.matchedPaths).toContain('query.page.content.on:Image.caption');
+  });
+
+  it('terminates on a recursive union', () => {
+    const result = searchSchemaPaths(schema, 'again');
+
+    expect(result.hasMore).toBe(false);
+    expect(result.matchedPaths.length).toBeGreaterThan(0);
+  });
+});
+
 describe('schema path search index', () => {
   const index = createSchemaPathSearchIndex(['query.user.name', 'query.user.id']);
 

--- a/packages/libraries/laboratory/src/lib/operations.utils.spec.ts
+++ b/packages/libraries/laboratory/src/lib/operations.utils.spec.ts
@@ -1,4 +1,4 @@
-import { buildSchema } from 'graphql';
+import { buildSchema, parse } from 'graphql';
 import {
   addArgToField,
   addPathToQuery,
@@ -165,6 +165,122 @@ describe('addPathToQuery / deletePathFromQuery', () => {
     const result = deletePathFromQuery('query { user { id name } }', 'query.user.name');
     expect(isPathInQuery(result, 'query.user.name')).toBe(false);
     expect(isPathInQuery(result, 'query.user.id')).toBe(true);
+  });
+
+  // The walk is anchored at the operation root, so the same field name at two
+  // depths addresses two different selections.
+  it('does not confuse the same field name at a different depth', () => {
+    const query = 'query { user { name } }';
+
+    expect(isPathInQuery(query, 'query.name')).toBe(false);
+    expect(isPathInQuery(addPathToQuery(query, 'query.name'), 'query.user.name')).toBe(true);
+  });
+});
+
+describe('inline fragments in the document', () => {
+  const IMAGE = 'query.page.content.on:Image.url';
+  const VIDEO = 'query.page.content.on:Video.url';
+
+  it('writes a type condition as an inline fragment and round-trips it', () => {
+    const result = addPathToQuery('', IMAGE);
+
+    expect(result).toContain('... on Image');
+    expect(isPathInQuery(result, IMAGE)).toBe(true);
+    expect(() => parse(result)).not.toThrow();
+  });
+
+  // Both members declare `url`. Without the type condition in the path the two
+  // selections are indistinguishable, which is the whole reason it exists.
+  it('keeps identically named fields in different members apart', () => {
+    const onlyImage = addPathToQuery('', IMAGE);
+
+    expect(isPathInQuery(onlyImage, IMAGE)).toBe(true);
+    expect(isPathInQuery(onlyImage, VIDEO)).toBe(false);
+
+    const both = addPathToQuery(onlyImage, VIDEO);
+
+    expect(isPathInQuery(both, IMAGE)).toBe(true);
+    expect(isPathInQuery(both, VIDEO)).toBe(true);
+    expect(both.match(/\.\.\. on /g)).toHaveLength(2);
+  });
+
+  it('reuses an existing fragment rather than adding a second one', () => {
+    const result = addPathToQuery(addPathToQuery('', IMAGE), 'query.page.content.on:Image.title');
+
+    expect(result.match(/\.\.\. on Image/g)).toHaveLength(1);
+    expect(isPathInQuery(result, IMAGE)).toBe(true);
+    expect(isPathInQuery(result, 'query.page.content.on:Image.title')).toBe(true);
+  });
+
+  // A field appended beside the fragment instead of inside it is invalid on a
+  // union, which is what the old prefix-matching insert produced.
+  it('inserts into a parent whose selections are only fragments', () => {
+    const result = addPathToQuery(addPathToQuery('', IMAGE), VIDEO);
+
+    expect(() => parse(result)).not.toThrow();
+    expect(result).not.toMatch(/\}\s*url/);
+  });
+
+  // An emptied fragment prints as `... on X` with no braces, which is a syntax
+  // error, and every walker swallows a parse failure and stops working.
+  it('removes a fragment left empty by its last field', () => {
+    const both = addPathToQuery(addPathToQuery('', IMAGE), VIDEO);
+    const result = deletePathFromQuery(both, IMAGE);
+
+    expect(() => parse(result)).not.toThrow();
+    expect(result).not.toContain('... on Image');
+    expect(isPathInQuery(result, VIDEO)).toBe(true);
+  });
+
+  it('keeps a fragment that still has other fields', () => {
+    const withBoth = addPathToQuery(addPathToQuery('', IMAGE), 'query.page.content.on:Image.title');
+    const result = deletePathFromQuery(withBoth, IMAGE);
+
+    expect(result).toContain('... on Image');
+    expect(isPathInQuery(result, 'query.page.content.on:Image.title')).toBe(true);
+  });
+
+  it('reports fragment paths so a loaded document expands them', () => {
+    const paths = getOpenPaths('query { page { content { ... on Image { url } } } }');
+
+    expect(paths).toContain('query.page.content');
+    expect(paths).toContain('query.page.content.on:Image');
+    expect(paths).toContain(IMAGE);
+  });
+
+  it('treats a fragment with no type condition as transparent', () => {
+    const query = 'query { page { content { ... @include(if: $x) { url } } } }';
+
+    expect(getOpenPaths(query)).toContain('query.page.content.url');
+    expect(isPathInQuery(query, 'query.page.content.url')).toBe(true);
+  });
+
+  it('leaves a named fragment spread alone', () => {
+    const query = 'query { page { content { ...Fields } } }';
+
+    expect(isPathInQuery(query, 'query.page.content.url')).toBe(false);
+    expect(deletePathFromQuery(query, 'query.page.content.url')).toContain('...Fields');
+    expect(addPathToQuery(query, 'query.page.title')).toContain('...Fields');
+  });
+
+  it('adds and removes an argument on a field inside a fragment', () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Image {
+        url(size: Int): String
+      }
+      union Content = Image
+      type Page {
+        content: [Content!]!
+      }
+      type Query {
+        page: Page
+      }
+    `);
+
+    const withArg = addArgToField(addPathToQuery('', IMAGE), IMAGE, 'size', schema);
+
+    expect(isArgInQuery(withArg, IMAGE, 'size')).toBe(true);
+    expect(isArgInQuery(removeArgFromField(withArg, IMAGE, 'size'), IMAGE, 'size')).toBe(false);
   });
 });
 

--- a/packages/libraries/laboratory/src/lib/operations.utils.ts
+++ b/packages/libraries/laboratory/src/lib/operations.utils.ts
@@ -7,6 +7,7 @@ import {
   GraphQLScalarType,
   GraphQLSchema,
   GraphQLUnionType,
+  isAbstractType,
   Kind,
   OperationTypeNode,
   parse,
@@ -165,6 +166,34 @@ function descendSelections(
   return steps;
 }
 
+/**
+ * An abstract field selects nothing on its own, so a selection set holding only
+ * `__typename` is the smallest valid thing the builder can write for one. Seeding
+ * it on the way in means the document is never momentarily invalid, and it is
+ * what keeps the set non-empty as branches come and go.
+ */
+const ensureTypename = (node: FieldNode | InlineFragmentNode) => {
+  if (!node.selectionSet) {
+    (node as { selectionSet: SelectionSetNode }).selectionSet = {
+      kind: Kind.SELECTION_SET,
+      selections: [],
+    };
+  }
+
+  const selectionSet = node.selectionSet as SelectionSetNode;
+
+  const hasTypename = selectionSet.selections.some(
+    selection => selection.kind === Kind.FIELD && selection.name.value === '__typename',
+  );
+
+  if (!hasTypename) {
+    asSelections(selectionSet).unshift({
+      kind: Kind.FIELD,
+      name: { kind: Kind.NAME, value: '__typename' },
+    });
+  }
+};
+
 const removeSelection = (parent: SelectionSetNode, node: SelectionNode) => {
   (parent as { selections: readonly SelectionNode[] }).selections = parent.selections.filter(
     selection => selection !== node,
@@ -215,7 +244,12 @@ export function isPathInQuery(query: string, path: string, operationName?: strin
   return descendSelections(operationDefinition, segments) !== null;
 }
 
-export function addPathToQuery(query: string, path: string, operationName?: string | null) {
+export function addPathToQuery(
+  query: string,
+  path: string,
+  operationName?: string | null,
+  schema?: GraphQLSchema,
+) {
   query = healQuery(query);
 
   const [operation, ...parts] = path.split('.') as [OperationTypeNode, ...string[]];
@@ -288,7 +322,18 @@ export function addPathToQuery(query: string, path: string, operationName?: stri
       .join('\n');
   }
 
-  descendSelections(operationDefinition, parts, true);
+  const steps = descendSelections(operationDefinition, parts, true);
+  const schemaSteps = schema ? resolveSchemaPath(path, schema) : null;
+
+  if (steps && schemaSteps) {
+    // A type-condition step resolves to its concrete member, so `__typename`
+    // lands on the abstract parent rather than inside each branch.
+    steps.forEach((step, i) => {
+      if (schemaSteps[i] && isAbstractType(schemaSteps[i].type)) {
+        ensureTypename(step.node);
+      }
+    });
+  }
 
   return print(doc);
 }
@@ -540,7 +585,7 @@ export function addArgToField(
   query = print(doc);
 
   if (!isPathInQuery(query, path, operationName)) {
-    doc = parse(addPathToQuery(query, path, operationName));
+    doc = parse(addPathToQuery(query, path, operationName, schema));
 
     operationDefinition = doc.definitions.find(v => {
       if (v.kind === Kind.OPERATION_DEFINITION && v.operation === operation) {

--- a/packages/libraries/laboratory/src/lib/operations.utils.ts
+++ b/packages/libraries/laboratory/src/lib/operations.utils.ts
@@ -11,24 +11,165 @@ import {
   OperationTypeNode,
   parse,
   print,
-  visit,
+  type ArgumentNode,
   type DefinitionNode,
   type DocumentNode,
   type FieldNode,
   type GraphQLField,
   type GraphQLNamedType,
   type GraphQLOutputType,
+  type InlineFragmentNode,
   type OperationDefinitionNode,
   type SelectionNode,
+  type SelectionSetNode,
   type VariableDefinitionNode,
 } from 'graphql';
 import { get } from 'lodash';
 import type { LaboratoryOperation } from './operations';
-import { resolveSchemaPath } from './schema-path';
+import {
+  decodeTypeConditionSegment,
+  encodeTypeConditionSegment,
+  resolveSchemaPath,
+} from './schema-path';
 
 export function healQuery(query: string) {
   return query.replace(/\{(\s+)?\}/g, '');
 }
+
+const createSelection = (segment: string): FieldNode | InlineFragmentNode => {
+  const typeName = decodeTypeConditionSegment(segment);
+
+  if (typeName === null) {
+    return { kind: Kind.FIELD, name: { kind: Kind.NAME, value: segment } };
+  }
+
+  return {
+    kind: Kind.INLINE_FRAGMENT,
+    typeCondition: { kind: Kind.NAMED_TYPE, name: { kind: Kind.NAME, value: typeName } },
+    // An inline fragment with no selections prints as `... on X`, with no braces,
+    // which does not parse. Every walker swallows a parse failure and no-ops, so
+    // one of these would freeze the whole builder.
+    selectionSet: { kind: Kind.SELECTION_SET, selections: [] },
+  };
+};
+
+type SelectionStep = { parent: SelectionSetNode; node: FieldNode | InlineFragmentNode };
+
+/**
+ * Finds the selection one segment addresses, along with the selection set that
+ * actually holds it, which is what a later removal has to filter.
+ */
+const locateSelection = (
+  selectionSet: SelectionSetNode,
+  segment: string,
+): SelectionStep | undefined => {
+  const typeName = decodeTypeConditionSegment(segment);
+
+  for (const selection of selectionSet.selections) {
+    if (typeName === null) {
+      if (selection.kind === Kind.FIELD && selection.name.value === segment) {
+        return { parent: selectionSet, node: selection };
+      }
+    } else if (
+      selection.kind === Kind.INLINE_FRAGMENT &&
+      selection.typeCondition?.name.value === typeName
+    ) {
+      return { parent: selectionSet, node: selection };
+    }
+  }
+
+  // Only after a direct match fails: a fragment with no type condition is not a
+  // level of its own, so what it holds is addressable at this same path.
+  for (const selection of selectionSet.selections) {
+    if (selection.kind === Kind.INLINE_FRAGMENT && !selection.typeCondition) {
+      const found = locateSelection(selection.selectionSet, segment);
+
+      if (found) {
+        return found;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const asSelections = (selectionSet: SelectionSetNode) => selectionSet.selections as SelectionNode[];
+
+/**
+ * Walks a path's segments down an operation's selections, one step per segment.
+ *
+ * Anchored at the operation root rather than matching a field name wherever it
+ * turns up, so the same name at two depths cannot be confused, and a type
+ * condition is a step of its own rather than something to see through. With
+ * `create`, missing nodes are added on the way down.
+ */
+function descendSelections(
+  operationDefinition: OperationDefinitionNode,
+  segments: string[],
+  create = false,
+): SelectionStep[] | null {
+  if (segments.length === 0) {
+    return null;
+  }
+
+  if (!operationDefinition.selectionSet) {
+    if (!create) {
+      return null;
+    }
+
+    (operationDefinition as { selectionSet: SelectionSetNode }).selectionSet = {
+      kind: Kind.SELECTION_SET,
+      selections: [],
+    };
+  }
+
+  let parent = operationDefinition.selectionSet;
+  const steps: SelectionStep[] = [];
+
+  for (let i = 0; i < segments.length; ++i) {
+    let step = locateSelection(parent, segments[i]);
+
+    if (!step) {
+      if (!create) {
+        return null;
+      }
+
+      const created = createSelection(segments[i]);
+
+      asSelections(parent).push(created);
+      step = { parent, node: created };
+    }
+
+    const { node } = step;
+
+    steps.push(step);
+
+    if (i === segments.length - 1) {
+      break;
+    }
+
+    if (!node.selectionSet) {
+      if (!create) {
+        return null;
+      }
+
+      (node as { selectionSet: SelectionSetNode }).selectionSet = {
+        kind: Kind.SELECTION_SET,
+        selections: [],
+      };
+    }
+
+    parent = node.selectionSet as SelectionSetNode;
+  }
+
+  return steps;
+}
+
+const removeSelection = (parent: SelectionSetNode, node: SelectionNode) => {
+  (parent as { selections: readonly SelectionNode[] }).selections = parent.selections.filter(
+    selection => selection !== node,
+  );
+};
 
 export function isPathInQuery(query: string, path: string, operationName?: string | null) {
   if (!query || !path) {
@@ -71,30 +212,7 @@ export function isPathInQuery(query: string, path: string, operationName?: strin
     return true;
   }
 
-  const currentPath: string[] = [];
-
-  let found = false;
-
-  visit(operationDefinition, {
-    Field: {
-      enter(field) {
-        currentPath.push(field.name.value);
-
-        if (
-          currentPath.length === segments.length &&
-          currentPath.every((v, i) => v === segments[i])
-        ) {
-          found = true;
-          return false;
-        }
-      },
-      leave() {
-        currentPath.pop();
-      },
-    },
-  });
-
-  return found;
+  return descendSelections(operationDefinition, segments) !== null;
 }
 
 export function addPathToQuery(query: string, path: string, operationName?: string | null) {
@@ -170,75 +288,7 @@ export function addPathToQuery(query: string, path: string, operationName?: stri
       .join('\n');
   }
 
-  const currentPath: string[] = [];
-
-  visit(operationDefinition, {
-    OperationDefinition: {
-      enter(operationDefinition) {
-        const fieldName = parts[0];
-
-        // @ts-expect-error temp
-        operationDefinition.selectionSet ??= {
-          kind: Kind.SELECTION_SET,
-          selections: [],
-        };
-
-        let fieldNode: FieldNode = operationDefinition.selectionSet.selections.find(v => {
-          return v.kind === Kind.FIELD && v.name.value === fieldName;
-        }) as FieldNode;
-
-        if (!fieldNode) {
-          fieldNode = {
-            kind: Kind.FIELD,
-            name: {
-              kind: Kind.NAME,
-              value: fieldName,
-            },
-          };
-
-          (operationDefinition.selectionSet.selections as SelectionNode[]).push(fieldNode);
-        }
-      },
-    },
-    Field: {
-      enter(field) {
-        currentPath.push(field.name.value);
-
-        if (currentPath.every((v, i) => v === parts[i])) {
-          if (currentPath.length === parts.length) {
-            return false;
-          }
-
-          const fieldName = parts[currentPath.length];
-
-          // @ts-expect-error temp
-          field.selectionSet ??= {
-            kind: Kind.SELECTION_SET,
-            selections: [],
-          };
-
-          let fieldNode: FieldNode = field.selectionSet!.selections.find(v => {
-            return v.kind === Kind.FIELD && v.name.value === fieldName;
-          }) as FieldNode;
-
-          if (!fieldNode) {
-            fieldNode = {
-              kind: Kind.FIELD,
-              name: {
-                kind: Kind.NAME,
-                value: fieldName,
-              },
-            };
-
-            (field.selectionSet!.selections as SelectionNode[]).push(fieldNode);
-          }
-        }
-      },
-      leave() {
-        currentPath.pop();
-      },
-    },
-  });
+  descendSelections(operationDefinition, parts, true);
 
   return print(doc);
 }
@@ -276,48 +326,28 @@ export function deletePathFromQuery(query: string, path: string, operationName?:
     return query;
   }
 
-  const currentPath: string[] = [];
-  let isOperationSelectionSetEmpty = false;
+  const steps = descendSelections(operationDefinition, segments);
 
-  visit(operationDefinition, {
-    OperationDefinition: {
-      enter(operationDefinition) {
-        if (segments.length === 1) {
-          const fieldName = segments[0];
+  if (steps) {
+    const last = steps[steps.length - 1];
 
-          if (operationDefinition.selectionSet) {
-            operationDefinition.selectionSet.selections =
-              operationDefinition.selectionSet.selections.filter(v => {
-                return v.kind !== Kind.FIELD || v.name.value !== fieldName;
-              });
+    removeSelection(last.parent, last.node);
 
-            isOperationSelectionSetEmpty = operationDefinition.selectionSet.selections.length === 0;
-          }
-        }
-      },
-    },
-    Field: {
-      enter(field) {
-        currentPath.push(field.name.value);
+    // An inline fragment left holding nothing prints as `... on X`, with no
+    // braces, which does not parse. Prune from the inside out, stopping at the
+    // first ancestor that still has selections of its own.
+    for (let i = steps.length - 2; i >= 0; --i) {
+      const { parent, node } = steps[i];
 
-        if (
-          currentPath.length === segments.length - 1 &&
-          currentPath.every((v, i) => v === segments[i])
-        ) {
-          const fieldName = segments[currentPath.length];
+      if (node.kind !== Kind.INLINE_FRAGMENT || node.selectionSet.selections.length > 0) {
+        break;
+      }
 
-          if (field.selectionSet) {
-            field.selectionSet.selections = field.selectionSet.selections.filter(v => {
-              return v.kind !== Kind.FIELD || v.name.value !== fieldName;
-            });
-          }
-        }
-      },
-      leave() {
-        currentPath.pop();
-      },
-    },
-  });
+      removeSelection(parent, node);
+    }
+  }
+
+  const isOperationSelectionSetEmpty = operationDefinition.selectionSet?.selections.length === 0;
 
   if (isOperationSelectionSetEmpty) {
     if (doc.definitions.length > 1) {
@@ -432,30 +462,13 @@ export function isArgInQuery(
     return false;
   }
 
-  const currentPath: string[] = [];
+  const node = descendSelections(operationDefinition, segments)?.at(-1)?.node;
 
-  let found = false;
+  if (node?.kind !== Kind.FIELD) {
+    return false;
+  }
 
-  visit(operationDefinition, {
-    Field: {
-      enter(field) {
-        currentPath.push(field.name.value);
-
-        if (
-          currentPath.length === segments.length &&
-          currentPath.every((v, i) => v === segments[i]) &&
-          field.arguments
-        ) {
-          found = field.arguments.some(v => v.name.value === argName);
-        }
-      },
-      leave() {
-        currentPath.pop();
-      },
-    },
-  });
-
-  return found;
+  return node.arguments?.some(v => v.name.value === argName) ?? false;
 }
 
 export function addArgToField(
@@ -542,175 +555,37 @@ export function addArgToField(
     }) as OperationDefinitionNode;
   }
 
-  const currentPath: string[] = [];
+  const fieldNode = descendSelections(operationDefinition, segments)?.at(-1)?.node;
+  const arg = getFieldByPath(path, schema)?.args.find(v => v.name === argName);
 
-  visit(operationDefinition, {
-    Field: {
-      enter(field) {
-        currentPath.push(field.name.value);
+  if (fieldNode?.kind !== Kind.FIELD || !arg) {
+    return print(doc);
+  }
 
-        if (
-          currentPath.length === segments.length - 1 &&
-          currentPath.every((v, i) => v === segments[i])
-        ) {
-          const fieldName = segments[currentPath.length];
+  const variableDefinitions = ((
+    operationDefinition as { variableDefinitions?: unknown }
+  ).variableDefinitions ||= []) as VariableDefinitionNode[];
 
-          if (field.selectionSet) {
-            const typeField = getFieldByPath(
-              [operation, ...currentPath, fieldName].join('.'),
-              schema,
-            );
+  let variableName = arg.name;
+  let i = 2;
 
-            if (typeField?.args) {
-              const arg = typeField.args.find(v => v.name === argName);
+  while (variableDefinitions.find(v => v.variable.name.value === variableName)) {
+    variableName = arg.name + i;
+    ++i;
+  }
 
-              if (arg) {
-                // @ts-expect-error temp
-                operationDefinition.variableDefinitions ||= [];
+  variableDefinitions.push({
+    kind: Kind.VARIABLE_DEFINITION,
+    variable: { kind: Kind.VARIABLE, name: { kind: Kind.NAME, value: variableName } },
+    type: { kind: Kind.NAMED_TYPE, name: { kind: Kind.NAME, value: arg.type.toString() } },
+  });
 
-                let variableName = arg.name;
+  const args = ((fieldNode as { arguments?: unknown }).arguments ||= []) as ArgumentNode[];
 
-                let i = 2;
-
-                while (
-                  (operationDefinition.variableDefinitions as VariableDefinitionNode[]).find(
-                    v => v.variable.name.value === variableName,
-                  )
-                ) {
-                  variableName = arg.name + i;
-                  ++i;
-                }
-
-                (operationDefinition.variableDefinitions as VariableDefinitionNode[]).push({
-                  kind: Kind.VARIABLE_DEFINITION,
-                  variable: {
-                    kind: Kind.VARIABLE,
-                    name: {
-                      kind: Kind.NAME,
-                      value: variableName,
-                    },
-                  },
-                  type: {
-                    kind: Kind.NAMED_TYPE,
-                    name: {
-                      kind: Kind.NAME,
-                      value: arg.type.toString(),
-                    },
-                  },
-                });
-
-                const fieldNode: FieldNode = field.selectionSet.selections.find(v => {
-                  return v.kind === Kind.FIELD && v.name.value === fieldName;
-                }) as FieldNode;
-
-                if (fieldNode) {
-                  // @ts-expect-error temp
-                  fieldNode.arguments ||= [];
-
-                  // @ts-expect-error temp
-                  fieldNode.arguments.push({
-                    kind: Kind.ARGUMENT,
-                    name: {
-                      kind: Kind.NAME,
-                      value: argName,
-                    },
-                    value: {
-                      kind: Kind.VARIABLE,
-                      name: {
-                        kind: Kind.NAME,
-                        value: variableName,
-                      },
-                    },
-                  });
-                }
-              }
-            }
-          }
-        }
-      },
-      leave() {
-        currentPath.pop();
-      },
-    },
-    OperationDefinition: {
-      enter(operationDefinition) {
-        if (segments.length === 1) {
-          const fieldName = segments[0];
-
-          if (operationDefinition.selectionSet) {
-            const typeField = getFieldByPath(
-              [operation, ...currentPath, fieldName].join('.'),
-              schema,
-            );
-
-            if (typeField?.args) {
-              const arg = typeField.args.find(v => v.name === argName);
-
-              if (arg) {
-                // @ts-expect-error temp
-                operationDefinition.variableDefinitions ||= [];
-
-                let variableName = arg.name;
-
-                let i = 2;
-
-                while (
-                  (operationDefinition.variableDefinitions as VariableDefinitionNode[]).find(
-                    v => v.variable.name.value === variableName,
-                  )
-                ) {
-                  variableName = arg.name + i;
-                  ++i;
-                }
-
-                (operationDefinition.variableDefinitions as VariableDefinitionNode[]).push({
-                  kind: Kind.VARIABLE_DEFINITION,
-                  variable: {
-                    kind: Kind.VARIABLE,
-                    name: {
-                      kind: Kind.NAME,
-                      value: variableName,
-                    },
-                  },
-                  type: {
-                    kind: Kind.NAMED_TYPE,
-                    name: {
-                      kind: Kind.NAME,
-                      value: arg.type.toString(),
-                    },
-                  },
-                });
-
-                const fieldNode: FieldNode = operationDefinition.selectionSet.selections.find(v => {
-                  return v.kind === Kind.FIELD && v.name.value === fieldName;
-                }) as FieldNode;
-
-                if (fieldNode) {
-                  // @ts-expect-error temp
-                  fieldNode.arguments ||= [];
-
-                  // @ts-expect-error temp
-                  fieldNode.arguments.push({
-                    kind: Kind.ARGUMENT,
-                    name: {
-                      kind: Kind.NAME,
-                      value: argName,
-                    },
-                    value: {
-                      kind: Kind.VARIABLE,
-                      name: {
-                        kind: Kind.NAME,
-                        value: variableName,
-                      },
-                    },
-                  });
-                }
-              }
-            }
-          }
-        }
-      },
-    },
+  args.push({
+    kind: Kind.ARGUMENT,
+    name: { kind: Kind.NAME, value: argName },
+    value: { kind: Kind.VARIABLE, name: { kind: Kind.NAME, value: variableName } },
   });
 
   return print(doc);
@@ -754,58 +629,13 @@ export function removeArgFromField(
     return query;
   }
 
-  const currentPath: string[] = [];
+  const fieldNode = descendSelections(operationDefinition, segments)?.at(-1)?.node;
 
-  visit(operationDefinition, {
-    Field: {
-      enter(field) {
-        currentPath.push(field.name.value);
-
-        if (
-          currentPath.length === segments.length - 1 &&
-          currentPath.every((v, i) => v === segments[i])
-        ) {
-          const fieldName = segments[currentPath.length];
-
-          if (field.selectionSet) {
-            const fieldNode: FieldNode = field.selectionSet.selections.find(v => {
-              return v.kind === Kind.FIELD && v.name.value === fieldName;
-            }) as FieldNode;
-
-            if (fieldNode?.arguments) {
-              // @ts-expect-error temp
-              fieldNode.arguments = fieldNode.arguments.filter(v => {
-                return v.kind !== Kind.ARGUMENT || v.name.value !== argName;
-              });
-            }
-          }
-        }
-      },
-      leave() {
-        currentPath.pop();
-      },
-    },
-    OperationDefinition: {
-      enter(operationDefinition) {
-        if (segments.length === 1) {
-          const fieldName = segments[0];
-
-          if (operationDefinition.selectionSet) {
-            const fieldNode: FieldNode = operationDefinition.selectionSet.selections.find(v => {
-              return v.kind === Kind.FIELD && v.name.value === fieldName;
-            }) as FieldNode;
-
-            if (fieldNode?.arguments) {
-              // @ts-expect-error temp
-              fieldNode.arguments = fieldNode.arguments.filter(v => {
-                return v.kind !== Kind.ARGUMENT || v.name.value !== argName;
-              });
-            }
-          }
-        }
-      },
-    },
-  });
+  if (fieldNode?.kind === Kind.FIELD && fieldNode.arguments) {
+    (fieldNode as { arguments: readonly ArgumentNode[] }).arguments = fieldNode.arguments.filter(
+      v => v.name.value !== argName,
+    );
+  }
 
   return print(doc);
 }
@@ -823,13 +653,29 @@ export function extractPaths(query: string): string[][] {
 
     const traverse = (selections: readonly SelectionNode[], currentPath: string[] = []) => {
       for (const selection of selections) {
-        if (selection.kind === 'Field') {
+        if (selection.kind === Kind.FIELD) {
           const newPath = [...currentPath, selection.name.value];
           paths.push(newPath);
 
           if (selection.selectionSet) {
             traverse(selection.selectionSet.selections, newPath);
           }
+
+          continue;
+        }
+
+        if (selection.kind === Kind.INLINE_FRAGMENT) {
+          // A fragment with no type condition adds no level, so its fields stay
+          // addressable at the parent's path.
+          const newPath = selection.typeCondition
+            ? [...currentPath, encodeTypeConditionSegment(selection.typeCondition.name.value)]
+            : currentPath;
+
+          if (selection.typeCondition) {
+            paths.push(newPath);
+          }
+
+          traverse(selection.selectionSet.selections, newPath);
         }
       }
     };

--- a/packages/libraries/laboratory/src/lib/operations.utils.ts
+++ b/packages/libraries/laboratory/src/lib/operations.utils.ts
@@ -18,14 +18,13 @@ import {
   type GraphQLField,
   type GraphQLNamedType,
   type GraphQLOutputType,
-  type GraphQLType,
   type OperationDefinitionNode,
   type SelectionNode,
   type VariableDefinitionNode,
 } from 'graphql';
-import type { Maybe } from 'graphql/jsutils/Maybe';
 import { get } from 'lodash';
 import type { LaboratoryOperation } from './operations';
+import { resolveSchemaPath } from './schema-path';
 
 export function healQuery(query: string) {
   return query.replace(/\{(\s+)?\}/g, '');
@@ -459,72 +458,6 @@ export function isArgInQuery(
   return found;
 }
 
-export function extractOfType(
-  type: GraphQLOutputType,
-): GraphQLObjectType | GraphQLScalarType | null {
-  if (type instanceof GraphQLNonNull) {
-    return extractOfType(type.ofType);
-  }
-
-  if (type instanceof GraphQLNonNull) {
-    return extractOfType(type.ofType);
-  }
-
-  if (type instanceof GraphQLList) {
-    return extractOfType(type.ofType);
-  }
-
-  if (type instanceof GraphQLObjectType) {
-    return type;
-  }
-
-  if (type instanceof GraphQLScalarType) {
-    return type;
-  }
-
-  return null;
-}
-
-export function findFieldInSchema(path: string, schema: GraphQLSchema) {
-  const [operation, ...segments] = path.split('.') as [OperationTypeNode, ...string[]];
-
-  let type: Maybe<GraphQLType>;
-
-  if (operation === 'query') {
-    type = schema.getQueryType();
-  } else if (operation === 'mutation') {
-    type = schema.getMutationType();
-  } else if (operation === 'subscription') {
-    type = schema.getSubscriptionType();
-  }
-
-  if (!type) {
-    return;
-  }
-
-  for (let i = 0; i < segments.length; ++i) {
-    if (!type) {
-      return;
-    }
-
-    if (type instanceof GraphQLObjectType) {
-      const field = type.getFields()[segments[i]] as GraphQLField<unknown, unknown, unknown>;
-
-      if (!field) {
-        return;
-      }
-
-      if (i === segments.length - 1) {
-        return field;
-      }
-
-      type = extractOfType(field.type);
-    }
-  }
-
-  return null;
-}
-
 export function addArgToField(
   query: string,
   path: string,
@@ -623,7 +556,7 @@ export function addArgToField(
           const fieldName = segments[currentPath.length];
 
           if (field.selectionSet) {
-            const typeField = findFieldInSchema(
+            const typeField = getFieldByPath(
               [operation, ...currentPath, fieldName].join('.'),
               schema,
             );
@@ -705,7 +638,7 @@ export function addArgToField(
           const fieldName = segments[0];
 
           if (operationDefinition.selectionSet) {
-            const typeField = findFieldInSchema(
+            const typeField = getFieldByPath(
               [operation, ...currentPath, fieldName].join('.'),
               schema,
             );
@@ -1336,36 +1269,27 @@ export function handleTemplate(query: string, env: Record<string, any>) {
   });
 }
 
+/**
+ * The field a path names, or null if the path does not resolve.
+ *
+ * A path ending in a type condition names no field of its own, so the nearest
+ * enclosing field is returned instead: that is the abstract field the branch
+ * narrows, which is what a caller holding such a path is asking about.
+ */
 export function getFieldByPath(path: string, schema: GraphQLSchema) {
-  const [operation, ...segments] = path.split('.') as [OperationTypeNode, ...string[]];
+  const steps = resolveSchemaPath(path, schema);
 
-  let type: Maybe<GraphQLType>;
-
-  if (operation === 'query') {
-    type = schema.getQueryType();
-  } else if (operation === 'mutation') {
-    type = schema.getMutationType();
-  } else if (operation === 'subscription') {
-    type = schema.getSubscriptionType();
-  }
-
-  if (!type) {
+  if (!steps) {
     return null;
   }
 
-  let field: Maybe<GraphQLField<unknown, unknown, unknown>>;
+  for (let i = steps.length - 1; i >= 0; --i) {
+    const { field } = steps[i];
 
-  for (const segment of segments) {
-    if (type instanceof GraphQLObjectType) {
-      field = type.getFields()[segment] as GraphQLField<unknown, unknown, unknown>;
-
-      if (!field) {
-        return null;
-      }
-
-      type = field.type;
+    if (field) {
+      return field;
     }
   }
 
-  return field;
+  return null;
 }

--- a/packages/libraries/laboratory/src/lib/operations.utils.ts
+++ b/packages/libraries/laboratory/src/lib/operations.utils.ts
@@ -8,6 +8,9 @@ import {
   GraphQLSchema,
   GraphQLUnionType,
   isAbstractType,
+  isInterfaceType,
+  isObjectType,
+  isUnionType,
   Kind,
   OperationTypeNode,
   parse,
@@ -1058,7 +1061,13 @@ export function searchSchemaPaths(
   type Frame = {
     operation: OperationTypeNode;
     field: GraphQLField<unknown, unknown, unknown>;
+    /** Full path, which may carry `on:Type` segments. */
     pathSegments: string[];
+    /**
+     * Field names only. Matching runs against these so a search for "on" or for a
+     * type's own name cannot hit every field inside a branch by way of the sigil.
+     */
+    fieldSegments: string[];
     typeTrail: string[];
     depth: number;
   };
@@ -1087,6 +1096,7 @@ export function searchSchemaPaths(
         operation,
         field: rootField,
         pathSegments: [rootField.name],
+        fieldSegments: [rootField.name],
         typeTrail: [rootType.name],
         depth: 1,
       });
@@ -1106,9 +1116,9 @@ export function searchSchemaPaths(
     ++nodesVisited;
 
     const path = `${frame.operation}.${frame.pathSegments.join('.')}`;
-    const pathSegmentsLower = frame.pathSegments.map(segment => segment.toLowerCase());
+    const fieldSegmentsLower = frame.fieldSegments.map(segment => segment.toLowerCase());
 
-    if (matchSearchAgainstPath(pathSegmentsLower, normalizedSearch, searchSegments)) {
+    if (matchSearchAgainstPath(fieldSegmentsLower, normalizedSearch, searchSegments)) {
       matchedPaths.push(path);
       visiblePaths.add(path);
 
@@ -1128,20 +1138,60 @@ export function searchSchemaPaths(
 
     const namedType = unwrapNamedType(frame.field.type);
 
-    if (!isSearchableFieldType(namedType) || frame.typeTrail.includes(namedType.name)) {
+    if (frame.typeTrail.includes(namedType.name)) {
       continue;
     }
 
     const nextTrail = [...frame.typeTrail, namedType.name];
 
-    for (const childField of Object.values(namedType.getFields())) {
+    const enqueue = (
+      childField: GraphQLField<unknown, unknown, unknown>,
+      branch: GraphQLObjectType | null,
+      typeTrail: string[],
+    ) => {
       queue.push({
         operation: frame.operation,
         field: childField,
-        pathSegments: [...frame.pathSegments, childField.name],
-        typeTrail: nextTrail,
+        pathSegments: branch
+          ? [...frame.pathSegments, encodeTypeConditionSegment(branch.name), childField.name]
+          : [...frame.pathSegments, childField.name],
+        fieldSegments: [...frame.fieldSegments, childField.name],
+        typeTrail,
         depth: frame.depth + 1,
       });
+    };
+
+    if (isObjectType(namedType) || isInterfaceType(namedType)) {
+      for (const childField of Object.values(namedType.getFields())) {
+        enqueue(childField, null, nextTrail);
+      }
+    }
+
+    // A type condition is a branch, not a schema level, so reaching a member field
+    // costs the same depth budget as reaching a field of an object type would.
+    const possibleTypes = isUnionType(namedType)
+      ? namedType.getTypes()
+      : isInterfaceType(namedType)
+        ? schema.getPossibleTypes(namedType)
+        : [];
+
+    // The rows above already carry what the interface itself declares.
+    const inherited = isInterfaceType(namedType)
+      ? new Set(Object.keys(namedType.getFields()))
+      : null;
+
+    for (const possibleType of possibleTypes) {
+      if (frame.typeTrail.includes(possibleType.name)) {
+        continue;
+      }
+
+      const branchTrail = [...nextTrail, possibleType.name];
+
+      for (const childField of Object.values(possibleType.getFields())) {
+        if (!inherited?.has(childField.name)) {
+          enqueue(childField, possibleType, branchTrail);
+        }
+      }
     }
   }
 

--- a/packages/libraries/laboratory/src/lib/schema-path.spec.ts
+++ b/packages/libraries/laboratory/src/lib/schema-path.spec.ts
@@ -1,0 +1,125 @@
+import { buildSchema } from 'graphql';
+import {
+  decodeTypeConditionSegment,
+  encodeTypeConditionSegment,
+  isTypeConditionSegment,
+  parseSchemaPath,
+  resolveSchemaPath,
+  toFieldSegments,
+} from './schema-path';
+
+const schema = buildSchema(/* GraphQL */ `
+  type Image {
+    url: String
+    title: String
+  }
+  type Video {
+    url: String
+    duration: Int
+  }
+  union CmsContent = Image | Video
+  interface Node {
+    id: ID!
+    name: String
+  }
+  type Page implements Node {
+    id: ID!
+    name: String
+    content: [CmsContent!]!
+    slug: String
+  }
+  type Article implements Node {
+    id: ID!
+    name: String
+    body: String
+  }
+  type Query {
+    categoryPage: Page
+    node: Node
+  }
+`);
+
+describe('type condition segments', () => {
+  it('round-trips a type name', () => {
+    expect(decodeTypeConditionSegment(encodeTypeConditionSegment('Image'))).toBe('Image');
+  });
+
+  it('reads an ordinary field name as a field', () => {
+    expect(decodeTypeConditionSegment('content')).toBeNull();
+    expect(isTypeConditionSegment('content')).toBe(false);
+  });
+
+  // Every path consumer splits on '.', and the ancestry helpers slice at every
+  // dot, so a sigil containing one would shatter into empty segments.
+  it('encodes without a dot', () => {
+    expect(encodeTypeConditionSegment('Image')).not.toContain('.');
+  });
+
+  it('treats a bare prefix as a field rather than an unnamed condition', () => {
+    expect(decodeTypeConditionSegment('on:')).toBeNull();
+  });
+});
+
+describe('parseSchemaPath', () => {
+  it('separates field segments from type conditions', () => {
+    const { operation, segments } = parseSchemaPath('query.categoryPage.content.on:Image.url');
+
+    expect(operation).toBe('query');
+    expect(segments).toEqual([
+      { kind: 'field', name: 'categoryPage' },
+      { kind: 'field', name: 'content' },
+      { kind: 'typeCondition', typeName: 'Image' },
+      { kind: 'field', name: 'url' },
+    ]);
+  });
+
+  it('rejects a path that does not start at an operation root', () => {
+    expect(parseSchemaPath('categoryPage.content').operation).toBeNull();
+  });
+
+  it('projects to field names only', () => {
+    const { segments } = parseSchemaPath('query.categoryPage.content.on:Image.url');
+
+    expect(toFieldSegments(segments)).toEqual(['categoryPage', 'content', 'url']);
+  });
+});
+
+describe('resolveSchemaPath', () => {
+  it('walks into a union member', () => {
+    const steps = resolveSchemaPath('query.categoryPage.content.on:Image.url', schema);
+
+    expect(steps?.map(step => step.parentType.name)).toEqual([
+      'Query',
+      'Page',
+      'CmsContent',
+      'Image',
+    ]);
+    expect(steps?.at(-1)?.field?.name).toBe('url');
+  });
+
+  it('walks into an interface implementation', () => {
+    const steps = resolveSchemaPath('query.node.on:Article.body', schema);
+
+    expect(steps?.at(-1)?.field?.name).toBe('body');
+  });
+
+  it('unwraps list and non-null wrappers between segments', () => {
+    const steps = resolveSchemaPath('query.categoryPage.content', schema);
+
+    expect(steps?.at(-1)?.type.name).toBe('CmsContent');
+  });
+
+  it('rejects a type that is not a member of the abstract type', () => {
+    expect(resolveSchemaPath('query.node.on:Image.url', schema)).toBeNull();
+  });
+
+  it('rejects a field the type does not have', () => {
+    expect(resolveSchemaPath('query.categoryPage.nope', schema)).toBeNull();
+  });
+
+  // A partial walk would let a caller mistake the last type it resolved for the
+  // one the path named.
+  it('returns null rather than a partial walk', () => {
+    expect(resolveSchemaPath('query.categoryPage.content.url', schema)).toBeNull();
+  });
+});

--- a/packages/libraries/laboratory/src/lib/schema-path.ts
+++ b/packages/libraries/laboratory/src/lib/schema-path.ts
@@ -1,0 +1,171 @@
+import {
+  getNamedType,
+  isInterfaceType,
+  isObjectType,
+  isUnionType,
+  OperationTypeNode,
+  type GraphQLField,
+  type GraphQLInterfaceType,
+  type GraphQLNamedType,
+  type GraphQLObjectType,
+  type GraphQLSchema,
+  type GraphQLUnionType,
+} from 'graphql';
+
+/**
+ * Builder rows address a schema location by a dotted path from an operation root
+ * (`query.me.id`). A field inside an inline fragment needs the type condition in
+ * that path too, or two possible types that share a field name are the same path.
+ *
+ * A colon cannot appear in a GraphQL Name, so an encoded segment can never collide
+ * with a field, and it carries no dot, so the callers that derive ancestry by
+ * slicing at every dot keep treating it as one ordinary level.
+ */
+const TYPE_CONDITION_PREFIX = 'on:';
+
+export type SchemaPathSegment =
+  | { kind: 'field'; name: string }
+  | { kind: 'typeCondition'; typeName: string };
+
+/** A type a path can be positioned on and still have somewhere to go. */
+export type SchemaPathParentType = GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType;
+
+export type SchemaPathStep = {
+  segment: SchemaPathSegment;
+  /** The type the segment was resolved against. */
+  parentType: SchemaPathParentType;
+  /** null on a type-condition step, which narrows rather than selects. */
+  field: GraphQLField<unknown, unknown> | null;
+  /** The named type the path sits on after this step. */
+  type: GraphQLNamedType;
+};
+
+export function encodeTypeConditionSegment(typeName: string): string {
+  return `${TYPE_CONDITION_PREFIX}${typeName}`;
+}
+
+/** Returns the type name, or null when the segment is an ordinary field. */
+export function decodeTypeConditionSegment(segment: string): string | null {
+  if (!segment.startsWith(TYPE_CONDITION_PREFIX)) {
+    return null;
+  }
+
+  return segment.slice(TYPE_CONDITION_PREFIX.length) || null;
+}
+
+export function isTypeConditionSegment(segment: string): boolean {
+  return decodeTypeConditionSegment(segment) !== null;
+}
+
+const toSegment = (segment: string): SchemaPathSegment => {
+  const typeName = decodeTypeConditionSegment(segment);
+
+  return typeName === null ? { kind: 'field', name: segment } : { kind: 'typeCondition', typeName };
+};
+
+const toOperation = (segment: string | undefined): OperationTypeNode | null => {
+  switch (segment) {
+    case 'query':
+      return OperationTypeNode.QUERY;
+    case 'mutation':
+      return OperationTypeNode.MUTATION;
+    case 'subscription':
+      return OperationTypeNode.SUBSCRIPTION;
+    default:
+      return null;
+  }
+};
+
+export function parseSchemaPath(path: string): {
+  operation: OperationTypeNode | null;
+  segments: SchemaPathSegment[];
+} {
+  const [operation, ...rest] = path.split('.');
+
+  return { operation: toOperation(operation), segments: rest.map(toSegment) };
+}
+
+/**
+ * Field names only. Search matches against this so a type condition cannot match
+ * on the spelling of its own sigil, and labels read as GraphQL rather than as paths.
+ */
+export function toFieldSegments(segments: readonly SchemaPathSegment[]): string[] {
+  return segments.flatMap(segment => (segment.kind === 'field' ? [segment.name] : []));
+}
+
+const rootTypeFor = (operation: OperationTypeNode, schema: GraphQLSchema) => {
+  switch (operation) {
+    case OperationTypeNode.QUERY:
+      return schema.getQueryType();
+    case OperationTypeNode.MUTATION:
+      return schema.getMutationType();
+    case OperationTypeNode.SUBSCRIPTION:
+      return schema.getSubscriptionType();
+  }
+};
+
+/**
+ * Walks a dotted path against the schema, one step per segment. Returns null on
+ * any miss rather than a partial walk, so a caller can never mistake the last
+ * type it happened to resolve for the one the path named.
+ */
+export function resolveSchemaPath(path: string, schema: GraphQLSchema): SchemaPathStep[] | null {
+  const { operation, segments } = parseSchemaPath(path);
+
+  if (!operation || segments.length === 0) {
+    return null;
+  }
+
+  let current: GraphQLNamedType | null | undefined = rootTypeFor(operation, schema);
+  const steps: SchemaPathStep[] = [];
+
+  for (const segment of segments) {
+    if (!current) {
+      return null;
+    }
+
+    if (segment.kind === 'typeCondition') {
+      const candidate = schema.getType(segment.typeName);
+
+      if (!candidate || !isObjectType(candidate)) {
+        return null;
+      }
+
+      if (isObjectType(current)) {
+        // Narrowing an object to anything but itself selects nothing.
+        if (current.name !== candidate.name) {
+          return null;
+        }
+      } else if (isUnionType(current) || isInterfaceType(current)) {
+        if (!schema.isSubType(current, candidate)) {
+          return null;
+        }
+      } else {
+        return null;
+      }
+
+      steps.push({ segment, parentType: current, field: null, type: candidate });
+      current = candidate;
+      continue;
+    }
+
+    if (!isObjectType(current) && !isInterfaceType(current)) {
+      return null;
+    }
+
+    // Annotated because `current` is reassigned from `type` below, which makes
+    // the inference of both circular.
+    const field: GraphQLField<unknown, unknown> | undefined = current.getFields()[segment.name];
+
+    if (!field) {
+      return null;
+    }
+
+    const type: GraphQLNamedType = getNamedType(field.type);
+
+    steps.push({ segment, parentType: current, field, type });
+    current = type;
+  }
+
+  return steps;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,8 +941,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-foundry:
-        specifier: 0.0.10
-        version: 0.0.10(@types/node@24.13.3)(babel-plugin-react-compiler@19.1.0-rc.3)(jiti@2.6.1)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)
+        specifier: 0.0.13
+        version: 0.0.13(@types/node@24.13.3)(babel-plugin-react-compiler@19.1.0-rc.3)(jiti@2.6.1)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)
       react-resizable-panels:
         specifier: ^3.0.6
         version: 3.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17106,6 +17106,14 @@ packages:
 
   react-foundry@0.0.10:
     resolution: {integrity: sha512-MKEtyOJwgafQXqOOZ/esiH8ohhod2VQ6pLCrrmy9Bzi25LIc6upzV3BiK9clguThP3BKRE2Z8U2NZCr0tlRSvA==}
+    engines: {node: '>=22'}
+    hasBin: true
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  react-foundry@0.0.13:
+    resolution: {integrity: sha512-s1dFMivVF/z/dPPtBN3QnZuvNbJDRL2Y/pUGDTnJnOhvpgc3zX4esdY3GvcGACQlRxbyCwQ9GUIr5K8kvTo6Ng==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
@@ -39208,9 +39216,9 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
-  react-foundry@0.0.10(@types/node@24.13.3)(babel-plugin-react-compiler@19.1.0-rc.3)(jiti@2.6.1)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3):
+  react-foundry@0.0.10(@types/node@25.5.0)(jiti@2.6.1)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3):
     dependencies:
-      '@vitejs/plugin-react': 6.0.3(babel-plugin-react-compiler@19.1.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+      '@vitejs/plugin-react': 6.0.3(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
       axe-core: 4.11.0
       cac: 6.7.14
       esbuild: 0.28.1
@@ -39219,7 +39227,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)
+      vite: 8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@rolldown/plugin-babel'
       - '@types/node'
@@ -39235,9 +39243,9 @@ snapshots:
       - tsx
       - yaml
 
-  react-foundry@0.0.10(@types/node@25.5.0)(jiti@2.6.1)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3):
+  react-foundry@0.0.13(@types/node@24.13.3)(babel-plugin-react-compiler@19.1.0-rc.3)(jiti@2.6.1)(less@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3):
     dependencies:
-      '@vitejs/plugin-react': 6.0.3(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
+      '@vitejs/plugin-react': 6.0.3(babel-plugin-react-compiler@19.1.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3))
       axe-core: 4.11.0
       cac: 6.7.14
       esbuild: 0.28.1
@@ -39246,7 +39254,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
-      vite: 8.1.5(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.6.1)(less@4.2.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@rolldown/plugin-babel'
       - '@types/node'


### PR DESCRIPTION
This PR makes union and interface fields expandable in the Laboratory query builder, closing a customer report that a `content: [CmsContent!]!` field could not be expanded and returned a 400 when run.

Each abstract field now lists its possible types as a `... on Type` row with selectable fields beneath, and selecting an abstract field also selects `__typename`, so the builder can no longer write a field with no selection set. Builder search and the docs context menu now work below abstract types as well.

There's also a change to Monaco Editor that disables `stickyScroll`, which was never properly implemented and creating overlays/ghosting in the editors.

One behaviour change worth knowing: in a document containing a hand-written inline fragment, a field selected inside it now checks the row under its own type rather than the parent's, so two members declaring the same field name are separate selections. Named fragment spreads are still not managed by the builder and are left untouched.